### PR TITLE
GH#2482: fix: clarify featured image access fields

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -376,7 +376,7 @@ class PostAbilities {
 			'sd-ai-agent/list-posts',
 			[
 				'label'               => __( 'List Posts', 'superdav-ai-agent' ),
-				'description'         => __( 'Query and list WordPress posts or pages. Filter by post_type, post_status (single string or array), search term, category, tag, date range (date_after/date_before), author, tax_query, and meta_query. Returns id, title, excerpt, status, post_type, date, permalink, featured-image state (has_featured_image, ID, alt text, and thumbnail URL when the current user can access the attachment), and query_args for each match. Default: 10 most recent published posts.', 'superdav-ai-agent' ),
+				'description'         => __( 'Query and list WordPress posts or pages. Filter by post_type, post_status (single string or array), search term, category, tag, date range (date_after/date_before), author, tax_query, and meta_query. Returns id, title, excerpt, status, post_type, date, permalink, featured-image state (has_featured_image plus ID, alt text, and thumbnail URL when the current user can edit the attachment; otherwise, those three fields are empty), and query_args for each match. Default: 10 most recent published posts.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',


### PR DESCRIPTION
## Summary

Clarifies that featured-image ID, alt text, and thumbnail URL are empty unless the current user can edit the attachment.

## Files Changed

includes/Abilities/PostAbilities.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run verify (Tests: 4135, Assertions: 18680, Errors: 0, Failures: 0, Skipped: 135; lint, PHPStan, build, and bundle budgets passed)

Resolves #2482


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 8m and 61,657 tokens on this as a headless worker.