### PR TITLE
GH#2487: fix image imports and feedback context

### DIFF
--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -648,9 +648,14 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	protected function import_from_temp( string $tmp_file, string $title, int $post_id = 0 ): array|\WP_Error {
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
 		if ( ! function_exists( 'media_handle_sideload' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/media.php';
-			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
 		$finfo    = new \finfo( FILEINFO_MIME_TYPE );

--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -23,8 +23,8 @@ class ReportBuilder {
 	 *
 	 * A fixed ±2 window can omit the tool call that caused a later assistant
 	 * response, because one agent turn may contain several call/response pairs.
-	 * Start at the preceding human user prompt, retain up to two messages after
-	 * the target for an in-progress response, and stop before the next user turn.
+	 * Start at the preceding human user prompt, retain every later message in
+	 * that turn, and stop before the next user turn.
 	 * This keeps reports bounded while preserving the complete failing workflow.
 	 *
 	 * @param array<int, array<string, mixed>> $messages     Full messages array.
@@ -39,7 +39,7 @@ class ReportBuilder {
 
 		$target = min( $total - 1, max( 0, $message_index ) );
 		$start  = max( 0, $target - 2 );
-		$end    = min( $total - 1, $target + 2 );
+		$end    = $total - 1;
 
 		for ( $index = $target; $index >= 0; $index-- ) {
 			if ( self::is_human_user_message( $messages[ $index ] ) ) {
@@ -48,7 +48,7 @@ class ReportBuilder {
 			}
 		}
 
-		for ( $index = $target + 1; $index <= $end; $index++ ) {
+		for ( $index = $target + 1; $index < $total; $index++ ) {
 			if ( self::is_human_user_message( $messages[ $index ] ) ) {
 				$end = $index - 1;
 				break;

--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -19,10 +19,13 @@ use SdAiAgent\Core\Database;
 class ReportBuilder {
 
 	/**
-	 * Slice the messages array to the targeted message ± 2 surrounding messages.
+	 * Slice messages to the user turn containing the targeted response.
 	 *
-	 * Used to scope thumbs-down reports to a relevant context window rather than
-	 * sending the full conversation (t186).
+	 * A fixed ±2 window can omit the tool call that caused a later assistant
+	 * response, because one agent turn may contain several call/response pairs.
+	 * Start at the preceding human user prompt, retain up to two messages after
+	 * the target for an in-progress response, and stop before the next user turn.
+	 * This keeps reports bounded while preserving the complete failing workflow.
 	 *
 	 * @param array<int, array<string, mixed>> $messages     Full messages array.
 	 * @param int                              $message_index Zero-based index of the target message.
@@ -30,10 +33,67 @@ class ReportBuilder {
 	 */
 	private static function slice_message_context( array $messages, int $message_index ): array {
 		$total = count( $messages );
-		$start = max( 0, $message_index - 2 );
-		$end   = min( $total - 1, $message_index + 2 );
+		if ( 0 === $total ) {
+			return array();
+		}
+
+		$target = min( $total - 1, max( 0, $message_index ) );
+		$start  = max( 0, $target - 2 );
+		$end    = min( $total - 1, $target + 2 );
+
+		for ( $index = $target; $index >= 0; $index-- ) {
+			if ( self::is_human_user_message( $messages[ $index ] ) ) {
+				$start = $index;
+				break;
+			}
+		}
+
+		for ( $index = $target + 1; $index <= $end; $index++ ) {
+			if ( self::is_human_user_message( $messages[ $index ] ) ) {
+				$end = $index - 1;
+				break;
+			}
+		}
 
 		return array_values( array_slice( $messages, $start, $end - $start + 1 ) );
+	}
+
+	/**
+	 * Whether a serialized message is a human prompt rather than a tool response.
+	 *
+	 * SDK function responses also use the `user` role, so the role alone cannot
+	 * identify the boundary between conversation turns.
+	 *
+	 * @param array<string, mixed> $message Serialized session message.
+	 */
+	private static function is_human_user_message( array $message ): bool {
+		if ( 'user' !== ( $message['role'] ?? '' ) ) {
+			return false;
+		}
+
+		$content = $message['parts'] ?? $message['content'] ?? array();
+		if ( is_string( $content ) ) {
+			return '' !== trim( $content );
+		}
+		if ( ! is_array( $content ) ) {
+			return false;
+		}
+
+		foreach ( $content as $part ) {
+			if ( is_string( $part ) && '' !== trim( $part ) ) {
+				return true;
+			}
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+
+			$text = $part['text'] ?? ( 'text' === ( $part['type'] ?? '' ) ? ( $part['content'] ?? '' ) : '' );
+			if ( is_string( $text ) && '' !== trim( $text ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -97,9 +157,9 @@ class ReportBuilder {
 	 * @param string $user_description  Optional free-text description from the user.
 	 * @param bool   $strip_tool_results When true, tool result content is redacted but
 	 *                                  tool names/arguments are retained.
-	 * @param int    $message_index     When >= 0, only the targeted message ± 2
-	 *                                  surrounding messages are included. Pass -1 to
-	 *                                  include all messages (default).
+	 * @param int    $message_index     When >= 0, only the user turn containing the
+	 *                                  targeted response is included. Pass -1 to include
+	 *                                  all messages (default).
 	 * @return array<string, mixed>|null Structured payload or null when the session does
 	 *                                  not exist or does not belong to the current user.
 	 */

--- a/includes/REST/FeedbackController.php
+++ b/includes/REST/FeedbackController.php
@@ -46,8 +46,8 @@ final class FeedbackController extends XWP_REST_Controller {
 	/**
 	 * Handle GET /feedback/preview — return the sanitized payload for modal preview.
 	 *
-	 * When message_index >= 0, only the targeted message +/- 2 surrounding messages
-	 * are included (thumbs-down scoped context, t186).
+	 * When message_index >= 0, only the user turn containing the targeted response
+	 * is included (thumbs-down scoped context, t186).
 	 *
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error
@@ -103,8 +103,8 @@ final class FeedbackController extends XWP_REST_Controller {
 	/**
 	 * Handle POST /feedback/send — build, sanitize, and forward the report.
 	 *
-	 * When message_index >= 0, only the targeted message +/- 2 surrounding messages
-	 * are included in the report (thumbs-down scoped context, t186).
+	 * When message_index >= 0, only the user turn containing the targeted response
+	 * is included in the report (thumbs-down scoped context, t186).
 	 *
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error

--- a/src/components/feedback-consent-modal.js
+++ b/src/components/feedback-consent-modal.js
@@ -21,7 +21,7 @@ import apiFetch from '@wordpress/api-fetch';
  *
  * Features (t186):
  *   7. Optional messageIndex prop: when set, the payload is scoped to the targeted
- *      message ± 2 surrounding messages rather than the full conversation.
+ *      response's complete user turn rather than the full conversation.
  *   8. "Include full conversation" checkbox, visible only when messageIndex is set.
  *
  * @param {Object}   props                      - Component props.
@@ -36,7 +36,7 @@ import apiFetch from '@wordpress/api-fetch';
  * @param {number}   [props.messageIndex]       - Zero-based index of the specific
  *                                              message that triggered the report.
  *                                              When provided, the payload includes
- *                                              only that message ± 2 context messages
+ *                                              only that response's complete user turn
  *                                              unless the user opts into the full
  *                                              conversation via the checkbox.
  * @param {Function} props.onClose              - Called when the modal should close.
@@ -51,7 +51,7 @@ export default function FeedbackConsentModal( {
 } ) {
 	const [ description, setDescription ] = useState( userDescription );
 	const [ stripToolResults, setStripToolResults ] = useState( false );
-	// When messageIndex is provided, the payload is scoped to that message ± 2.
+	// When messageIndex is provided, the payload is scoped to that response's user turn.
 	// The user can opt out of the scope restriction by checking this box (t186).
 	const [ includeFullConversation, setIncludeFullConversation ] =
 		useState( false );
@@ -306,7 +306,7 @@ export default function FeedbackConsentModal( {
 											}
 										/>
 										{ __(
-											'Include full conversation (by default only the selected response and 2 surrounding messages are sent)',
+											'Include full conversation (by default only the user turn containing the selected response is sent)',
 											'superdav-ai-agent'
 										) }
 									</label>

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -617,6 +617,9 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 		$reflection->setAccessible( true );
 		/** @var array<string,mixed>|\WP_Error $import_result */
 		$import_result = $reflection->invoke( $real_ability, $tmp_file, 'Test Provenance Image', 0 );
+		$this->assertTrue( function_exists( 'wp_handle_sideload' ), 'The file-handling dependency must be loaded for non-admin requests.' );
+		$this->assertTrue( function_exists( 'wp_generate_attachment_metadata' ), 'The image metadata dependency must be loaded for non-admin requests.' );
+		$this->assertTrue( function_exists( 'media_handle_sideload' ), 'The media sideload dependency must be loaded for non-admin requests.' );
 
 		if ( is_wp_error( $import_result ) ) {
 			$this->markTestSkipped( 'media_handle_sideload unavailable in this test environment: ' . $import_result->get_error_message() );

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -46,6 +46,42 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Targeted reports retain every tool exchange from the selected user turn.
+	 */
+	public function test_targeted_report_includes_complete_user_turn(): void {
+		$sessionId = $this->create_session_with_tool_history();
+
+		$report = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 10 );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( 7, $report['session_data']['message_count'] );
+		$this->assertSame(
+			array( 'target-call', 'target-call', 'after-call', 'after-call' ),
+			array_column( $report['session_data']['tool_calls'], 'id' )
+		);
+	}
+
+	/**
+	 * Scoped reports never include the next human conversation turn.
+	 */
+	public function test_targeted_report_stops_before_next_user_turn(): void {
+		$sessionId = $this->create_session_with_tool_history();
+		$session   = Database::get_session( $sessionId );
+		$this->assertNotFalse( $session );
+
+		$messages   = json_decode( (string) $session->messages, true );
+		$messages[] = array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Next task' ) ) );
+		$messages[] = array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Next answer' ) ) );
+		$this->assertTrue( Database::update_session( $sessionId, array( 'messages' => wp_json_encode( $messages ) ) ) );
+
+		$report = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 10 );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( 7, $report['session_data']['message_count'] );
+		$this->assertSame( 'Target task', $report['session_data']['messages'][0]['parts'][0]['text'] );
+	}
+
+	/**
 	 * Full-session reports preserve the complete tool log.
 	 */
 	public function test_full_report_preserves_all_tool_calls(): void {
@@ -109,6 +145,7 @@ class ReportBuilderTest extends WP_UnitTestCase {
 			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Target answer' ) ) ),
 			$this->function_message( 'model', 'functionCall', 'after-call' ),
 			$this->function_message( 'user', 'functionResponse', 'after-call' ),
+			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Final answer' ) ) ),
 		);
 
 		$toolCalls = array(

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -34,12 +34,12 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	public function test_targeted_report_scopes_tool_calls_to_message_context(): void {
 		$sessionId = $this->create_session_with_tool_history();
 
-		$report  = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 5 );
-		$summary = ReportBuilder::build_summary( $sessionId, false, 5 );
+		$report  = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 1 );
+		$summary = ReportBuilder::build_summary( $sessionId, false, 1 );
 
 		$this->assertNotNull( $report );
 		$this->assertNotNull( $summary );
-		$this->assertSame( array( 'target-call', 'target-call' ), array_column( $report['session_data']['tool_calls'], 'id' ) );
+		$this->assertSame( array( 'before-call', 'before-call' ), array_column( $report['session_data']['tool_calls'], 'id' ) );
 		$this->assertSame( array( 'call', 'response' ), array_column( $report['session_data']['tool_calls'], 'type' ) );
 		$this->assertSame( 2, $report['session_data']['tool_call_count'] );
 		$this->assertSame( 2, $summary['tool_call_count'] );
@@ -51,7 +51,7 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	public function test_targeted_report_includes_complete_user_turn(): void {
 		$sessionId = $this->create_session_with_tool_history();
 
-		$report = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 10 );
+		$report = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 7 );
 
 		$this->assertNotNull( $report );
 		$this->assertSame( 7, $report['session_data']['message_count'] );
@@ -59,6 +59,7 @@ class ReportBuilderTest extends WP_UnitTestCase {
 			array( 'target-call', 'target-call', 'after-call', 'after-call' ),
 			array_column( $report['session_data']['tool_calls'], 'id' )
 		);
+		$this->assertSame( 'Final answer', $report['session_data']['messages'][6]['parts'][0]['text'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- load WordPress file, image, and media dependencies independently before importing generated images during REST chat requests
- scope thumbs-down feedback to the complete user turn so multi-step tool failures retain all relevant calls and responses
- update feedback consent copy and add regression coverage for both paths

The existing image-option normalization on `main` remains responsible for converting legacy `1792x1024`, `hd`, and `natural` inputs to provider-compatible options.

## Live verification

- Reproduced the chat-path failure before this change: `Call to undefined function wp_handle_sideload()`.
- Retried through the SD AI Agent chat UI with the legacy size, quality, and style values.
- The chat completed successfully and created WordPress attachment `27` in the Media Library.
- Verified the attachment is a non-empty PNG: 1254×1254, 760421 bytes, with generated attachment metadata and alt text.
- SHA-256: `bc8eaa1dfa9585d14b9b7c554af9c8c68d3d6add1978606eedafaab657a6a255`

## Worker self-verification
- PHPUnit: Tests: 4259, Assertions: 19609, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2487

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image importing outside admin areas, ensuring generated images and related metadata are handled correctly.
  - Feedback reports now include the complete user turn containing the selected response and exclude subsequent turns.

- **Documentation**
  - Clarified feedback consent messaging and endpoint documentation to explain the updated report scope.

- **Tests**
  - Added coverage for image importing and feedback report boundaries across complete user turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
