### PR TITLE
GH#2491: feat: add bounded editor capability manifest

### DIFF
--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -118,6 +118,59 @@ class JsAbilityCatalog {
 				'screens'       => array( 'editor' ),
 			),
 			array(
+				'name'          => 'sd-ai-agent-js/get-editor-capabilities',
+				'label'         => 'Get Editor Capabilities',
+				'description'   => 'Return a bounded, current manifest of installed Gutenberg blocks and active editor/theme capabilities without changing editor state.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(
+						'blockNames' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+					'required'   => array(),
+				),
+				'output_schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'available'           => array( 'type' => 'boolean' ),
+						'block_names'         => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'block_details'       => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'object' ),
+						),
+						'global'              => array( 'type' => 'object' ),
+						'requested'           => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'unregistered'        => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'disallowed'          => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'omitted_blocks'      => array( 'type' => 'integer' ),
+						'truncated'           => array( 'type' => 'boolean' ),
+						'unavailable_sources' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'annotations'   => array(
+					'readonly' => true,
+				),
+				'screens'       => array( 'editor' ),
+			),
+			array(
 				'name'          => 'sd-ai-agent-js/insert-block',
 				'label'         => 'Insert Block',
 				'description'   => 'Insert a Gutenberg block into the active block editor. Only available on editor screens.',

--- a/src/abilities/__tests__/editor-capabilities.test.js
+++ b/src/abilities/__tests__/editor-capabilities.test.js
@@ -1,0 +1,139 @@
+/** Unit tests for the read-only Gutenberg editor capability manifest. */
+
+/**
+ * Load an isolated editor capabilities module.
+ *
+ * @return {Object} Module exports.
+ */
+function loadModule() {
+	let mod;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		mod = require( '../editor-capabilities' );
+	} );
+	return mod;
+}
+
+/**
+ * Set a minimal Gutenberg editor environment.
+ *
+ * @param {Object}   root0
+ * @param {Object[]} [root0.blocks]
+ * @param {Object}   [root0.settings]
+ * @param {Function} [root0.canInsertBlockType]
+ */
+function setEditor( { blocks = [], settings, canInsertBlockType } = {} ) {
+	global.wp = {
+		blocks: {
+			getBlockTypes: jest.fn( () => blocks ),
+			getBlockVariations: jest.fn( () => [] ),
+			getBlockStyles: jest.fn( () => [] ),
+		},
+		data: {
+			select: jest.fn( () => ( {
+				getSettings: () => settings,
+				canInsertBlockType,
+			} ) ),
+		},
+	};
+}
+
+describe( 'get-editor-capabilities', () => {
+	afterEach( () => {
+		delete global.wp;
+	} );
+
+	test( 'returns bounded allowlisted details for requested blocks', () => {
+		setEditor( {
+			blocks: [
+				{
+					name: 'core/paragraph',
+					title: 'Paragraph',
+					category: 'text',
+					supports: {
+						color: { text: true, custom: 'unsafe' },
+						html: false,
+					},
+					attributes: {
+						content: { type: 'string' },
+						unknown: { type: 'object', default: { private: true } },
+					},
+				},
+			],
+			settings: {
+				colors: [
+					{ name: 'Primary', slug: 'primary', color: '#000000' },
+				],
+				layout: { contentSize: '640px', wideSize: '1200px' },
+			},
+			canInsertBlockType: ( name ) => name === 'core/paragraph',
+		} );
+
+		const { getEditorCapabilities } = loadModule();
+		const result = getEditorCapabilities( {
+			blockNames: [ 'core/paragraph', 'missing/block' ],
+		} );
+
+		expect( result ).toMatchObject( {
+			available: true,
+			block_names: [ 'core/paragraph' ],
+			unregistered: [ 'missing/block' ],
+			global: { colors: [ { slug: 'primary', color: '#000000' } ] },
+		} );
+		expect( result.block_details[ 0 ] ).toMatchObject( {
+			name: 'core/paragraph',
+			allowed: true,
+			supports: { color: [ 'text' ], html: false },
+			attributes: [ { name: 'content', type: 'string' } ],
+		} );
+		expect( JSON.stringify( result ) ).not.toContain( 'private' );
+	} );
+
+	test( 'caps summary and detailed requested blocks', () => {
+		const blocks = Array.from( { length: 101 }, ( _, index ) => ( {
+			name: `plugin/block-${ index }`,
+		} ) );
+		setEditor( { blocks, settings: {} } );
+		const { getEditorCapabilities } = loadModule();
+		const result = getEditorCapabilities( {
+			blockNames: Array.from(
+				{ length: 21 },
+				( _, index ) => `plugin/block-${ index }`
+			),
+		} );
+
+		expect( result.block_names ).toHaveLength( 100 );
+		expect( result.block_details ).toHaveLength( 20 );
+		expect( result.omitted_blocks ).toBe( 1 );
+		expect( result.truncated ).toBe( true );
+	} );
+
+	test( 'reports unavailable optional sources without throwing', () => {
+		global.wp = {
+			blocks: { getBlockTypes: () => [ { name: 'core/paragraph' } ] },
+			data: { select: () => ( {} ) },
+		};
+		const { getEditorCapabilities } = loadModule();
+		const result = getEditorCapabilities();
+
+		expect( result ).toMatchObject( {
+			available: true,
+			block_names: [ 'core/paragraph' ],
+		} );
+		expect( result.unavailable_sources ).toEqual(
+			expect.arrayContaining( [
+				'editor_settings',
+				'allowed_block_constraints',
+				'block_style_metadata',
+			] )
+		);
+	} );
+
+	test( 'returns a structured unavailable response outside Gutenberg', () => {
+		const { getEditorCapabilities } = loadModule();
+		expect( getEditorCapabilities() ).toMatchObject( {
+			available: false,
+			unavailable_sources: [ 'block_registry', 'editor_settings' ],
+		} );
+	} );
+} );

--- a/src/abilities/editor-capabilities.js
+++ b/src/abilities/editor-capabilities.js
@@ -1,0 +1,424 @@
+/**
+ * Read-only Gutenberg editor capability manifest.
+ *
+ * Collects a bounded, allowlisted snapshot of the active editor without
+ * retaining settings or exposing raw third-party registration objects.
+ */
+
+import { registerClientAbility } from './registry';
+
+export const MAX_SUMMARY_BLOCKS = 100;
+export const MAX_DETAILED_BLOCKS = 20;
+export const MAX_RESPONSE_BYTES = 128 * 1024;
+
+const MAX_STRING_LENGTH = 200;
+const SUPPORT_KEYS = [
+	'align',
+	'anchor',
+	'ariaLabel',
+	'background',
+	'border',
+	'color',
+	'dimensions',
+	'filter',
+	'html',
+	'inserter',
+	'layout',
+	'position',
+	'shadow',
+	'spacing',
+	'typography',
+];
+const ATTRIBUTE_KEYS = [
+	'align',
+	'anchor',
+	'backgroundColor',
+	'content',
+	'fontSize',
+	'gradient',
+	'layout',
+	'style',
+	'textColor',
+];
+
+/**
+ * Return a bounded string safe for a JSON response.
+ *
+ * @param {*} value Candidate value.
+ * @return {string} Bounded string, or an empty string for non-strings.
+ */
+function safeString( value ) {
+	return typeof value === 'string' ? value.slice( 0, MAX_STRING_LENGTH ) : '';
+}
+
+/**
+ * Get the UTF-8 byte length of a string.
+ *
+ * @param {string} value String to measure.
+ * @return {number} UTF-8 byte length.
+ */
+function getByteLength( value ) {
+	if ( typeof TextEncoder !== 'undefined' ) {
+		return new TextEncoder().encode( value ).byteLength;
+	}
+
+	return unescape( encodeURIComponent( value ) ).length;
+}
+
+/**
+ * Normalize known boolean/object support flags without copying raw supports.
+ *
+ * @param {*} supports Block support configuration.
+ * @return {Object} Allowlisted capability flags.
+ */
+function normalizeSupports( supports ) {
+	if ( ! supports || typeof supports !== 'object' ) {
+		return {};
+	}
+
+	return SUPPORT_KEYS.reduce( ( normalized, key ) => {
+		if ( typeof supports[ key ] === 'boolean' ) {
+			normalized[ key ] = supports[ key ];
+		} else if ( supports[ key ] && typeof supports[ key ] === 'object' ) {
+			normalized[ key ] = Object.keys( supports[ key ] )
+				.filter(
+					( childKey ) =>
+						typeof supports[ key ][ childKey ] === 'boolean'
+				)
+				.slice( 0, 10 )
+				.map( safeString );
+		}
+		return normalized;
+	}, {} );
+}
+
+/**
+ * Return an allowlisted subset of attributes useful when composing a block.
+ *
+ * @param {*} attributes Block attribute schema.
+ * @return {Object[]} Safe attribute summaries.
+ */
+function normalizeAttributes( attributes ) {
+	if ( ! attributes || typeof attributes !== 'object' ) {
+		return [];
+	}
+
+	return ATTRIBUTE_KEYS.filter( ( name ) => attributes[ name ] ).map(
+		( name ) => ( {
+			name,
+			type: safeString( attributes[ name ].type ),
+		} )
+	);
+}
+
+/**
+ * Normalize style or variation labels without returning arbitrary objects.
+ *
+ * @param {*} values Candidate style array.
+ * @return {Object[]} Bounded style metadata.
+ */
+function normalizeStyleMetadata( values ) {
+	if ( ! Array.isArray( values ) ) {
+		return [];
+	}
+
+	return values.slice( 0, 20 ).map( ( value ) => ( {
+		name: safeString( value?.name ),
+		label: safeString( value?.label || value?.title ),
+	} ) );
+}
+
+/**
+ * Normalize named theme presets to their generation-relevant public values.
+ *
+ * @param {*}      presets  Candidate preset array.
+ * @param {string} valueKey Value key to include.
+ * @return {Object[]} Bounded preset list.
+ */
+function normalizePresets( presets, valueKey ) {
+	if ( ! Array.isArray( presets ) ) {
+		return [];
+	}
+
+	return presets.slice( 0, 20 ).map( ( preset ) => ( {
+		name: safeString( preset?.name ),
+		slug: safeString( preset?.slug ),
+		[ valueKey ]: safeString( preset?.[ valueKey ] ),
+	} ) );
+}
+
+/**
+ * Resolve an editor setting from supported block-editor or editor selectors.
+ *
+ * @return {{settings: Object|null, unavailable: boolean}} Editor settings result.
+ */
+function getEditorSettings() {
+	if ( typeof wp === 'undefined' || ! wp.data?.select ) {
+		return { settings: null, unavailable: true };
+	}
+
+	for ( const storeName of [ 'core/block-editor', 'core/editor' ] ) {
+		try {
+			const selector = wp.data.select( storeName );
+			if ( typeof selector?.getSettings === 'function' ) {
+				const settings = selector.getSettings();
+				if ( settings && typeof settings === 'object' ) {
+					return { settings, unavailable: false };
+				}
+			}
+		} catch ( _error ) {
+			// Continue to the next selector: Gutenberg store availability varies.
+		}
+	}
+
+	return { settings: null, unavailable: true };
+}
+
+/**
+ * Determine whether a block is allowed by the current editor context.
+ *
+ * @param {string}      name     Block name.
+ * @param {Object}      selector Block editor selector.
+ * @param {Object|null} settings Editor settings.
+ * @return {boolean|null} Allowed state, or null when unavailable.
+ */
+function getAllowedStatus( name, selector, settings ) {
+	try {
+		if ( typeof selector?.canInsertBlockType === 'function' ) {
+			return !! selector.canInsertBlockType( name );
+		}
+	} catch ( _error ) {
+		return null;
+	}
+
+	if ( Array.isArray( settings?.allowedBlockTypes ) ) {
+		return settings.allowedBlockTypes.includes( name );
+	}
+	if ( typeof settings?.allowedBlockTypes === 'boolean' ) {
+		return settings.allowedBlockTypes;
+	}
+
+	return null;
+}
+
+/**
+ * Normalize a registered block type into a serializable manifest entry.
+ *
+ * @param {Object}      block    Registered block type.
+ * @param {Object}      selector Block editor selector.
+ * @param {Object|null} settings Editor settings.
+ * @return {Object} Safe block capability entry.
+ */
+function normalizeBlock( block, selector, settings ) {
+	const name = safeString( block?.name );
+	const getVariations = wp.blocks?.getBlockVariations;
+	const getStyles = wp.blocks?.getBlockStyles;
+	let variations = [];
+	let styles = [];
+
+	try {
+		variations =
+			typeof getVariations === 'function'
+				? normalizeStyleMetadata( getVariations( name ) )
+				: [];
+	} catch ( _error ) {
+		// Keep the remaining editor snapshot when a third-party registry fails.
+	}
+
+	try {
+		styles =
+			typeof getStyles === 'function'
+				? normalizeStyleMetadata( getStyles( name ) )
+				: [];
+	} catch ( _error ) {
+		// Keep the remaining editor snapshot when a third-party registry fails.
+	}
+
+	return {
+		name,
+		title: safeString( block?.title ),
+		category: safeString( block?.category ),
+		allowed: getAllowedStatus( name, selector, settings ),
+		supports: normalizeSupports( block?.supports ),
+		attributes: normalizeAttributes( block?.attributes ),
+		variations,
+		styles,
+	};
+}
+
+/**
+ * Return normalized global editor and theme capabilities.
+ *
+ * @param {Object|null} settings Editor settings.
+ * @return {Object} Bounded global capability data.
+ */
+function getGlobalCapabilities( settings ) {
+	return {
+		colors: normalizePresets( settings?.colors, 'color' ),
+		gradients: normalizePresets( settings?.gradients, 'gradient' ),
+		duotone: normalizePresets( settings?.duotone, 'slug' ),
+		fontSizes: normalizePresets( settings?.fontSizes, 'size' ),
+		spacingSizes: normalizePresets( settings?.spacingSizes, 'size' ),
+		layout: {
+			contentSize: safeString( settings?.layout?.contentSize ),
+			wideSize: safeString( settings?.layout?.wideSize ),
+			supportsLayout: !! settings?.supportsLayout,
+			appearanceTools: !! settings?.appearanceTools,
+		},
+		style: {
+			stylesheet: safeString( settings?.stylesheet ),
+			variation: safeString( settings?.styleVariation ),
+		},
+	};
+}
+
+/**
+ * Return a bounded runtime capability manifest for the active editor.
+ *
+ * @param {Object}   args              Ability arguments.
+ * @param {string[]} [args.blockNames] Optional installed block names for details.
+ * @return {Object} JSON-serializable capability manifest.
+ */
+export function getEditorCapabilities( args = {} ) {
+	const unavailableSources = [];
+	const empty = {
+		available: false,
+		block_names: [],
+		block_details: [],
+		global: getGlobalCapabilities( null ),
+		requested: [],
+		unregistered: [],
+		disallowed: [],
+		omitted_blocks: 0,
+		truncated: false,
+		unavailable_sources: [ 'block_registry', 'editor_settings' ],
+	};
+
+	if ( typeof wp === 'undefined' || ! wp.blocks ) {
+		return empty;
+	}
+
+	try {
+		if ( typeof wp.blocks.getBlockTypes !== 'function' ) {
+			return empty;
+		}
+
+		const blocks = wp.blocks
+			.getBlockTypes()
+			.filter( ( block ) => safeString( block?.name ) );
+		const { settings, unavailable } = getEditorSettings();
+		if ( unavailable ) {
+			unavailableSources.push( 'editor_settings' );
+		}
+		let selector = null;
+		try {
+			selector = wp.data?.select?.( 'core/block-editor' );
+		} catch ( _error ) {
+			unavailableSources.push( 'block_editor_selector' );
+		}
+		if ( ! selector?.canInsertBlockType && ! settings?.allowedBlockTypes ) {
+			unavailableSources.push( 'allowed_block_constraints' );
+		}
+		if (
+			typeof wp.blocks.getBlockVariations !== 'function' ||
+			typeof wp.blocks.getBlockStyles !== 'function'
+		) {
+			unavailableSources.push( 'block_style_metadata' );
+		}
+
+		const requested = Array.isArray( args.blockNames )
+			? [
+					...new Set(
+						args.blockNames.filter(
+							( name ) => typeof name === 'string'
+						)
+					),
+			  ].slice( 0, MAX_DETAILED_BLOCKS )
+			: [];
+		const blocksByName = new Map(
+			blocks.map( ( block ) => [ block.name, block ] )
+		);
+		const detailedBlocks = requested
+			.map( ( name ) => blocksByName.get( name ) )
+			.filter( Boolean )
+			.map( ( block ) => normalizeBlock( block, selector, settings ) );
+		const unregistered = requested.filter(
+			( name ) => ! blocksByName.has( name )
+		);
+		const disallowed = detailedBlocks
+			.filter( ( block ) => block.allowed === false )
+			.map( ( block ) => block.name );
+		const summary = blocks
+			.slice( 0, MAX_SUMMARY_BLOCKS )
+			.map( ( block ) => block.name );
+		const result = {
+			available: true,
+			block_names: summary,
+			block_details: detailedBlocks,
+			global: getGlobalCapabilities( settings ),
+			requested,
+			unregistered,
+			disallowed,
+			omitted_blocks: Math.max( 0, blocks.length - summary.length ),
+			truncated:
+				blocks.length > summary.length ||
+				( Array.isArray( args.blockNames ) &&
+					args.blockNames.length > requested.length ),
+			unavailable_sources: unavailableSources,
+		};
+
+		if ( getByteLength( JSON.stringify( result ) ) > MAX_RESPONSE_BYTES ) {
+			result.block_details = [];
+			result.truncated = true;
+			result.unavailable_sources.push( 'response_size_limit' );
+		}
+
+		return result;
+	} catch ( _error ) {
+		return empty;
+	}
+}
+
+/**
+ * Register the read-only editor capability ability.
+ *
+ * @return {Promise<void>} Registration completion.
+ */
+export async function registerEditorCapabilitiesAbility() {
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/get-editor-capabilities',
+		label: 'Get Editor Capabilities',
+		description:
+			'Return a bounded, current manifest of installed Gutenberg blocks and active editor/theme capabilities without changing editor state.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				blockNames: {
+					type: 'array',
+					items: { type: 'string' },
+				},
+			},
+			required: [],
+		},
+		outputSchema: {
+			type: 'object',
+			properties: {
+				available: { type: 'boolean' },
+				block_names: { type: 'array', items: { type: 'string' } },
+				block_details: { type: 'array', items: { type: 'object' } },
+				global: { type: 'object' },
+				requested: { type: 'array', items: { type: 'string' } },
+				unregistered: { type: 'array', items: { type: 'string' } },
+				disallowed: { type: 'array', items: { type: 'string' } },
+				omitted_blocks: { type: 'integer' },
+				truncated: { type: 'boolean' },
+				unavailable_sources: {
+					type: 'array',
+					items: { type: 'string' },
+				},
+			},
+		},
+		annotations: { readonly: true },
+		callback: getEditorCapabilities,
+	} );
+}

--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -37,6 +37,7 @@ import { registerCategory } from './registry';
 import { registerNavigationAbility } from './navigation';
 import { registerRefreshPageAbility } from './refresh-page';
 import { registerEditorAbility } from './editor';
+import { registerEditorCapabilitiesAbility } from './editor-capabilities';
 import {
 	registerCaptureScreenshotAbility,
 	registerScreenshotUrlAbility,
@@ -108,6 +109,7 @@ export function ensureRegistered() {
 		await registerNavigationAbility();
 		await registerRefreshPageAbility();
 		await registerEditorAbility();
+		await registerEditorCapabilitiesAbility();
 		await registerCaptureScreenshotAbility();
 		await registerScreenshotUrlAbility();
 		try {

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -66,6 +66,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent-js/navigate-to', $names );
 		$this->assertContains( 'sd-ai-agent-js/refresh-page', $names );
 		$this->assertContains( 'sd-ai-agent-js/get-editor-selection', $names );
+		$this->assertContains( 'sd-ai-agent-js/get-editor-capabilities', $names );
 		$this->assertContains( 'sd-ai-agent-js/insert-block', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-page-quality', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-theme-completion', $names );
@@ -78,6 +79,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/navigate-to' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/refresh-page' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/get-editor-selection' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/get-editor-capabilities' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/insert-block' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-page-quality' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-theme-completion' ) );
@@ -95,6 +97,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'sd-ai-agent-js/navigate-to', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/refresh-page', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/get-editor-selection', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/get-editor-capabilities', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/insert-block', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-page-quality', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-theme-completion', $map );
@@ -113,6 +116,13 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'editor' ), $selection['screens'] );
 		$this->assertArrayHasKey( 'fingerprint', $selection['output_schema']['properties'] );
 		$this->assertArrayHasKey( 'truncated', $selection['output_schema']['properties'] );
+
+		$capabilities = $map['sd-ai-agent-js/get-editor-capabilities'];
+		$this->assertSame( 'sd-ai-agent-js', $capabilities['category'] );
+		$this->assertTrue( $capabilities['annotations']['readonly'] );
+		$this->assertSame( array( 'editor' ), $capabilities['screens'] );
+		$this->assertArrayHasKey( 'blockNames', $capabilities['input_schema']['properties'] );
+		$this->assertArrayHasKey( 'unavailable_sources', $capabilities['output_schema']['properties'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a read-only, capped Gutenberg block and theme capability manifest with matched browser and server descriptors.

## Files Changed

includes/Abilities/Js/JsAbilityCatalog.php, src/abilities/__tests__/editor-capabilities.test.js, src/abilities/editor-capabilities.js, src/abilities/index.js, tests/SdAiAgent/Core/AgentLoopClientToolsTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run verify (PHPUnit 4136 tests, PHP/JS/CSS lint, PHPStan, build, and bundle budgets)

## Worker self-verification
- PHPUnit: Tests: 4136, Assertions: 18698, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2491

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 19m and 135,575 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only editor capabilities manifest for Gutenberg screens.
  * Reports available blocks, editor settings, theme styles, permissions, supported features, and requested block availability.
  * Includes response limits, truncation indicators, and unavailable data sources for reliable results.
  * Added support for optional filtering by block name.

* **Bug Fixes**
  * Handles missing editor data, invalid requests, and unavailable optional sources gracefully.

* **Tests**
  * Added coverage for capability discovery, filtering, limits, fallback behavior, and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->