### PR TITLE
GH#2494: Show Gutenberg selection context and mutation status

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -257,6 +257,13 @@ Base unit: **4px**
 - All icon buttons: 32×32px, consistent spacing (`gap: 5px`)
 - Textarea grows with content; `resize: none`
 
+**Block-editor context:**
+- In the Gutenberg editor, place a compact selected-block chip and editor-mutation status immediately above the composer frame.
+- Keep selection state presentation-only: store block IDs-derived labels and counts, never selected markup or block attributes, and never attach selection content to a chat request automatically.
+- The chip may show two block labels before collapsing the remainder into a count. Its icon-only clear action must clear selection without changing block content and must retain a tooltip, accessible label, and visible keyboard focus.
+- Announce mutation progress and outcomes with one polite atomic live region. Confirm success only when the tool result explicitly reports `applied: true`; stale, rejected, unavailable, and uncertain results require truthful next-step copy.
+- On compact screens, let the chip and mutation copy occupy full rows. In forced-colour mode preserve explicit borders and focus outlines; under reduced-motion preferences stop spinner animation while retaining the textual progress label.
+
 ### Border Radius Scale
 
 | Size | Value | Use |

--- a/src/components/chat-widget/__tests__/editor-selection-status.test.js
+++ b/src/components/chat-widget/__tests__/editor-selection-status.test.js
@@ -1,0 +1,244 @@
+/**
+ * Tests for editor selection and mutation status presentation.
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import {
+	EditorSelectionStatus,
+	getEditorMutationStatus,
+	getSelectionLabel,
+} from '../editor-selection-status';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		Button: ( { label, onClick, className } ) =>
+			React.createElement(
+				'button',
+				{ 'aria-label': label, onClick, className },
+				label
+			),
+		Spinner: () => React.createElement( 'span', { 'data-spinner': true } ),
+		Tooltip: ( { children } ) => children,
+	};
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '../../../store', () => 'sd-ai-agent/store' );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: () => null,
+	blockDefault: {},
+	closeSmall: {},
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+	sprintf: ( template, ...values ) => {
+		let nextIndex = 0;
+		return template.replace( /%(?:(\d+)\$)?[sd]/g, ( _match, position ) => {
+			const index = position ? Number( position ) - 1 : nextIndex++;
+			return String( values[ index ] );
+		} );
+	},
+} ) );
+
+jest.mock( '../use-editor-selection', () => jest.fn() );
+
+const REPLACE_CALL = {
+	type: 'call',
+	id: 'replace-1',
+	name: 'sd-ai-agent-js/replace-editor-selection',
+};
+
+describe( 'getEditorMutationStatus', () => {
+	test( 'shows progress only for an active unmatched editor call', () => {
+		expect(
+			getEditorMutationStatus( [ REPLACE_CALL ], { isActive: true } )
+		).toEqual( {
+			kind: 'running',
+			text: 'Updating selected blocks…',
+		} );
+		expect( getEditorMutationStatus( [ REPLACE_CALL ] ) ).toBeNull();
+	} );
+
+	test( 'maps stale selection to actionable non-success copy', () => {
+		expect(
+			getEditorMutationStatus( [
+				REPLACE_CALL,
+				{
+					type: 'response',
+					id: 'replace-1',
+					response: {
+						applied: false,
+						reason: 'stale_selection',
+					},
+				},
+			] )
+		).toEqual( {
+			kind: 'warning',
+			text: 'Selection changed. Reselect the blocks and try again.',
+		} );
+	} );
+
+	test( 'states that validation rejection changed no blocks', () => {
+		expect(
+			getEditorMutationStatus( [
+				{
+					type: 'call',
+					id: 'insert-1',
+					name: 'wpab__sd-ai-agent-js__insert-block-markup',
+				},
+				{
+					type: 'result',
+					id: 'insert-1',
+					response: JSON.stringify( {
+						result: {
+							applied: false,
+							reason: 'validation_failed',
+						},
+					} ),
+				},
+			] )
+		).toEqual( {
+			kind: 'warning',
+			text: 'No blocks were changed. Review the selection or markup and try again.',
+		} );
+	} );
+
+	test( 'does not claim success for an uncertain dispatch', () => {
+		expect(
+			getEditorMutationStatus( [
+				REPLACE_CALL,
+				{
+					type: 'response',
+					id: 'replace-1',
+					response: {
+						applied: 'unknown',
+						reason: 'post_dispatch_unverified',
+					},
+				},
+			] )
+		).toEqual( {
+			kind: 'warning',
+			text: 'The editor result could not be confirmed. Review the blocks before retrying.',
+		} );
+	} );
+
+	test( 'maps a confirmed history result using its direction', () => {
+		expect(
+			getEditorMutationStatus( [
+				{
+					type: 'call',
+					id: 'history-1',
+					name: 'sd-ai-agent-js/change-editor-history',
+					args: { direction: 'redo' },
+				},
+				{
+					type: 'response',
+					id: 'history-1',
+					response: { applied: true, direction: 'redo' },
+				},
+			] )
+		).toEqual( {
+			kind: 'success',
+			text: 'Editor change redone.',
+		} );
+	} );
+} );
+
+describe( 'EditorSelectionStatus', () => {
+	test( 'summarizes multiple selected blocks with bounded labels', () => {
+		expect(
+			getSelectionLabel( {
+				count: 4,
+				labels: [ 'Paragraph', 'Heading', 'Image', 'Group' ],
+			} )
+		).toBe( '4 blocks selected: Paragraph, Heading, +2 more' );
+	} );
+
+	test( 'renders a keyboard button that invokes selection-only clearing', async () => {
+		const onClearSelection = jest.fn();
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () =>
+			root.render(
+				createElement( EditorSelectionStatus, {
+					selection: {
+						available: true,
+						count: 1,
+						labels: [ 'Paragraph' ],
+					},
+					onClearSelection,
+					mutationStatus: null,
+				} )
+			)
+		);
+
+		expect( container.textContent ).toContain(
+			'Selected block: Paragraph'
+		);
+		const button = container.querySelector(
+			'[aria-label="Clear block selection"]'
+		);
+		expect( button ).not.toBeNull();
+		await act( async () =>
+			button.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) )
+		);
+		expect( onClearSelection ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => root.unmount() );
+	} );
+
+	test( 'renders mutation copy as a polite atomic live region', async () => {
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () =>
+			root.render(
+				createElement( EditorSelectionStatus, {
+					selection: { available: true, count: 0, labels: [] },
+					onClearSelection: jest.fn(),
+					mutationStatus: {
+						kind: 'warning',
+						text: 'No blocks were changed.',
+					},
+				} )
+			)
+		);
+
+		const status = container.querySelector( '[role="status"]' );
+		expect( status.getAttribute( 'aria-live' ) ).toBe( 'polite' );
+		expect( status.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
+		expect( status.textContent ).toBe( 'No blocks were changed.' );
+
+		await act( async () => root.unmount() );
+	} );
+
+	test( 'renders nothing outside the editor', async () => {
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () =>
+			root.render(
+				createElement( EditorSelectionStatus, {
+					selection: { available: false, count: 2, labels: [] },
+					onClearSelection: jest.fn(),
+					mutationStatus: {
+						kind: 'success',
+						text: 'Blocks inserted.',
+					},
+				} )
+			)
+		);
+		expect( container.innerHTML ).toBe( '' );
+
+		await act( async () => root.unmount() );
+	} );
+} );

--- a/src/components/chat-widget/__tests__/new-chat-actions.test.js
+++ b/src/components/chat-widget/__tests__/new-chat-actions.test.js
@@ -44,6 +44,7 @@ jest.mock( '../../use-speech-recognition', () => () => ( {
 jest.mock( '../../feedback-consent-modal', () => () => null );
 jest.mock( '../../chat-redesign/ModelPicker', () => () => null );
 jest.mock( '../../chat-redesign/AgentPicker', () => () => null );
+jest.mock( '../editor-selection-status', () => () => null );
 jest.mock( '../../chat-redesign/icons', () => ( {
 	AiIcon: () => null,
 	Microphone: () => null,

--- a/src/components/chat-widget/__tests__/use-editor-selection.test.js
+++ b/src/components/chat-widget/__tests__/use-editor-selection.test.js
@@ -1,0 +1,158 @@
+/**
+ * Tests for compact Gutenberg selection subscriptions.
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import useEditorSelection, {
+	clearEditorSelection,
+	readEditorSelection,
+} from '../use-editor-selection';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+describe( 'useEditorSelection', () => {
+	let selectedIds;
+	let blocks;
+	let listener;
+	let unsubscribe;
+	let dispatcher;
+
+	beforeEach( () => {
+		selectedIds = [ 'first' ];
+		blocks = {
+			first: { clientId: 'first', name: 'core/paragraph' },
+			second: { clientId: 'second', name: 'core/heading' },
+		};
+		listener = null;
+		unsubscribe = jest.fn();
+		dispatcher = { clearSelectedBlock: jest.fn() };
+		global.wp = {
+			data: {
+				select: jest.fn( () => ( {
+					getSelectedBlockClientIds: () => selectedIds,
+					getBlock: jest.fn( ( clientId ) => blocks[ clientId ] ),
+				} ) ),
+				dispatch: jest.fn( () => dispatcher ),
+				subscribe: jest.fn( ( callback ) => {
+					listener = callback;
+					return unsubscribe;
+				} ),
+			},
+			blocks: {
+				getBlockType: ( name ) => ( {
+					title: name === 'core/heading' ? 'Heading' : 'Paragraph',
+				} ),
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete global.wp;
+	} );
+
+	test( 'reads labels without retaining markup or attributes', () => {
+		blocks.first.attributes = { content: 'Private selected content' };
+
+		expect( readEditorSelection() ).toEqual( {
+			available: true,
+			count: 1,
+			labels: [ 'Paragraph' ],
+			signature: '1:first:Paragraph',
+		} );
+	} );
+
+	test( 'bounds block lookups and labels for large selections', () => {
+		selectedIds = [
+			'first',
+			'second',
+			...Array.from(
+				{ length: 998 },
+				( _value, index ) => `additional-${ index }`
+			),
+		];
+		const selection = readEditorSelection();
+		const editor = global.wp.data.select.mock.results[ 0 ].value;
+
+		expect( selection.count ).toBe( 1000 );
+		expect( selection.labels ).toEqual( [ 'Paragraph', 'Heading' ] );
+		expect( selection.signature ).toBe(
+			'1000:first:Paragraph|second:Heading'
+		);
+		expect( editor.getBlock ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'subscribes once, updates changed selection, and cleans up', async () => {
+		const states = [];
+		/** Render the latest selection labels for subscription assertions. */
+		function Probe() {
+			const selection = useEditorSelection();
+			states.push( selection );
+			return createElement( 'span', null, selection.labels.join( ', ' ) );
+		}
+
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () => root.render( createElement( Probe ) ) );
+		expect( container.textContent ).toBe( 'Paragraph' );
+		expect( global.wp.data.subscribe ).toHaveBeenCalledWith(
+			expect.any( Function ),
+			'core/block-editor'
+		);
+
+		const renderCount = states.length;
+		await act( async () => listener() );
+		expect( states ).toHaveLength( renderCount );
+
+		selectedIds = [ 'first', 'second' ];
+		await act( async () => listener() );
+		expect( container.textContent ).toBe( 'Paragraph, Heading' );
+
+		await act( async () => root.unmount() );
+		expect( unsubscribe ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'becomes unavailable when the editor store disappears', async () => {
+		/** Render editor availability for store-disappearance assertions. */
+		function Probe() {
+			const selection = useEditorSelection();
+			return createElement(
+				'span',
+				null,
+				selection.available ? 'available' : 'unavailable'
+			);
+		}
+
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () => root.render( createElement( Probe ) ) );
+		expect( container.textContent ).toBe( 'available' );
+
+		global.wp.data.select.mockReturnValue( null );
+		await act( async () => listener() );
+		expect( container.textContent ).toBe( 'unavailable' );
+
+		await act( async () => root.unmount() );
+	} );
+
+	test( 'clears selection without dispatching a content action', () => {
+		expect( clearEditorSelection() ).toBe( true );
+		expect( dispatcher.clearSelectedBlock ).toHaveBeenCalledTimes( 1 );
+		expect( global.wp.data.dispatch ).toHaveBeenCalledWith(
+			'core/block-editor'
+		);
+	} );
+
+	test( 'falls back to selectBlock when clearSelectedBlock is unavailable', () => {
+		dispatcher = { selectBlock: jest.fn() };
+
+		expect( clearEditorSelection() ).toBe( true );
+		expect( dispatcher.selectBlock ).toHaveBeenCalledWith( null );
+	} );
+} );

--- a/src/components/chat-widget/__tests__/widget-input.test.js
+++ b/src/components/chat-widget/__tests__/widget-input.test.js
@@ -21,6 +21,9 @@ jest.mock( '../../slash-command-menu', () => () => null );
 jest.mock( '../../feedback-consent-modal', () => () => null );
 jest.mock( '../../chat-redesign/ModelPicker', () => () => null );
 jest.mock( '../../chat-redesign/AgentPicker', () => () => null );
+jest.mock( '../editor-selection-status', () => () => (
+	<div data-testid="editor-selection-status" />
+) );
 jest.mock( '../../chat-redesign/icons', () => ( {
 	Paperclip: () => null,
 	Microphone: () => null,
@@ -73,6 +76,22 @@ function composerState( overrides = {} ) {
 }
 
 describe( 'WidgetInput', () => {
+	test( 'places editor context immediately above the composer frame', async () => {
+		useChatComposer.mockReturnValue( composerState( { sending: false } ) );
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+		await act( async () => root.render( createElement( WidgetInput ) ) );
+
+		const context = container.querySelector(
+			'[data-testid="editor-selection-status"]'
+		);
+		const frame = container.querySelector( '.sdaa-w-input-frame' );
+		expect( context ).not.toBeNull();
+		expect( context.nextElementSibling ).toBe( frame );
+
+		await act( async () => root.unmount() );
+	} );
+
 	test( 'keeps pointer controls for queue and stop while sending', async () => {
 		const composer = composerState();
 		useChatComposer.mockReturnValue( composer );

--- a/src/components/chat-widget/editor-selection-status.js
+++ b/src/components/chat-widget/editor-selection-status.js
@@ -1,0 +1,374 @@
+/**
+ * Gutenberg selection context and editor-mutation status for the chat widget.
+ */
+
+import { Button, Spinner, Tooltip } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, blockDefault, closeSmall } from '@wordpress/icons';
+
+import STORE_NAME from '../../store';
+import { getToolCallDisplayName } from '../chat-redesign/message-helpers';
+import useEditorSelection from './use-editor-selection';
+
+const EDITOR_MUTATION_TOOLS = new Set( [
+	'sd-ai-agent-js/replace-editor-selection',
+	'sd-ai-agent-js/insert-block-markup',
+	'sd-ai-agent-js/change-editor-history',
+] );
+
+const VALIDATION_REASONS = new Set( [
+	'block_api_unavailable',
+	'block_count_exceeded',
+	'block_depth_exceeded',
+	'canonicalization_failed',
+	'disallowed_block',
+	'editor_unavailable',
+	'empty_markup',
+	'expected_selection_required',
+	'history_unavailable',
+	'insertion_point_unavailable',
+	'invalid_block',
+	'invalid_history_direction',
+	'invalid_insertion_point',
+	'markup_limit',
+	'parse_failed',
+	'protected_selection',
+	'top_level_block_limit',
+	'unregistered_block',
+	'unstable_markup',
+	'unsupported_block',
+	'validation_failed',
+] );
+
+/**
+ * Parse a possibly encoded tool result without exposing arbitrary payload data.
+ *
+ * @param {*} value Candidate result value.
+ * @return {*} Parsed result value.
+ */
+function parseResultValue( value ) {
+	if ( typeof value !== 'string' ) {
+		return value;
+	}
+
+	try {
+		return JSON.parse( value );
+	} catch ( _error ) {
+		return value;
+	}
+}
+
+/**
+ * Extract the bounded editor result from a paired response entry.
+ *
+ * @param {Object} response Tool response entry.
+ * @return {*} Editor mutation result.
+ */
+function getResponseResult( response ) {
+	if ( response?.error ) {
+		return { error: true };
+	}
+
+	let result = parseResultValue( response?.response ?? response?.result );
+	for ( let depth = 0; depth < 2; depth++ ) {
+		if (
+			result &&
+			typeof result === 'object' &&
+			! Array.isArray( result ) &&
+			! Object.prototype.hasOwnProperty.call( result, 'applied' )
+		) {
+			if ( Object.prototype.hasOwnProperty.call( result, 'result' ) ) {
+				result = parseResultValue( result.result );
+				continue;
+			}
+			if ( Object.prototype.hasOwnProperty.call( result, 'response' ) ) {
+				result = parseResultValue( result.response );
+				continue;
+			}
+		}
+		break;
+	}
+
+	return result;
+}
+
+/**
+ * Read call arguments in either object or encoded form.
+ *
+ * @param {Object} call Tool call entry.
+ * @return {Object} Safe call arguments.
+ */
+function getCallArguments( call ) {
+	const args = parseResultValue( call?.args ?? call?.arguments );
+	return args && typeof args === 'object' && ! Array.isArray( args )
+		? args
+		: {};
+}
+
+/**
+ * Return concise running copy for an editor mutation.
+ *
+ * @param {string} toolName Canonical editor ability name.
+ * @param {Object} call     Tool call entry.
+ * @return {string} Localized status copy.
+ */
+function getRunningCopy( toolName, call ) {
+	if ( toolName.endsWith( '/replace-editor-selection' ) ) {
+		return __( 'Updating selected blocks…', 'superdav-ai-agent' );
+	}
+	if ( toolName.endsWith( '/insert-block-markup' ) ) {
+		return __( 'Inserting blocks…', 'superdav-ai-agent' );
+	}
+
+	return getCallArguments( call ).direction === 'redo'
+		? __( 'Redoing the editor change…', 'superdav-ai-agent' )
+		: __( 'Undoing the editor change…', 'superdav-ai-agent' );
+}
+
+/**
+ * Return concise success copy for an editor mutation.
+ *
+ * @param {string} toolName Canonical editor ability name.
+ * @param {Object} call     Tool call entry.
+ * @return {string} Localized status copy.
+ */
+function getSuccessCopy( toolName, call ) {
+	if ( toolName.endsWith( '/replace-editor-selection' ) ) {
+		return __( 'Selected blocks updated.', 'superdav-ai-agent' );
+	}
+	if ( toolName.endsWith( '/insert-block-markup' ) ) {
+		return __( 'Blocks inserted.', 'superdav-ai-agent' );
+	}
+
+	return getCallArguments( call ).direction === 'redo'
+		? __( 'Editor change redone.', 'superdav-ai-agent' )
+		: __( 'Editor change undone.', 'superdav-ai-agent' );
+}
+
+/**
+ * Derive the latest relevant editor mutation status from existing job activity.
+ *
+ * @param {Array}   toolCalls        Tool call and response entries.
+ * @param {Object}  options          Resolver options.
+ * @param {boolean} options.isActive Whether these entries belong to an active job.
+ * @return {{kind: string, text: string}|null} Compact user-facing status.
+ */
+export function getEditorMutationStatus(
+	toolCalls,
+	{ isActive = false } = {}
+) {
+	if ( ! Array.isArray( toolCalls ) || ! toolCalls.length ) {
+		return null;
+	}
+
+	const responses = new Map();
+	const calls = [];
+	for ( const entry of toolCalls ) {
+		if (
+			( entry?.type === 'response' || entry?.type === 'result' ) &&
+			entry.id
+		) {
+			responses.set( entry.id, entry );
+		}
+		if ( entry?.type === 'call' ) {
+			const toolName = getToolCallDisplayName( entry );
+			if ( EDITOR_MUTATION_TOOLS.has( toolName ) ) {
+				calls.push( { call: entry, toolName } );
+			}
+		}
+	}
+
+	const latest = calls[ calls.length - 1 ];
+	if ( ! latest ) {
+		return null;
+	}
+
+	const response = latest.call.id ? responses.get( latest.call.id ) : null;
+	if ( ! response ) {
+		return isActive
+			? {
+					kind: 'running',
+					text: getRunningCopy( latest.toolName, latest.call ),
+			  }
+			: null;
+	}
+
+	const result = getResponseResult( response );
+	if ( result?.applied === true ) {
+		return {
+			kind: 'success',
+			text: getSuccessCopy( latest.toolName, latest.call ),
+		};
+	}
+	if ( result?.reason === 'stale_selection' ) {
+		return {
+			kind: 'warning',
+			text: __(
+				'Selection changed. Reselect the blocks and try again.',
+				'superdav-ai-agent'
+			),
+		};
+	}
+	if ( result?.applied === 'unknown' || result?.error || response?.error ) {
+		return {
+			kind: 'warning',
+			text: __(
+				'The editor result could not be confirmed. Review the blocks before retrying.',
+				'superdav-ai-agent'
+			),
+		};
+	}
+	if ( result?.applied === false ) {
+		if ( VALIDATION_REASONS.has( result.reason ) ) {
+			return {
+				kind: 'warning',
+				text: __(
+					'No blocks were changed. Review the selection or markup and try again.',
+					'superdav-ai-agent'
+				),
+			};
+		}
+		return {
+			kind: 'warning',
+			text: latest.toolName.endsWith( '/change-editor-history' )
+				? __(
+						'No editor history change was available.',
+						'superdav-ai-agent'
+				  )
+				: __( 'No blocks were changed.', 'superdav-ai-agent' ),
+		};
+	}
+
+	return {
+		kind: 'warning',
+		text: __(
+			'The editor result could not be confirmed. Review the blocks before retrying.',
+			'superdav-ai-agent'
+		),
+	};
+}
+
+/**
+ * Build the compact selection label without exposing block IDs or attributes.
+ *
+ * @param {Object} selection Selection presentation metadata.
+ * @return {string} Localized compact label.
+ */
+export function getSelectionLabel( selection ) {
+	const labels = Array.isArray( selection?.labels ) ? selection.labels : [];
+	if ( selection?.count === 1 ) {
+		return sprintf(
+			/* translators: %s: selected block type */
+			__( 'Selected block: %s', 'superdav-ai-agent' ),
+			labels[ 0 ] || __( 'Block', 'superdav-ai-agent' )
+		);
+	}
+
+	const visible = labels.slice( 0, 2 ).join( ', ' );
+	const overflow = Math.max( 0, selection.count - 2 );
+	const details = overflow
+		? sprintf(
+				/* translators: 1: selected block labels, 2: additional block count */
+				__( '%1$s, +%2$d more', 'superdav-ai-agent' ),
+				visible,
+				overflow
+		  )
+		: visible;
+
+	return sprintf(
+		/* translators: 1: selected block count, 2: selected block labels */
+		__( '%1$d blocks selected: %2$s', 'superdav-ai-agent' ),
+		selection.count,
+		details || __( 'Blocks', 'superdav-ai-agent' )
+	);
+}
+
+/**
+ * Pure selection and mutation status presentation.
+ *
+ * @param {Object}      root0
+ * @param {Object}      root0.selection        Compact editor selection metadata.
+ * @param {Function}    root0.onClearSelection Selection-only clear action.
+ * @param {Object|null} root0.mutationStatus   User-facing mutation status.
+ * @return {JSX.Element|null} Editor context UI.
+ */
+export function EditorSelectionStatus( {
+	selection,
+	onClearSelection,
+	mutationStatus,
+} ) {
+	if ( ! selection?.available || ( ! selection.count && ! mutationStatus ) ) {
+		return null;
+	}
+
+	const clearLabel = __( 'Clear block selection', 'superdav-ai-agent' );
+
+	return (
+		<div className="sd-ai-agent-editor-context">
+			{ selection.count > 0 && (
+				<div className="sd-ai-agent-editor-selection-chip">
+					<Icon icon={ blockDefault } size={ 16 } />
+					<span className="sd-ai-agent-editor-selection-label">
+						{ getSelectionLabel( selection ) }
+					</span>
+					<Tooltip text={ clearLabel }>
+						<Button
+							className="sd-ai-agent-editor-selection-clear"
+							icon={ closeSmall }
+							label={ clearLabel }
+							onClick={ onClearSelection }
+						/>
+					</Tooltip>
+				</div>
+			) }
+			{ mutationStatus && (
+				<div
+					className={ `sd-ai-agent-editor-mutation-status is-${ mutationStatus.kind }` }
+					role="status"
+					aria-live="polite"
+					aria-atomic="true"
+				>
+					{ mutationStatus.kind === 'running' && <Spinner /> }
+					<span>{ mutationStatus.text }</span>
+				</div>
+			) }
+		</div>
+	);
+}
+
+/**
+ * Connect compact editor context to existing selection and job stores.
+ *
+ * @return {JSX.Element|null} Connected editor context UI.
+ */
+export default function ConnectedEditorSelectionStatus() {
+	const selection = useEditorSelection();
+	const activity = useSelect( ( select ) => {
+		const store = select( STORE_NAME );
+		const sessionId = store.getCurrentSessionId();
+		const sessionJob = store.getSessionJob?.( sessionId );
+		const liveToolCalls = store.getLiveToolCalls?.() || [];
+		return {
+			active: Boolean( sessionJob || store.getCurrentJobId?.() ),
+			activeToolCalls:
+				sessionJob?.toolCalls?.length > 0
+					? sessionJob.toolCalls
+					: liveToolCalls,
+			historyToolCalls: store.getCurrentSessionToolCalls?.() || [],
+		};
+	}, [] );
+	const mutationStatus = activity.active
+		? getEditorMutationStatus( activity.activeToolCalls, {
+				isActive: true,
+		  } )
+		: getEditorMutationStatus( activity.historyToolCalls );
+
+	return (
+		<EditorSelectionStatus
+			selection={ selection }
+			onClearSelection={ selection.clearSelection }
+			mutationStatus={ mutationStatus }
+		/>
+	);
+}

--- a/src/components/chat-widget/use-editor-selection.js
+++ b/src/components/chat-widget/use-editor-selection.js
@@ -1,0 +1,156 @@
+/**
+ * Subscribe to compact Gutenberg selection metadata for the floating widget.
+ *
+ * Selected markup and block attributes deliberately stay out of React state.
+ */
+
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const EMPTY_SELECTION = {
+	available: false,
+	count: 0,
+	labels: [],
+	signature: 'unavailable',
+};
+
+/**
+ * Convert a registered block name into a short localized display label.
+ *
+ * @param {string} blockName Registered Gutenberg block name.
+ * @return {string} Human-readable block label.
+ */
+function getBlockLabel( blockName ) {
+	const type = wp.blocks?.getBlockType?.( blockName );
+	if ( typeof type?.title === 'string' && type.title.trim() ) {
+		return type.title.trim();
+	}
+
+	const fallback = String( blockName || '' )
+		.split( '/' )
+		.pop();
+	return fallback || __( 'Block', 'superdav-ai-agent' );
+}
+
+/**
+ * Read only the metadata needed to present the current editor selection.
+ *
+ * @return {{available: boolean, count: number, labels: string[], signature: string}} Compact selection metadata.
+ */
+export function readEditorSelection() {
+	if ( typeof wp === 'undefined' || ! wp.data?.select ) {
+		return EMPTY_SELECTION;
+	}
+
+	try {
+		const editor = wp.data.select( 'core/block-editor' );
+		if ( ! editor || typeof editor.getBlock !== 'function' ) {
+			return EMPTY_SELECTION;
+		}
+
+		let selectedIds = [];
+		if ( typeof editor.getSelectedBlockClientIds === 'function' ) {
+			selectedIds = editor.getSelectedBlockClientIds();
+		} else if ( typeof editor.getSelectedBlockClientId === 'function' ) {
+			const selectedId = editor.getSelectedBlockClientId();
+			selectedIds = selectedId ? [ selectedId ] : [];
+		}
+
+		const clientIds = Array.isArray( selectedIds ) ? selectedIds : [];
+		const visibleIds = clientIds.slice( 0, 2 );
+		const labels = visibleIds.map( ( clientId ) => {
+			const block = editor.getBlock( clientId );
+			return getBlockLabel( block?.name );
+		} );
+
+		return {
+			available: true,
+			count: clientIds.length,
+			labels,
+			signature:
+				`${ clientIds.length }:` +
+				visibleIds
+					.map(
+						( clientId, index ) =>
+							`${ clientId }:${ labels[ index ] }`
+					)
+					.join( '|' ),
+		};
+	} catch ( _error ) {
+		return EMPTY_SELECTION;
+	}
+}
+
+/**
+ * Clear Gutenberg selection without mutating block content.
+ *
+ * @return {boolean} Whether a supported selection action was dispatched.
+ */
+export function clearEditorSelection() {
+	if ( typeof wp === 'undefined' || ! wp.data?.dispatch ) {
+		return false;
+	}
+
+	try {
+		const dispatcher = wp.data.dispatch( 'core/block-editor' );
+		if ( typeof dispatcher?.clearSelectedBlock === 'function' ) {
+			dispatcher.clearSelectedBlock();
+			return true;
+		}
+		if ( typeof dispatcher?.selectBlock === 'function' ) {
+			dispatcher.selectBlock( null );
+			return true;
+		}
+	} catch ( _error ) {
+		return false;
+	}
+
+	return false;
+}
+
+/**
+ * Subscribe to Gutenberg selection changes without polling or render storms.
+ *
+ * @return {{available: boolean, count: number, labels: string[], clearSelection: Function}} Selection presentation state.
+ */
+export default function useEditorSelection() {
+	const [ selection, setSelection ] = useState( EMPTY_SELECTION );
+	const signatureRef = useRef( EMPTY_SELECTION.signature );
+
+	useEffect( () => {
+		if ( typeof wp === 'undefined' || ! wp.data?.subscribe ) {
+			return undefined;
+		}
+
+		let active = true;
+		const update = () => {
+			const next = readEditorSelection();
+			if ( next.signature === signatureRef.current ) {
+				return;
+			}
+			signatureRef.current = next.signature;
+			if ( active ) {
+				setSelection( next );
+			}
+		};
+
+		update();
+		const unsubscribe = wp.data.subscribe( update, 'core/block-editor' );
+
+		return () => {
+			active = false;
+			if ( typeof unsubscribe === 'function' ) {
+				unsubscribe();
+			}
+		};
+	}, [] );
+
+	const clearSelection = useCallback( () => clearEditorSelection(), [] );
+
+	return {
+		available: selection.available,
+		count: selection.count,
+		labels: selection.labels,
+		clearSelection,
+	};
+}

--- a/src/components/chat-widget/widget-input.js
+++ b/src/components/chat-widget/widget-input.js
@@ -16,6 +16,7 @@ import FeedbackConsentModal from '../feedback-consent-modal';
 import { Paperclip, Microphone, Stop } from '../chat-redesign/icons';
 import ModelPicker from '../chat-redesign/ModelPicker';
 import AgentPicker from '../chat-redesign/AgentPicker';
+import ConnectedEditorSelectionStatus from './editor-selection-status';
 
 /**
  * Render the compact floating-widget composer.
@@ -73,6 +74,7 @@ export default function WidgetInput( { isSimpleMode = false } = {} ) {
 					{ composer.attachmentError }
 				</div>
 			) }
+			<ConnectedEditorSelectionStatus />
 			<div
 				className={ `sdaa-w-input-frame${
 					composer.isDragOver ? ' is-drag-over' : ''

--- a/src/components/chat-widget/widget-panel.css
+++ b/src/components/chat-widget/widget-panel.css
@@ -1036,6 +1036,92 @@
 	background: #fff;
 }
 
+.sd-ai-agent-editor-context {
+	display: flex;
+	min-width: 0;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 4px 8px;
+	margin-bottom: 6px;
+}
+
+.sd-ai-agent-editor-selection-chip {
+	display: inline-flex;
+	min-width: 0;
+	max-width: 100%;
+	height: 26px;
+	align-items: center;
+	gap: 4px;
+	padding: 0 1px 0 7px;
+	border: 1px solid color-mix(in srgb, var(--sdaa-w-primary) 35%, #dcdcde);
+	border-radius: var(--sdaa-w-radius-pill);
+	background: var(--sdaa-w-surface-active);
+	color: var(--sdaa-w-text-secondary);
+	font-size: 11px;
+	line-height: 1;
+}
+
+.sd-ai-agent-editor-selection-chip > svg {
+	flex-shrink: 0;
+	fill: currentcolor;
+}
+
+.sd-ai-agent-editor-selection-label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sd-ai-agent-editor-selection-clear.components-button {
+	display: inline-flex;
+	width: 24px;
+	min-width: 24px;
+	height: 24px;
+	min-height: 24px;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border-radius: var(--sdaa-w-radius-pill);
+	color: var(--sdaa-w-text-muted);
+}
+
+.sd-ai-agent-editor-selection-clear.components-button:hover {
+	background: var(--sdaa-w-surface-hover);
+	color: var(--sdaa-w-text-primary);
+}
+
+.sd-ai-agent-editor-selection-clear.components-button:focus-visible {
+	outline: 2px solid var(--sdaa-w-primary);
+	outline-offset: 1px;
+	box-shadow: none;
+}
+
+.sd-ai-agent-editor-mutation-status {
+	display: inline-flex;
+	min-width: 0;
+	align-items: center;
+	gap: 5px;
+	color: var(--sdaa-w-text-muted);
+	font-size: 11px;
+	line-height: 1.35;
+}
+
+.sd-ai-agent-editor-mutation-status.is-success {
+	color: #007c24;
+}
+
+.sd-ai-agent-editor-mutation-status.is-warning {
+	color: #7a5a10;
+}
+
+.sd-ai-agent-editor-mutation-status .components-spinner {
+	width: 12px;
+	height: 12px;
+	margin: 0;
+	flex-shrink: 0;
+}
+
 .sdaa-w-input-frame {
 	padding: 8px 10px 6px;
 	border: 1px solid var(--sdaa-w-border-strong);
@@ -1264,6 +1350,47 @@
 		height: auto;
 	}
 
+	.sd-ai-agent-editor-selection-chip {
+		width: 100%;
+		height: auto;
+		min-height: 44px;
+		padding-right: 0;
+	}
+
+	.sd-ai-agent-editor-selection-label {
+		flex: 1;
+	}
+
+	.sd-ai-agent-editor-selection-clear.components-button {
+		width: 44px;
+		min-width: 44px;
+		height: 44px;
+		min-height: 44px;
+	}
+
+	.sd-ai-agent-editor-mutation-status {
+		flex-basis: 100%;
+	}
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.sd-ai-agent-editor-mutation-status .components-spinner {
+		animation: none;
+	}
+}
+
+@media (forced-colors: active) {
+	.sd-ai-agent-editor-selection-chip,
+	.sd-ai-agent-editor-mutation-status {
+		border: 1px solid CanvasText;
+		background: Canvas;
+		color: CanvasText;
+	}
+
+	.sd-ai-agent-editor-selection-clear.components-button:focus-visible {
+		outline-color: Highlight;
+	}
 }
 
 /* =================================================================


### PR DESCRIPTION
## Summary

Add a compact selected-block chip, selection-only clear action, and truthful live mutation outcomes to the floating Gutenberg chat widget. Keep editor context presentation-only and document the responsive and accessibility contract in DESIGN.md.

## Files Changed

DESIGN.md, src/components/chat-widget/__tests__/editor-selection-status.test.js, src/components/chat-widget/__tests__/new-chat-actions.test.js, src/components/chat-widget/__tests__/use-editor-selection.test.js, src/components/chat-widget/__tests__/widget-input.test.js, src/components/chat-widget/editor-selection-status.js, src/components/chat-widget/use-editor-selection.js, src/components/chat-widget/widget-input.js, src/components/chat-widget/widget-panel.css

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Full Jest: 57 suites, 549 tests, 6 snapshots passed. Live Gutenberg browser checks passed at 390px, 800px, and 1280px, including keyboard clear with unchanged content, non-editor omission, and running/success/stale/rejected/uncertain mutation copy. Review evidence bundle 44220448c3c67ca9c4a419e48f2376891daa001c8e7e9969eaf4fb67fe9763f7.

## Worker self-verification
- PHPUnit: Tests: 4137, Assertions: 18735, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2494


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 3h and 2,564,966 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editor context indicators showing selected blocks within the chat input.
  - Added mutation status updates for running, completed, stale, validation-failed, and uncertain editor actions.
  - Added controls to clear the current block selection.
- **Accessibility**
  - Added localized labels, live status announcements, keyboard support, forced-colour styling, responsive layouts, and reduced-motion behavior.
- **Documentation**
  - Expanded input-area guidance for editor selection and mutation feedback.
- **Tests**
  - Added coverage for selection handling, status mapping, accessibility rendering, updates, cleanup, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->