### PR TITLE
auto-recover: orphaned worker branch for #2533

### DIFF
--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -94,6 +94,7 @@ describe( 'editor post reflector', () => {
 
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/my-plugin/v1/books/42?context=edit',
+			signal: expect.any( AbortSignal ),
 		} );
 	} );
 
@@ -111,6 +112,7 @@ describe( 'editor post reflector', () => {
 
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/page/42?context=edit',
+			signal: expect.any( AbortSignal ),
 		} );
 		expect( coreData.receiveEntityRecords ).toHaveBeenCalledWith(
 			'postType',
@@ -236,6 +238,48 @@ describe( 'editor post reflector', () => {
 			],
 			{ __unstableShouldCreateUndoLevel: false }
 		);
+	} );
+
+	test( 'continues queued reflections after an unresponsive request is aborted', async () => {
+		jest.useFakeTimers();
+		const { editorDispatcher } = setEditor();
+		global.wp.blocks.parse.mockImplementation( ( rawContent ) => [
+			{ clientId: rawContent },
+		] );
+		apiFetch
+			.mockImplementationOnce(
+				( { signal } ) =>
+					new Promise( ( _resolve, reject ) => {
+						signal.addEventListener( 'abort', () =>
+							reject( new Error( 'aborted' ) )
+						);
+					} )
+			)
+			.mockResolvedValueOnce( {
+				id: 42,
+				content: {
+					raw: '<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+				},
+			} );
+
+		const firstReflection = reflectEditorPost( postEvent() );
+		const secondReflection = reflectEditorPost( postEvent() );
+
+		jest.advanceTimersByTime( 15_000 );
+		await firstReflection;
+		await secondReflection;
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenCalledWith(
+			[
+				{
+					clientId:
+						'<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+				},
+			],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
+		jest.useRealTimers();
 	} );
 
 	test.each( [

--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -30,6 +30,7 @@ function setEditor( options = {} ) {
 			rest_namespace: restNamespace,
 		} ) ),
 	};
+	const editorDispatcher = { resetEditorBlocks: jest.fn() };
 	const blockDispatcher = { resetBlocks: jest.fn() };
 	global.wp = {
 		data: {
@@ -46,12 +47,14 @@ function setEditor( options = {} ) {
 				if ( store === 'core' ) {
 					return coreData;
 				}
-				return blockDispatcher;
+				return store === 'core/editor'
+					? editorDispatcher
+					: blockDispatcher;
 			} ),
 		},
 		blocks: { parse: jest.fn( () => [ { clientId: 'fresh' } ] ) },
 	};
-	return { state, editor, coreData, blockDispatcher };
+	return { state, editor, coreData, editorDispatcher, blockDispatcher };
 }
 
 /**
@@ -95,7 +98,7 @@ describe( 'editor post reflector', () => {
 	} );
 
 	test( 'synchronizes fetched server content into a matching clean editor', async () => {
-		const { coreData, blockDispatcher } = setEditor();
+		const { coreData, editorDispatcher, blockDispatcher } = setEditor();
 		const record = {
 			id: 42,
 			content: {
@@ -114,9 +117,11 @@ describe( 'editor post reflector', () => {
 			'page',
 			[ record ]
 		);
-		expect( blockDispatcher.resetBlocks ).toHaveBeenCalledWith( [
-			{ clientId: 'fresh' },
-		] );
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenCalledWith(
+			[ { clientId: 'fresh' } ],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
 	} );
 
 	test.each( [
@@ -181,6 +186,56 @@ describe( 'editor post reflector', () => {
 
 		expect( coreData.receiveEntityRecords ).not.toHaveBeenCalled();
 		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'serializes overlapping reflections so the latest revision wins', async () => {
+		const { editorDispatcher } = setEditor();
+		let resolveFirst;
+		let resolveSecond;
+		global.wp.blocks.parse.mockImplementation( ( rawContent ) => [
+			{ clientId: rawContent },
+		] );
+		apiFetch
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveFirst = resolve;
+				} )
+			)
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveSecond = resolve;
+				} )
+			);
+
+		const firstReflection = reflectEditorPost( postEvent() );
+		const secondReflection = reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		resolveFirst( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Older<!-- /wp:paragraph -->',
+			},
+		} );
+		await firstReflection;
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		resolveSecond( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+			},
+		} );
+		await secondReflection;
+
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenLastCalledWith(
+			[
+				{
+					clientId:
+						'<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+				},
+			],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
 	} );
 
 	test.each( [

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -8,6 +8,7 @@
 import apiFetch from '@wordpress/api-fetch';
 
 const reflectionQueues = new Map();
+const REFLECTION_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Compare post identifiers without making numeric/string REST values diverge.
@@ -94,12 +95,30 @@ async function reflectEditorPostEvent( event ) {
 		return;
 	}
 
+	let record;
 	try {
-		const record = await apiFetch( {
-			path: `/${ context.restNamespace }/${ encodeURIComponent(
-				context.restBase
-			) }/${ encodeURIComponent( affected.post_id ) }?context=edit`,
-		} );
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(),
+			REFLECTION_REQUEST_TIMEOUT_MS
+		);
+		try {
+			record = await apiFetch( {
+				path: `/${ context.restNamespace }/${ encodeURIComponent(
+					context.restBase
+				) }/${ encodeURIComponent( affected.post_id ) }?context=edit`,
+				signal: controller.signal,
+			} );
+		} finally {
+			clearTimeout( timeout );
+		}
+	} catch ( _error ) {
+		// A missing REST route is safe to ignore: the persisted revision remains
+		// available after a reload.
+		return;
+	}
+
+	try {
 		const rawContent = record?.content?.raw;
 		if ( typeof rawContent !== 'string' ) {
 			return;
@@ -124,8 +143,8 @@ async function reflectEditorPostEvent( event ) {
 			__unstableShouldCreateUndoLevel: false,
 		} );
 	} catch ( _error ) {
-		// A missing REST route, parsing failure, or unavailable editor is safe to
-		// ignore: the persisted revision remains available after a reload.
+		// A parsing failure or unavailable editor is safe to ignore: the persisted
+		// revision remains available after a reload.
 	}
 }
 

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -8,7 +8,7 @@
 import apiFetch from '@wordpress/api-fetch';
 
 const reflectionQueues = new Map();
-const REFLECTION_REQUEST_TIMEOUT_MS = 15_000;
+const reflectionRequestTimeoutMs = 15_000;
 
 /**
  * Compare post identifiers without making numeric/string REST values diverge.
@@ -100,7 +100,7 @@ async function reflectEditorPostEvent( event ) {
 		const controller = new AbortController();
 		const timeout = setTimeout(
 			() => controller.abort(),
-			REFLECTION_REQUEST_TIMEOUT_MS
+			reflectionRequestTimeoutMs
 		);
 		try {
 			record = await apiFetch( {

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -7,6 +7,8 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
+const reflectionQueues = new Map();
+
 /**
  * Compare post identifiers without making numeric/string REST values diverge.
  *
@@ -35,23 +37,21 @@ function getEditorContext( postId ) {
 
 	try {
 		const editor = wp.data.select( 'core/editor' );
-		const blockEditor = wp.data.select( 'core/block-editor' );
 		const core = wp.data.select( 'core' );
 		const coreData = wp.data.dispatch( 'core' );
-		const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+		const editorDispatcher = wp.data.dispatch( 'core/editor' );
 		const currentPostId = editor?.getCurrentPostId?.();
 		const postType = editor?.getCurrentPostType?.();
 		const postTypeRecord = core?.getPostType?.( postType );
 
 		if (
 			! editor ||
-			! blockEditor ||
 			! samePost( currentPostId, postId ) ||
 			editor.isEditedPostDirty?.() !== false ||
 			typeof postType !== 'string' ||
 			! postType ||
 			typeof coreData?.receiveEntityRecords !== 'function' ||
-			typeof blockDispatcher?.resetBlocks !== 'function' ||
+			typeof editorDispatcher?.resetEditorBlocks !== 'function' ||
 			typeof wp.blocks?.parse !== 'function'
 		) {
 			return null;
@@ -63,7 +63,7 @@ function getEditorContext( postId ) {
 			restBase: postTypeRecord?.rest_base || postType,
 			restNamespace: postTypeRecord?.rest_namespace || 'wp/v2',
 			coreData,
-			blockDispatcher,
+			editorDispatcher,
 		};
 	} catch ( _error ) {
 		return null;
@@ -76,7 +76,7 @@ function getEditorContext( postId ) {
  * @param {{affected?: {fields?: string[], post_id?: number|string, render_mode?: string}, result?: {preview?: Object}}} event Reflection event.
  * @return {Promise<void>} Resolves after safely applying or skipping the update.
  */
-export async function reflectEditorPost( event ) {
+async function reflectEditorPostEvent( event ) {
 	const affected = event?.affected;
 	if (
 		! Array.isArray( affected?.fields ) ||
@@ -120,9 +120,41 @@ export async function reflectEditorPost( event ) {
 		current.coreData.receiveEntityRecords( 'postType', current.postType, [
 			record,
 		] );
-		current.blockDispatcher.resetBlocks( blocks );
+		current.editorDispatcher.resetEditorBlocks( blocks, {
+			__unstableShouldCreateUndoLevel: false,
+		} );
 	} catch ( _error ) {
 		// A missing REST route, parsing failure, or unavailable editor is safe to
 		// ignore: the persisted revision remains available after a reload.
 	}
+}
+
+/**
+ * Serialize server reflections for one post so an older REST response cannot
+ * replace a newer revision after overlapping tool events.
+ *
+ * @param {Object} event Reflection event.
+ * @return {Promise<void>} Resolves after safely applying or skipping the update.
+ */
+export function reflectEditorPost( event ) {
+	const postId = event?.affected?.post_id;
+	if ( postId === undefined || postId === null ) {
+		return Promise.resolve();
+	}
+
+	const queueKey = String( postId );
+	const previous = reflectionQueues.get( queueKey );
+	const reflection = previous
+		? previous
+				.catch( () => undefined )
+				.then( () => reflectEditorPostEvent( event ) )
+		: reflectEditorPostEvent( event );
+
+	reflectionQueues.set( queueKey, reflection );
+
+	return reflection.finally( () => {
+		if ( reflectionQueues.get( queueKey ) === reflection ) {
+			reflectionQueues.delete( queueKey );
+		}
+	} );
 }

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -611,8 +611,11 @@ test.describe( 'client-abilities — server post reflection', () => {
 					const blocks = wp.data
 						.select( 'core/block-editor' )
 						.getBlocks();
+					const normalizedMarkup = wp.blocks.serialize(
+						wp.blocks.parse( serverMarkup )
+					);
 					return (
-						wp.blocks.serialize( blocks ) === serverMarkup &&
+						wp.blocks.serialize( blocks ) === normalizedMarkup &&
 						editor.isEditedPostDirty() === false
 					);
 				},

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -229,14 +229,22 @@ async function createDraftAndOpenEditor( page ) {
 
 	await page.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
 	await page.waitForLoadState( 'domcontentloaded' );
-	await page
-		.locator( '.block-editor-writing-flow, .editor-styles-wrapper' )
-		.first()
-		.waitFor( { state: 'visible', timeout: 60_000 } );
+	// The editor canvas can remain visually hidden while Gutenberg finishes
+	// loading on shared CI runners. The reflection tests need its data stores,
+	// not a visible canvas, so wait for those real runtime dependencies instead.
 	await page.waitForFunction(
-		() => typeof window.sdAiAgentReflection?.emit === 'function',
+		() => {
+			const editor = wp.data?.select?.( 'core/editor' );
+			const blockEditor = wp.data?.select?.( 'core/block-editor' );
+			return (
+				typeof editor?.getCurrentPostId === 'function' &&
+				typeof editor?.isEditedPostDirty === 'function' &&
+				typeof blockEditor?.getBlocks === 'function' &&
+				typeof window.sdAiAgentReflection?.emit === 'function'
+			);
+		},
 		null,
-		{ timeout: 30_000 }
+		{ timeout: 90_000 }
 	);
 
 	return postId;

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -550,6 +550,70 @@ test.describe( 'client-abilities — server post reflection', () => {
 		);
 	} );
 
+	test( 'keeps successive server mutations reflected and the editor clean', async ( {
+		page,
+	} ) => {
+		const postId = await createDraftAndOpenEditor( page );
+		const revisions = [
+			{
+				tool: 'sd-ai-agent/update-post',
+				markup:
+					'<!-- wp:heading -->\n<h2>Updated heading.</h2>\n<!-- /wp:heading -->',
+			},
+			{
+				tool: 'sd-ai-agent/edit-block-tree',
+				markup:
+					'<!-- wp:list -->\n<ul class="wp-block-list"><li>Updated nested item.</li></ul>\n<!-- /wp:list -->',
+			},
+			{
+				tool: 'sd-ai-agent/append-post-content',
+				markup:
+					'<!-- wp:paragraph -->\n<p>Appended server paragraph.</p>\n<!-- /wp:paragraph -->',
+			},
+		];
+
+		for ( const revision of revisions ) {
+			await page.evaluate(
+				async ( { currentPostId, serverMarkup, tool } ) => {
+					await wp.apiFetch( {
+						path: `/wp/v2/posts/${ currentPostId }`,
+						method: 'POST',
+						data: { content: serverMarkup },
+					} );
+					window.sdAiAgentReflection.emit( {
+						type: 'tool-applied',
+						tool,
+						affected: {
+							kind: 'post',
+							post_id: currentPostId,
+							fields: [ 'post_content' ],
+						},
+					} );
+				},
+				{
+					currentPostId: postId,
+					serverMarkup: revision.markup,
+					tool: revision.tool,
+				}
+			);
+
+			await page.waitForFunction(
+				( serverMarkup ) => {
+					const editor = wp.data.select( 'core/editor' );
+					const blocks = wp.data
+						.select( 'core/block-editor' )
+						.getBlocks();
+					return (
+						wp.blocks.serialize( blocks ) === serverMarkup &&
+						editor.isEditedPostDirty() === false
+					);
+				},
+				revision.markup,
+				{ timeout: 15_000 }
+			);
+		}
+	} );
+
 	test( 'preserves a dirty local editor after a server mutation event', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## Summary

- serialize Gutenberg post reflections per post so stale REST responses cannot overwrite newer revisions
- abort stalled reflection fetches after 15 seconds so queued updates can continue
- apply persisted blocks through `core/editor.resetEditorBlocks` without adding an undo level or dirtying the editor
- cover overlapping, timed-out, clean, dirty, and three-step sequential reflection paths

## Verification

- `pnpm run verify`
- `pnpm run test:js -- src/floating-widget/reflectors/__tests__/editor-post.test.js --runInBand` — 13 tests passed
- `pnpm exec playwright test tests/e2e/client-abilities.spec.js --grep "server post reflection" --project=chromium` — 3 tests passed

## Worker self-verification
- PHPUnit: Tests: 4140, Assertions: 18747, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2533

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.285 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol
