### PR TITLE
fix: avoid false health rollback on mapped sites

### DIFF
--- a/includes/Core/Health/PostMutationHealthCheck.php
+++ b/includes/Core/Health/PostMutationHealthCheck.php
@@ -50,9 +50,9 @@ class PostMutationHealthCheck {
 
 	/**
 	 * Perform the loopback request and return one of three states:
-	 *   healthy     — got a 200 with our success token
-	 *   broken      — connected but WP returned an error body / bad token
-	 *   unreachable — could not establish a connection at all
+	 *   healthy     — got a 2xx response with our success token
+	 *   broken      — got a 5xx response, or a 2xx response with a bad token
+	 *   unreachable — could not connect, or received a redirect/client error
 	 *
 	 * @return string One of STATUS_HEALTHY, STATUS_BROKEN, or STATUS_UNREACHABLE.
 	 */
@@ -81,8 +81,9 @@ class PostMutationHealthCheck {
 		$response = wp_remote_get(
 			$health_url,
 			[
-				'timeout'   => 10,
-				'sslverify' => false,
+				'timeout'     => 10,
+				'redirection' => 0,
+				'sslverify'   => false,
 			]
 		);
 
@@ -90,8 +91,31 @@ class PostMutationHealthCheck {
 			return self::STATUS_UNREACHABLE;
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-		return str_contains( $body, '"success":true' )
+		return $this->classify_response( $response );
+	}
+
+	/**
+	 * Classify a connected health response by status before inspecting its body.
+	 *
+	 * @param array<string, mixed> $response WordPress HTTP API response.
+	 * @return string One of STATUS_HEALTHY, STATUS_BROKEN, or STATUS_UNREACHABLE.
+	 */
+	private function classify_response( array $response ): string {
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $status_code >= 300 && $status_code < 500 ) {
+			return self::STATUS_UNREACHABLE;
+		}
+
+		if ( $status_code >= 500 && $status_code < 600 ) {
+			return self::STATUS_BROKEN;
+		}
+
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			return self::STATUS_UNREACHABLE;
+		}
+
+		return str_contains( wp_remote_retrieve_body( $response ), '"success":true' )
 			? self::STATUS_HEALTHY
 			: self::STATUS_BROKEN;
 	}
@@ -151,20 +175,22 @@ class PostMutationHealthCheck {
 			$response = wp_remote_get(
 				$url,
 				[
-					'timeout'   => 5,
-					'sslverify' => false,
+					'timeout'     => 5,
+					'redirection' => 0,
+					'sslverify'   => false,
 				]
 			);
 			if ( is_wp_error( $response ) ) {
 				continue;
 			}
 
-			if ( str_contains( wp_remote_retrieve_body( $response ), '"success":true' ) ) {
+			$status = $this->classify_response( $response );
+			if ( self::STATUS_HEALTHY === $status ) {
 				set_transient( 'sd_ai_agent_health_url', $url, HOUR_IN_SECONDS );
 				return $url;
 			}
 
-			if ( wp_remote_retrieve_response_code( $response ) >= 500 ) {
+			if ( self::STATUS_BROKEN === $status ) {
 				$connected_url ??= $url;
 			}
 		}

--- a/includes/Core/Health/PostMutationHealthCheck.php
+++ b/includes/Core/Health/PostMutationHealthCheck.php
@@ -71,7 +71,8 @@ class PostMutationHealthCheck {
 		 *
 		 * @param string|null $url The health check URL, or null to auto-discover.
 		 */
-		$health_url = apply_filters( 'sd_ai_agent_health_url', $this->discover_health_url() );
+		$discovered_url = $this->discover_health_url();
+		$health_url     = apply_filters( 'sd_ai_agent_health_url', $discovered_url );
 
 		if ( null === $health_url ) {
 			return self::STATUS_UNREACHABLE;
@@ -91,7 +92,37 @@ class PostMutationHealthCheck {
 			return self::STATUS_UNREACHABLE;
 		}
 
-		return $this->classify_response( $response );
+		$status = $this->classify_response( $response );
+		$cached = get_transient( 'sd_ai_agent_health_url' );
+
+		if (
+			self::STATUS_UNREACHABLE !== $status
+			|| ! is_string( $cached )
+			|| $health_url !== $cached
+			|| $health_url !== $discovered_url
+		) {
+			return $status;
+		}
+
+		// A stale cached route may no longer reach this site; retry all candidates before giving up.
+		delete_transient( 'sd_ai_agent_health_url' );
+		$health_url = apply_filters( 'sd_ai_agent_health_url', $this->discover_health_url() );
+
+		if ( null === $health_url ) {
+			return self::STATUS_UNREACHABLE;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			$health_url,
+			[
+				'timeout'     => 10,
+				'redirection' => 0,
+				'sslverify'   => false,
+			]
+		);
+
+		return is_wp_error( $response ) ? self::STATUS_UNREACHABLE : $this->classify_response( $response );
 	}
 
 	/**

--- a/includes/Core/Health/PostMutationHealthCheck.php
+++ b/includes/Core/Health/PostMutationHealthCheck.php
@@ -106,13 +106,16 @@ class PostMutationHealthCheck {
 	}
 
 	/**
-	 * Walk candidate loopback URLs until one connects, cache successful URLs,
-	 * and return the first connected URL. Returns null when no candidate connects.
+	 * Walk candidate loopback URLs until one succeeds, cache successful URLs,
+	 * and retain only server-error responses as evidence of a broken site.
 	 *
 	 * Only 127.0.0.1 addresses are tried: the health endpoint rejects requests
 	 * whose REMOTE_ADDR is not loopback, so home_url() would always fail there.
-	 * Discovery caches only a full success response, but returns connected error
-	 * responses so callers can distinguish broken from unreachable.
+	 * Discovery caches only a full success response. Redirects and client errors
+	 * are treated as unreachable because mapped-domain and proxy configurations can
+	 * legitimately reject a public health request even while WordPress is healthy.
+	 * A 5xx response remains authoritative evidence that the candidate connected
+	 * but WordPress failed to boot.
 	 *
 	 * @return string|null The discovered health URL, or null if discovery failed.
 	 */
@@ -156,11 +159,13 @@ class PostMutationHealthCheck {
 				continue;
 			}
 
-			$connected_url ??= $url;
-
 			if ( str_contains( wp_remote_retrieve_body( $response ), '"success":true' ) ) {
 				set_transient( 'sd_ai_agent_health_url', $url, HOUR_IN_SECONDS );
 				return $url;
+			}
+
+			if ( wp_remote_retrieve_response_code( $response ) >= 500 ) {
+				$connected_url ??= $url;
 			}
 		}
 

--- a/includes/Core/Health/PostMutationHealthCheck.php
+++ b/includes/Core/Health/PostMutationHealthCheck.php
@@ -88,11 +88,9 @@ class PostMutationHealthCheck {
 			]
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return self::STATUS_UNREACHABLE;
-		}
-
-		$status = $this->classify_response( $response );
+		$status = is_wp_error( $response )
+			? self::STATUS_UNREACHABLE
+			: $this->classify_response( $response );
 		$cached = get_transient( 'sd_ai_agent_health_url' );
 
 		if (

--- a/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
+++ b/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
@@ -341,6 +341,38 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A transport failure from a cached URL must not hide a broken fallback candidate.
+	 */
+	public function test_failed_cached_health_url_retries_fallback_candidates(): void {
+		set_transient( 'sd_ai_agent_health_url', 'https://cached.example.test/health', HOUR_IN_SECONDS );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				$this->assertSame( 0, $args['redirection'] );
+
+				if ( 'https://cached.example.test/health' === $url ) {
+					return new WP_Error( 'connection_failed', 'Could not connect' );
+				}
+
+				return [
+					'headers'       => [],
+					'body'          => '',
+					'response'      => [ 'code' => str_contains( $url, '127.0.0.1' ) ? 500 : 403 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10,
+			3
+		);
+
+		$health_check = new PostMutationHealthCheck();
+		$this->assertSame( 'broken', $health_check->get_status() );
+		$this->assertFalse( get_transient( 'sd_ai_agent_health_url' ) );
+	}
+
+	/**
 	 * A server error remains broken even when its body contains the success token.
 	 */
 	public function test_server_error_with_success_token_is_broken(): void {

--- a/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
+++ b/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
@@ -221,6 +221,37 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A public health-route rejection is not evidence that WordPress is broken.
+	 */
+	public function test_verify_or_revert_ignores_public_health_route_rejection(): void {
+		add_filter(
+			'pre_http_request',
+			function () {
+				return [
+					'headers'       => [ 'content-type' => 'application/json' ],
+					'body'          => '{"code":"sd_ai_agent_health_forbidden"}',
+					'response'      => [ 'code' => 403 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10
+		);
+
+		$undo_called = false;
+		$undo        = function () use ( &$undo_called ) {
+			$undo_called = true;
+			return true;
+		};
+
+		$health_check = new PostMutationHealthCheck();
+		$result       = $health_check->verify_or_revert( $undo, 'Test operation' );
+
+		$this->assertNull( $result );
+		$this->assertFalse( $undo_called, 'A rejected public probe must not trigger rollback' );
+	}
+
+	/**
 	 * Test verify_or_revert() returns WP_Error when undo fails.
 	 */
 	public function test_verify_or_revert_includes_undo_error(): void {

--- a/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
+++ b/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
@@ -238,9 +238,9 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 			10
 		);
 
-		$undo_called = false;
-		$undo        = function () use ( &$undo_called ) {
-			$undo_called = true;
+		$undoCalled = false;
+		$undo       = function () use ( &$undoCalled ) {
+			$undoCalled = true;
 			return true;
 		};
 
@@ -248,7 +248,7 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 		$result       = $health_check->verify_or_revert( $undo, 'Test operation' );
 
 		$this->assertNull( $result );
-		$this->assertFalse( $undo_called, 'A rejected public probe must not trigger rollback' );
+		$this->assertFalse( $undoCalled, 'A rejected public probe must not trigger rollback' );
 	}
 
 	/**
@@ -299,6 +299,44 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 
 		$health_check = new PostMutationHealthCheck();
 		$this->assertSame( 'unreachable', $health_check->get_status() );
+		$this->assertFalse( get_transient( 'sd_ai_agent_health_url' ) );
+	}
+
+	/**
+	 * An unreachable cached URL must not hide a broken fallback candidate.
+	 */
+	public function test_unreachable_cached_health_url_retries_fallback_candidates(): void {
+		set_transient( 'sd_ai_agent_health_url', 'https://cached.example.test/health', HOUR_IN_SECONDS );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				$this->assertSame( 0, $args['redirection'] );
+
+				if ( 'https://cached.example.test/health' === $url ) {
+					return [
+						'headers'       => [],
+						'body'          => '',
+						'response'      => [ 'code' => 403 ],
+						'cookies'       => [],
+						'http_response' => null,
+					];
+				}
+
+				return [
+					'headers'       => [],
+					'body'          => '',
+					'response'      => [ 'code' => str_contains( $url, '127.0.0.1' ) ? 500 : 403 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10,
+			3
+		);
+
+		$health_check = new PostMutationHealthCheck();
+		$this->assertSame( 'broken', $health_check->get_status() );
 		$this->assertFalse( get_transient( 'sd_ai_agent_health_url' ) );
 	}
 

--- a/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
+++ b/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
@@ -252,6 +252,83 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A cached URL returning 403 remains unreachable rather than broken.
+	 */
+	public function test_cached_health_url_rejecting_request_is_unreachable(): void {
+		set_transient( 'sd_ai_agent_health_url', 'https://example.test/health', HOUR_IN_SECONDS );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args ) {
+				$this->assertSame( 0, $args['redirection'] );
+				return [
+					'headers'       => [ 'content-type' => 'application/json' ],
+					'body'          => '{"code":"sd_ai_agent_health_forbidden"}',
+					'response'      => [ 'code' => 403 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10,
+			2
+		);
+
+		$health_check = new PostMutationHealthCheck();
+		$this->assertSame( 'unreachable', $health_check->get_status() );
+	}
+
+	/**
+	 * Redirects cannot be followed or accepted even when their body has the token.
+	 */
+	public function test_redirect_with_success_token_is_unreachable(): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args ) {
+				$this->assertSame( 0, $args['redirection'] );
+				return [
+					'headers'       => [ 'location' => 'https://example.test/health' ],
+					'body'          => '{"success":true}',
+					'response'      => [ 'code' => 302 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10,
+			2
+		);
+
+		$health_check = new PostMutationHealthCheck();
+		$this->assertSame( 'unreachable', $health_check->get_status() );
+		$this->assertFalse( get_transient( 'sd_ai_agent_health_url' ) );
+	}
+
+	/**
+	 * A server error remains broken even when its body contains the success token.
+	 */
+	public function test_server_error_with_success_token_is_broken(): void {
+		set_transient( 'sd_ai_agent_health_url', 'https://example.test/health', HOUR_IN_SECONDS );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args ) {
+				$this->assertSame( 0, $args['redirection'] );
+				return [
+					'headers'       => [ 'content-type' => 'application/json' ],
+					'body'          => '{"success":true}',
+					'response'      => [ 'code' => 500 ],
+					'cookies'       => [],
+					'http_response' => null,
+				];
+			},
+			10,
+			2
+		);
+
+		$health_check = new PostMutationHealthCheck();
+		$this->assertSame( 'broken', $health_check->get_status() );
+	}
+
+	/**
 	 * Test verify_or_revert() returns WP_Error when undo fails.
 	 */
 	public function test_verify_or_revert_includes_undo_error(): void {


### PR DESCRIPTION
## Summary

- treat 3xx/4xx health-probe responses as unverifiable rather than proof that WordPress failed
- retain 5xx responses as authoritative broken-site evidence
- invalidate stale cached routes and retry fallback discovery after HTTP or transport-level failures
- cover mapped-domain rejection, stale cached HTTP responses, stale cached `WP_Error` responses, redirects, and misleading 5xx bodies

## Second review

An independent review found that a transport-level `WP_Error` from a stale cached URL returned early, leaving the stale transient in place and skipping fallback discovery. Commit `cf97f083` now classifies that response as unreachable, clears the cached route, and retries discovery. The follow-up review found no remaining material correctness issues.

## Verification

- `pnpm run test:php -- --filter PostMutationHealthCheckTest` — 22 tests, 59 assertions
- `pnpm exec playwright test tests/e2e/client-abilities.spec.js --grep "server post reflection"` — 3 passed
- `pnpm run verify` — passed

## Worker self-verification
- PHPUnit: Tests: 4148, Assertions: 18790, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol spent 7h 26m and 580,713 tokens on this with the user in an interactive session.