### PR TITLE
GH#2540: clarify advanced capability status

### DIFF
--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -518,7 +518,9 @@ class SystemInstructionBuilder {
 	 */
 	public static function build_advanced_companion_section(): string {
 		return "## Advanced Companion\n\n"
-			. 'Your active ability manifest is authoritative. If a requested action needs an ability that is not available, or a tool returns the `sd_ai_agent_advanced_plugin_required` error, explain that the capability is provided by Superdav AI Agent Advanced. '
+			. 'Your active ability manifest is authoritative. Treat questions such as “Is Advanced enabled?” or “Can you generate plugins?” as read-only capability-status questions: answer directly from that manifest without calling site-inspection tools such as list-options, list-posts, or get-plugins. '
+			. 'Plugin generation is available in the current session only when `sd-ai-agent/generate-plugin` appears in the active ability manifest or direct tool list. If it is present, say that plugin generation is available; if it is absent, say that plugin generation is not currently available and requires SD AI Agent Advanced. Do not infer availability from installed plugin files, options, or source-checkout contents. '
+			. 'If another requested action needs an ability that is not available, or a tool returns the `sd_ai_agent_advanced_plugin_required` error, explain that the capability is provided by SD AI Agent Advanced. '
 			. 'Do not attempt to download, install, activate, or update Advanced automatically. Direct the site administrator to https://sdaiagent.com/advanced/ for the direct ZIP download and manual installation instructions.';
 	}
 

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -110,6 +110,34 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Advanced capability questions must be answered from the active manifest.
+	 *
+	 * Regression: issue #2540 — a direct plugin-generation capability question
+	 * triggered unrelated site-inspection tools instead of a status answer.
+	 */
+	public function test_advanced_companion_section_answers_plugin_generation_status_from_manifest(): void {
+		$section = SystemInstructionBuilder::build_advanced_companion_section();
+
+		$this->assertStringContainsString( 'read-only capability-status questions', $section );
+		$this->assertStringContainsString( 'without calling site-inspection tools', $section );
+		$this->assertStringContainsString( 'list-options, list-posts, or get-plugins', $section );
+		$this->assertStringContainsString( '`sd-ai-agent/generate-plugin` appears', $section );
+		$this->assertStringContainsString( 'plugin generation is available', $section );
+		$this->assertStringContainsString( 'plugin generation is not currently available', $section );
+		$this->assertStringContainsString( 'Do not infer availability from installed plugin files', $section );
+	}
+
+	/** The assembled prompt must include the capability-status decision rule. */
+	public function test_build_includes_advanced_capability_status_guidance(): void {
+		$instruction = ( new SystemInstructionBuilder() )->build( array() );
+
+		$this->assertStringContainsString( '“Is Advanced enabled?”', $instruction );
+		$this->assertStringContainsString( '“Can you generate plugins?”', $instruction );
+		$this->assertStringContainsString( '`sd-ai-agent/generate-plugin`', $instruction );
+		$this->assertStringContainsString( 'requires SD AI Agent Advanced', $instruction );
+	}
+
+	/**
 	 * Frontend widget sessions include live-preview affected/refresh guidance.
 	 */
 	public function test_build_includes_frontend_live_preview_guidance(): void {


### PR DESCRIPTION
## Summary
- classify Advanced/plugin-generation questions as read-only capability checks
- answer directly from the active ability manifest instead of calling unrelated site-inspection tools
- state that `sd-ai-agent/generate-plugin` is the authoritative signal for current-session availability
- add regression coverage for the focused guidance and assembled system prompt

Resolves #2540

## Worker self-verification
- PHPUnit: Tests: 4142, Assertions: 18758, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Additional focused verification
- `pnpm run test:php -- --filter=SystemInstructionBuilderTest`: 17 tests, 83 assertions
- `vendor/bin/phpcs includes/Core/SystemInstructionBuilder.php tests/SdAiAgent/Core/SystemInstructionBuilderTest.php`: clean
- `php -l` on both changed PHP files: no syntax errors

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.287 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Advanced capability responses to accurately reflect the active capability manifest.
  * Clarified plugin-generation availability reporting.
  * Updated error guidance to use the correct “SD AI Agent Advanced” product name.

* **Tests**
  * Added coverage for capability-status responses and assembled guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->