### PR TITLE
GH#2539: fix: surface image tool prerequisites

### DIFF
--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -44,16 +44,12 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	/**
 	 * Register this ability.
 	 *
-	 * Only registers when an image-capable AI provider is actually configured.
-	 * Without one, exposing the ability would mislead the model into calling a
-	 * tool that can only return an error.
+	 * The ability remains discoverable when no image-capable provider is
+	 * configured. This lets the agent call it and receive the actionable setup
+	 * error instead of silently omitting image generation from the tool catalog.
 	 */
 	public static function register(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
-			return;
-		}
-
-		if ( ! self::is_image_generation_supported() ) {
 			return;
 		}
 
@@ -61,7 +57,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			'sd-ai-agent/generate-image',
 			[
 				'label'         => __( 'Generate Image', 'superdav-ai-agent' ),
-				'description'   => __( 'Generate unique AI images from a text prompt and import them into the media library. Supports size, style, quality, and multiple variations. Use for brand-specific imagery, concept illustrations, pattern backgrounds, and product visualisations — not for generic photography (use stock-image instead).', 'superdav-ai-agent' ),
+				'description'   => __( 'Generate unique AI images from a text prompt and import them into the media library. Supports size, style, quality, and multiple variations. Requires an image-capable provider configured on the Connectors settings page. Use for brand-specific imagery, concept illustrations, pattern backgrounds, and product visualisations — not for generic photography (use stock-image instead).', 'superdav-ai-agent' ),
 				'ability_class' => self::class,
 			]
 		);
@@ -78,7 +74,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * {@inheritdoc}
 	 */
 	protected function description(): string {
-		return __( 'Generate unique AI images from a text prompt and import them into the media library. Supports size, style, quality, and multiple variations. Use for brand-specific imagery, concept illustrations, pattern backgrounds, and product visualisations — not for generic photography (use stock-image instead).', 'superdav-ai-agent' );
+		return __( 'Generate unique AI images from a text prompt and import them into the media library. Supports size, style, quality, and multiple variations. Requires an image-capable provider configured on the Connectors settings page. Use for brand-specific imagery, concept illustrations, pattern backgrounds, and product visualisations — not for generic photography (use stock-image instead).', 'superdav-ai-agent' );
 	}
 
 	/**
@@ -305,7 +301,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			$error_message = 'All image generation attempts failed.';
 			if ( $last_error instanceof WP_Error ) {
 				$error_message = 'provider_unavailable' === $last_error->get_error_code()
-					? 'AI image generation is not available. Configure an image-capable provider in Settings > AI.'
+					? 'AI image generation is not available. Configure an image-capable provider on the Connectors settings page.'
 					: $last_error->get_error_message();
 			}
 
@@ -355,7 +351,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		if ( ! self::is_image_generation_supported() ) {
 			return new WP_Error(
 				'provider_unavailable',
-				'AI image generation is not available. Configure an image-capable provider in Settings > AI.'
+				'AI image generation is not available. Configure an image-capable provider on the Connectors settings page.'
 			);
 		}
 

--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -303,7 +303,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				'title'         => '',
 				'source'        => '',
 				'attribution'   => '',
-				'error'         => 'No free stock image source is available. Configure Openverse or Pixabay.',
+				'error'         => 'No free stock image source is available. Enable access to Openverse (no API key required) or configure a Pixabay API key.',
 			];
 			if ( $can_generate ) {
 				$response['tip'] = $generate_tip;

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -24,6 +24,31 @@ use WP_UnitTestCase;
  */
 class AiImageAbilitiesTest extends WP_UnitTestCase {
 
+	/**
+	 * Image generation remains discoverable so a missing provider produces an
+	 * actionable prerequisite message rather than an absent tool.
+	 */
+	public function test_generate_image_registers_without_a_configured_provider(): void {
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'WP 7.0+ Abilities API is unavailable.' );
+		}
+
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			wp_unregister_ability( 'sd-ai-agent/generate-image' );
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+		GenerateImageAbility::register();
+		array_pop( $wp_current_filter );
+
+		$ability = wp_get_ability( 'sd-ai-agent/generate-image' );
+
+		$this->assertNotNull( $ability );
+		$this->assertStringContainsString( 'Connectors settings page', $ability->get_description() );
+	}
+
 	// ─── handle_generate ──────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -483,6 +483,8 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'error', $result );
 		$this->assertFalse( $result['success'] );
 		$this->assertSame( 0, $result['attachment_id'] );
+		$this->assertStringContainsString( 'Openverse', $result['error'] );
+		$this->assertStringContainsString( 'Pixabay API key', $result['error'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Keep image generation discoverable without configured providers and clarify stock-image prerequisites.

## Files Changed

includes/Abilities/ImageAbilities/GenerateImageAbility.php, includes/Abilities/ImageAbilities/StockImageAbility.php, tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php, tests/SdAiAgent/Abilities/StockImageAbilityTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — vendor/bin/phpcs changed PHP files; pnpm run test:php -- --filter='AiImageAbilitiesTest|StockImageAbilityTest'

Resolves #2539


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-terra spent 46m and 222,587 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Image generation remains available even when no provider is configured, with guidance to configure one in Connector settings.
  * Updated setup errors to clearly explain how to enable image providers.
  * Stock image errors now identify Openverse and Pixabay configuration options.

* **Tests**
  * Added coverage for image-generation setup guidance and stock image source errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->