### PR TITLE
fix: restore nested plugin generation prompts

### DIFF
--- a/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
+++ b/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\PluginBuilder;
 
+use SdAiAgent\Core\ProviderCredentialLoader;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -50,6 +51,8 @@ class PluginGenerator {
 				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
 			);
 		}
+
+		ProviderCredentialLoader::load();
 
 		if ( empty( trim( $description ) ) ) {
 			return new WP_Error(
@@ -228,6 +231,8 @@ INSTRUCTION;
 			);
 		}
 
+		ProviderCredentialLoader::load();
+
 		$slug    = isset( $plan['slug'] ) ? (string) $plan['slug'] : 'generated-plugin';
 		$name    = isset( $plan['name'] ) ? (string) $plan['name'] : $slug;
 		$version = isset( $plan['version'] ) ? (string) $plan['version'] : '1.0.0';
@@ -308,6 +313,8 @@ INSTRUCTION;
 				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
 			);
 		}
+
+		ProviderCredentialLoader::load();
 
 		if ( empty( $files ) ) {
 			return new WP_Error(

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
@@ -100,6 +100,7 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 	private static function text_supported_options(): array {
 		return array(
 			new SupportedOption( OptionEnum::inputModalities(), array( array( ModalityEnum::text() ) ) ),
+			new SupportedOption( OptionEnum::outputModalities(), array( array( ModalityEnum::text() ) ) ),
 			new SupportedOption( OptionEnum::systemInstruction() ),
 			new SupportedOption( OptionEnum::maxTokens() ),
 			new SupportedOption( OptionEnum::temperature() ),

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
@@ -99,6 +99,7 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 	 */
 	private static function text_supported_options(): array {
 		return array(
+			new SupportedOption( OptionEnum::inputModalities(), array( array( ModalityEnum::text() ) ) ),
 			new SupportedOption( OptionEnum::systemInstruction() ),
 			new SupportedOption( OptionEnum::maxTokens() ),
 			new SupportedOption( OptionEnum::temperature() ),

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -358,6 +358,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 
 		$modelConfig = new ModelConfig();
 		$modelConfig->setSystemInstruction( 'Generate a WordPress plugin.' );
+		$modelConfig->setOutputModalities( array( ModalityEnum::text() ) );
 		$requirements = ModelRequirements::fromPromptData(
 			CapabilityEnum::textGeneration(),
 			array( new UserMessage( array( new MessagePart( 'Create a shortcode plugin.' ) ) ) ),

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -347,21 +347,21 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 'Example Model', $model->getName() );
 		$this->assertContainsEquals( CapabilityEnum::textGeneration(), $model->getSupportedCapabilities() );
 
-		$input_modalities = array_values(
+		$inputModalities = array_values(
 			array_filter(
 				$model->getSupportedOptions(),
 				static fn( SupportedOption $option ): bool => 'inputModalities' === $option->getName()->value
 			)
 		);
-		$this->assertCount( 1, $input_modalities );
-		$this->assertTrue( $input_modalities[0]->isSupportedValue( array( ModalityEnum::text() ) ) );
+		$this->assertCount( 1, $inputModalities );
+		$this->assertTrue( $inputModalities[0]->isSupportedValue( array( ModalityEnum::text() ) ) );
 
-		$model_config = new ModelConfig();
-		$model_config->setSystemInstruction( 'Generate a WordPress plugin.' );
+		$modelConfig = new ModelConfig();
+		$modelConfig->setSystemInstruction( 'Generate a WordPress plugin.' );
 		$requirements = ModelRequirements::fromPromptData(
 			CapabilityEnum::textGeneration(),
 			array( new UserMessage( array( new MessagePart( 'Create a shortcode plugin.' ) ) ) ),
-			$model_config
+			$modelConfig
 		);
 		$this->assertTrue( $requirements->areMetBy( $model ) );
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -35,6 +35,7 @@ use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
 use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
@@ -345,6 +346,24 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 'example-model', $model->getId() );
 		$this->assertSame( 'Example Model', $model->getName() );
 		$this->assertContainsEquals( CapabilityEnum::textGeneration(), $model->getSupportedCapabilities() );
+
+		$input_modalities = array_values(
+			array_filter(
+				$model->getSupportedOptions(),
+				static fn( SupportedOption $option ): bool => 'inputModalities' === $option->getName()->value
+			)
+		);
+		$this->assertCount( 1, $input_modalities );
+		$this->assertTrue( $input_modalities[0]->isSupportedValue( array( ModalityEnum::text() ) ) );
+
+		$model_config = new ModelConfig();
+		$model_config->setSystemInstruction( 'Generate a WordPress plugin.' );
+		$requirements = ModelRequirements::fromPromptData(
+			CapabilityEnum::textGeneration(),
+			array( new UserMessage( array( new MessagePart( 'Create a shortcode plugin.' ) ) ) ),
+			$model_config
+		);
+		$this->assertTrue( $requirements->areMetBy( $model ) );
 
 		$entry = ModelCapabilityRegistry::get( 'example-model' );
 		$this->assertSame( 4096, $entry['max_output_tokens'] );


### PR DESCRIPTION
## Summary

- reload provider credentials before AI-powered plugin planning, file generation, and review
- advertise text input modality support for managed text-generation models
- verify the model metadata satisfies the WordPress AI Client requirements produced by a text prompt with a system instruction

## Production evidence

The recorded production ability calls reached `sd-ai-agent/generate-plugin` twice and failed before any provider request with `prompt_invalid_argument`: `No models found that support text_generation for this prompt.` Production model discovery showed the managed chat models had `text_generation`, but their metadata omitted the `inputModalities` option automatically required for text prompts.

## Verification

- `pnpm run verify`
- PHPUnit: 4,149 tests, 18,798 assertions, 0 failures, 135 skipped, 4 incomplete
- focused provider test: 35 tests, 117 assertions
- PHP/JS/CSS lint clean
- PHPStan: 0 errors
- production build succeeded
- bundle budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider credentials are now loaded automatically during plugin plan generation, file generation, and code review.
  * Text-capable AI models now correctly indicate support for text input and satisfy text-generation requirements, including system instructions and user prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->