### PR TITLE
fix: isolate tenant file mutations

### DIFF
--- a/advanced-plugin/includes/Abilities/FileMutationAbilities.php
+++ b/advanced-plugin/includes/Abilities/FileMutationAbilities.php
@@ -34,6 +34,12 @@ class FileMutationAbilities {
 			return;
 		}
 
+		// These broad paths can address any wp-content subtree, including another
+		// tenant's uploads. Customer media changes use scoped media abilities.
+		if ( ! FileModGate::shared_code_modifications_allowed() ) {
+			return;
+		}
+
 		wp_register_ability(
 			'sd-ai-agent/file-write',
 			[
@@ -111,6 +117,17 @@ class FileWriteAbility extends AbstractFileAbility {
 		$path    = $input['path'] ?? '';
 		$content = $input['content'] ?? '';
 
+		// @phpstan-ignore-next-line
+		$full_path = $this->resolve_path( $path );
+		if ( is_wp_error( $full_path ) ) {
+			return $full_path;
+		}
+
+		$mod_allowed = FileModGate::assert_allowed( $full_path );
+		if ( is_wp_error( $mod_allowed ) ) {
+			return $mod_allowed;
+		}
+
 		// Check if this ability is in 'propose' mode.
 		// @phpstan-ignore-next-line
 		$permission = $this->get_tool_permission();
@@ -133,18 +150,6 @@ class FileWriteAbility extends AbstractFileAbility {
 				'file_path'    => $path,
 				'diff_preview' => $diff,
 			];
-		}
-
-		// @phpstan-ignore-next-line
-		$full_path = $this->resolve_path( $path );
-		if ( is_wp_error( $full_path ) ) {
-			return $full_path;
-		}
-
-		// Check if file modifications are allowed for this path.
-		$mod_allowed = FileModGate::assert_allowed( $full_path );
-		if ( is_wp_error( $mod_allowed ) ) {
-			return $mod_allowed;
 		}
 
 		// Validate PHP syntax before writing.
@@ -374,17 +379,23 @@ class FileEditAbility extends AbstractFileAbility {
 			}
 		}
 
+		// Resolve and authorize before proposal generation reads existing content.
+		// @phpstan-ignore-next-line
+		$full_path = $this->resolve_path( $path );
+		if ( is_wp_error( $full_path ) ) {
+			return $full_path;
+		}
+
+		$mod_allowed = FileModGate::assert_allowed( $full_path );
+		if ( is_wp_error( $mod_allowed ) ) {
+			return $mod_allowed;
+		}
+
 		// Check if this ability is in 'propose' mode.
 		// @phpstan-ignore-next-line
 		$permission = $this->get_tool_permission();
 		if ( 'propose' === $permission && ! isset( $input['_diff_only'] ) ) {
 			// For proposal mode, we need to compute the diff by applying edits to the current content.
-			// @phpstan-ignore-next-line
-			$full_path = $this->resolve_path( $path );
-			if ( is_wp_error( $full_path ) ) {
-				return $full_path;
-			}
-
 			if ( ! file_exists( $full_path ) ) {
 				// @phpstan-ignore-next-line
 				return new WP_Error( 'sd_ai_agent_file_not_found', sprintf( 'File not found: %s', $path ) );
@@ -428,18 +439,6 @@ class FileEditAbility extends AbstractFileAbility {
 				'file_path'    => $path,
 				'diff_preview' => $diff,
 			];
-		}
-
-		// @phpstan-ignore-next-line
-		$full_path = $this->resolve_path( $path );
-		if ( is_wp_error( $full_path ) ) {
-			return $full_path;
-		}
-
-		// Check if file modifications are allowed for this path.
-		$mod_allowed = FileModGate::assert_allowed( $full_path );
-		if ( is_wp_error( $mod_allowed ) ) {
-			return $mod_allowed;
 		}
 
 		if ( ! file_exists( $full_path ) ) {

--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -353,8 +353,8 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		// Bound both model discovery and generation for every SDK provider. This
 		// lets the agent continue with stock imagery or report the prerequisite
 		// instead of consuming the entire background-worker window.
-		$timeoutFilter = static fn (): int => self::IMAGE_REQUEST_TIMEOUT_SECONDS;
-		add_filter( 'wp_ai_client_default_request_timeout', $timeoutFilter, 999 );
+		$timeout_filter = static fn (): int => self::IMAGE_REQUEST_TIMEOUT_SECONDS;
+		add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
 		try {
 			if ( ! self::is_image_generation_supported() ) {
 				return new WP_Error(
@@ -367,7 +367,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		} catch ( \Throwable $e ) {
 			return new WP_Error( 'generation_failed', 'Image generation failed. The image provider did not respond within the allowed time.' );
 		} finally {
-			remove_filter( 'wp_ai_client_default_request_timeout', $timeoutFilter, 999 );
+			remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
 		}
 
 		if ( is_wp_error( $file ) ) {

--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -353,8 +353,8 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		// Bound both model discovery and generation for every SDK provider. This
 		// lets the agent continue with stock imagery or report the prerequisite
 		// instead of consuming the entire background-worker window.
-		$timeout_filter = static fn (): int => self::IMAGE_REQUEST_TIMEOUT_SECONDS;
-		add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+		$timeoutFilter = static fn (): int => self::IMAGE_REQUEST_TIMEOUT_SECONDS;
+		add_filter( 'wp_ai_client_default_request_timeout', $timeoutFilter, 999 );
 		try {
 			if ( ! self::is_image_generation_supported() ) {
 				return new WP_Error(
@@ -367,7 +367,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		} catch ( \Throwable $e ) {
 			return new WP_Error( 'generation_failed', 'Image generation failed. The image provider did not respond within the allowed time.' );
 		} finally {
-			remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+			remove_filter( 'wp_ai_client_default_request_timeout', $timeoutFilter, 999 );
 		}
 
 		if ( is_wp_error( $file ) ) {

--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -41,6 +41,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 
+	/** Maximum seconds an image-provider request may occupy the background worker. */
+	private const IMAGE_REQUEST_TIMEOUT_SECONDS = 90;
+
 	/**
 	 * Register this ability.
 	 *
@@ -279,10 +282,9 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 
 			if ( is_wp_error( $result ) ) {
 				$last_error = $result;
-				// No provider → stop immediately; retrying variations won't help.
-				if ( 'provider_unavailable' === $result->get_error_code() ) {
-					break;
-				}
+				// Repeating a failed provider request for each variation can outlive
+				// the background worker request and leave chat stuck in "Running".
+				break;
 			} else {
 				$attachments[] = [
 					'attachment_id' => $result['attachment_id'],
@@ -348,14 +350,25 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		int $post_id,
 		array $options = []
 	): array|\WP_Error {
-		if ( ! self::is_image_generation_supported() ) {
-			return new WP_Error(
-				'provider_unavailable',
-				'AI image generation is not available. Configure an image-capable provider on the Connectors settings page.'
-			);
-		}
+		// Bound both model discovery and generation for every SDK provider. This
+		// lets the agent continue with stock imagery or report the prerequisite
+		// instead of consuming the entire background-worker window.
+		$timeout_filter = static fn (): int => self::IMAGE_REQUEST_TIMEOUT_SECONDS;
+		add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+		try {
+			if ( ! self::is_image_generation_supported() ) {
+				return new WP_Error(
+					'provider_unavailable',
+					'AI image generation is not available. Configure an image-capable provider on the Connectors settings page.'
+				);
+			}
 
-		$file = $this->create_image_prompt_builder( $prompt, $options )->generate_image();
+			$file = $this->create_image_prompt_builder( $prompt, $options )->generate_image();
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'generation_failed', 'Image generation failed. The image provider did not respond within the allowed time.' );
+		} finally {
+			remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+		}
 
 		if ( is_wp_error( $file ) ) {
 			return new WP_Error(

--- a/includes/Core/Filesystem/FileModGate.php
+++ b/includes/Core/Filesystem/FileModGate.php
@@ -29,6 +29,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FileModGate {
 
 	/**
+	 * Whether the current request may mutate shared plugin or theme code.
+	 *
+	 * Plugin and theme directories are shared across sites in multisite. Limit
+	 * broad code mutations to the primary network's main site so a customer
+	 * subsite or isolated customer network cannot change code for other tenants.
+	 *
+	 * @return bool True when shared code mutations are allowed.
+	 */
+	public static function shared_code_modifications_allowed(): bool {
+		$allowed = ! is_multisite() || ( is_main_network() && is_main_site() );
+
+		/**
+		 * Filter whether the current request may mutate shared plugin/theme code.
+		 *
+		 * @param bool $allowed Whether shared code mutations are allowed.
+		 */
+		return (bool) apply_filters( 'sd_ai_agent_allow_shared_code_modifications', $allowed );
+	}
+
+	/**
 	 * Resolve the file modification context for a given path.
 	 *
 	 * Determines whether a path falls under plugin_files, theme_files, or
@@ -85,6 +105,14 @@ class FileModGate {
 	 */
 	public static function assert_allowed( string $path ) {
 		$context = self::context_for_path( $path );
+
+		if ( in_array( $context, [ 'plugin_files', 'theme_files' ], true ) && ! self::shared_code_modifications_allowed() ) {
+			return new WP_Error(
+				'sd_ai_agent_shared_code_mod_not_allowed',
+				'Shared plugin and theme files cannot be modified from a customer site.',
+				[ 'status' => 403 ]
+			);
+		}
 
 		if ( ! wp_is_file_mod_allowed( $context ) ) {
 			return new WP_Error(

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -541,7 +541,8 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 			->onlyMethods( [ 'generate_and_import' ] )
 			->getMock();
 
-		$ability->method( 'generate_and_import' )
+		$ability->expects( $this->once() )
+			->method( 'generate_and_import' )
 			->willReturn( new \WP_Error( 'generation_failed', 'Mock failure.' ) );
 
 		/** @var array<string,mixed>|\WP_Error $result */

--- a/tests/SdAiAgent/Core/Filesystem/FileModGateTest.php
+++ b/tests/SdAiAgent/Core/Filesystem/FileModGateTest.php
@@ -20,6 +20,15 @@ use WP_UnitTestCase;
 class FileModGateTest extends WP_UnitTestCase {
 
 	/**
+	 * Remove scope filters between tests.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_allow_shared_code_modifications' );
+		remove_all_filters( 'file_mod_allowed' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Test context_for_path returns 'plugin_files' for plugin paths.
 	 */
 	public function test_context_for_path_plugin_files() {
@@ -87,6 +96,67 @@ class FileModGateTest extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		remove_all_filters( 'file_mod_allowed' );
+	}
+
+	/**
+	 * Test customer contexts cannot mutate shared plugin files.
+	 */
+	public function test_assert_allowed_blocks_shared_plugin_files_for_customer_contexts() {
+		add_filter( 'sd_ai_agent_allow_shared_code_modifications', '__return_false' );
+		add_filter( 'file_mod_allowed', '__return_true' );
+
+		$result = FileModGate::assert_allowed( WP_PLUGIN_DIR . '/my-plugin/file.php' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_shared_code_mod_not_allowed', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test customer contexts cannot mutate shared theme files.
+	 */
+	public function test_assert_allowed_blocks_shared_theme_files_for_customer_contexts() {
+		add_filter( 'sd_ai_agent_allow_shared_code_modifications', '__return_false' );
+		add_filter( 'file_mod_allowed', '__return_true' );
+
+		$result = FileModGate::assert_allowed( get_theme_root() . '/ollie/patterns/footer-light.php' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_shared_code_mod_not_allowed', $result->get_error_code() );
+	}
+
+	/**
+	 * Test the shared-code scope can be explicitly filtered for host tooling.
+	 */
+	public function test_shared_code_modifications_allowed_is_filterable() {
+		add_filter( 'sd_ai_agent_allow_shared_code_modifications', '__return_false' );
+
+		$this->assertFalse( FileModGate::shared_code_modifications_allowed() );
+	}
+
+	/**
+	 * Test shared code mutations are allowed on the primary main site.
+	 */
+	public function test_shared_code_modifications_allowed_on_primary_main_site() {
+		$this->assertTrue( FileModGate::shared_code_modifications_allowed() );
+	}
+
+	/**
+	 * Test shared code mutations are denied on a customer subsite by default.
+	 */
+	public function test_shared_code_modifications_denied_on_multisite_subsite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires WordPress multisite.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+		switch_to_blog( $blog_id );
+
+		try {
+			$this->assertFalse( FileModGate::shared_code_modifications_allowed() );
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- suppress broad `wp-content` file-mutation abilities outside the primary network main site
- enforce plugin/theme mutation isolation before proposal-mode reads or execution
- bound image-provider discovery and generation to 90 seconds and stop retrying failed variations

## Verification

- `vendor/bin/phpunit --filter AiImageAbilitiesTest --no-coverage` (19 tests, 56 assertions)
- `WP_MULTISITE=1 vendor/bin/phpunit --filter FileModGateTest --no-coverage` (16 tests, 22 assertions)
- `composer lint` (PHPCS and PHPStan passed)
- full 4,117-test suite reached 94% without a reported failure before the 600-second local command timeout

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safeguards for file changes, preventing unauthorized modifications to shared plugin and theme files.
  * Added multisite protections so shared-code changes are restricted to permitted sites.
  * Improved image generation reliability by applying a longer timeout and stopping failed variation requests cleanly.
  * Image generation failures now return a consistent error instead of exposing unexpected exception details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->