### PR TITLE
Fix onboarding completion at iteration limit

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2274,7 +2274,6 @@ PROMPT;
 			}
 
 			$fallback_message = $fallback_result->toMessage();
-			$this->append_assistant_message_to_history( $fallback_message );
 			$this->accumulate_tokens( $fallback_result );
 
 			$reply = '';
@@ -2283,6 +2282,17 @@ PROMPT;
 			} catch ( \RuntimeException $e ) {
 				$reply = '';
 			}
+
+			// The summarization request is outside the executable tool budget. Some
+			// providers still return another function call because tools remain in
+			// the conversation history. Never persist that call as if it were going
+			// to run, and never complete the job with an empty customer response.
+			if ( $this->message_has_function_calls( $fallback_message ) || '' === trim( $reply ) ) {
+				$reply            = __( 'I reached the tool-call limit before I could finish. Some requested work may be incomplete, so please review the current site before retrying.', 'superdav-ai-agent' );
+				$fallback_message = new ModelMessage( array( new MessagePart( $reply ) ) );
+			}
+
+			$this->append_assistant_message_to_history( $fallback_message );
 
 			// Post-process the reply to inject real permalinks from create-post responses.
 			$reply = $this->inject_real_permalinks( $reply );
@@ -2299,6 +2309,7 @@ PROMPT;
 						'token_usage'     => $this->token_usage,
 						'iterations_used' => $this->iterations_used,
 						'model_id'        => $this->model_id,
+						'exit_reason'     => 'max_iterations',
 					)
 				)
 			);

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -593,7 +593,7 @@ class Agent {
 			// First-run builds deliberately reserve enough turns for discovery,
 			// composition, three-viewport browser QA, and at least one repair pass.
 			// General-agent edits retain the user's ordinary iteration budget.
-			$options['max_iterations'] = max( 60, (int) ( $options['max_iterations'] ?? 0 ) );
+			$options['max_iterations'] = max( 100, (int) ( $options['max_iterations'] ?? 0 ) );
 			$tier_1_tools              = array_values(
 				array_unique(
 					array_merge(
@@ -828,7 +828,7 @@ class Agent {
 			'greeting'       => __( "Hi! Give me a moment to look around, then I'll show you what I can do.", 'superdav-ai-agent' ),
 			'avatar_icon'    => 'dashicons-welcome-learn-more',
 			'tier_1_tools'   => self::get_unified_onboarding_tier_1_tools( $base_tools ),
-			'max_iterations' => 60,
+			'max_iterations' => 100,
 			'suggestions'    => [
 				[
 					'title'       => __( 'Build me a site', 'superdav-ai-agent' ),

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -2095,9 +2095,9 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 	/**
 	 * Test run() triggers the graceful fallback when max iterations are exhausted
-	 * with only tool calls. The fallback send_prompt() also returns a tool call
-	 * (no text), so toText() throws and reply is empty — but the result is still
-	 * a success array, not a WP_Error.
+	 * with only tool calls. If the fallback provider response is another tool call,
+	 * the loop must replace it with an honest terminal response rather than
+	 * persisting an unexecuted call and showing an empty reply.
 	 */
 	public function test_run_exhausts_max_iterations(): void {
 		$this->skip_if_sdk_unavailable();
@@ -2152,13 +2152,14 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$loop   = new AgentLoop( 'Loop forever', [], [], [ 'max_iterations' => 2 ] );
 		$result = $loop->run();
 
-		// The graceful fallback fires after the loop exhausts. The fallback
-		// send_prompt() also returns a tool call (no text), so toText() throws
-		// and reply is ''. The result is a success array, not a WP_Error.
+		// The graceful fallback fires after the loop exhausts. The mocked provider
+		// still returns a tool call, so the deterministic terminal response must win.
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'reply', $result );
 		$this->assertArrayHasKey( 'tool_calls', $result );
 		$this->assertArrayHasKey( 'iterations_used', $result );
+		$this->assertStringContainsString( 'tool-call limit', $result['reply'] );
+		$this->assertSame( 'max_iterations', $result['exit_reason'] );
 		// 2 loop iterations + 1 fallback call = 3.
 		$this->assertSame( 3, $result['iterations_used'] );
 	}

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -633,7 +633,7 @@ class AgentTest extends WP_UnitTestCase {
 
 		try {
 			$options = Agent::get_loop_options( $agent->id );
-			$this->assertSame( 60, $options['max_iterations'] );
+			$this->assertSame( 100, $options['max_iterations'] );
 			$this->assertContains( 'sd-ai-agent/get-option', $options['tier_1_tools'] );
 			$this->assertContains( 'sd-ai-agent/create-menu', $options['tier_1_tools'] );
 			$this->assertContains( 'sd-ai-agent/add-menu-item', $options['tier_1_tools'] );


### PR DESCRIPTION
## Summary

- raise the Setup Assistant's bounded first-run iteration budget from 60 to 100
- replace an empty max-iteration fallback or another fallback tool call with an honest terminal response
- expose `max_iterations` as the exit reason and avoid persisting a tool call that will never execute

## Evidence

A fresh photographer onboarding run reached the 60-turn boundary after creating its requested pages. The active job disappeared while the persisted conversation ended on an unexecuted `run-php` function call, leaving the customer with no final response. The fallback path already requested a summary, but the provider could answer with another tool call and the loop treated the resulting empty text as success.

## Verification

- Focused AgentLoop/Agent tests: 197 tests, 576 assertions, 67 skipped
- Full verification: 4,155 tests, 18,810 assertions, 0 errors, 0 failures, 136 skipped, 4 incomplete
- PHP, JavaScript, and CSS lint: clean
- PHPStan: 0 errors
- Production build: succeeded
- Bundle budgets: passed

## Worker self-verification
- PHPUnit: Tests: 4155, Assertions: 18810, Errors: 0, Failures: 0, Skipped: 136
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol spent 14h 13m and 3,422,876 tokens on this with the user in an interactive session.