### PR TITLE
fix: enforce onboarding media call budget

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1937,21 +1937,28 @@ PROMPT;
 
 			// Check if the model wants to call tools.
 			if ( ! $this->message_has_function_calls( $assistant_message ) ) {
-				if ( '' !== $media_budget['guidance'] && $iterations > 0 ) {
-					$this->history[]       = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
-					$this->last_loop_phase = 'onboarding_media_budget_guarded';
-					continue;
+				$guarded_terminal_reply = '';
+				if ( '' !== $media_budget['guidance'] ) {
+					if ( $iterations > 0 ) {
+						$this->history[]       = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
+						$this->last_loop_phase = 'onboarding_media_budget_guarded';
+						continue;
+					}
+
+					$guarded_terminal_reply = $media_budget['guidance'];
 				}
 
 				// No tool calls — we're done.
 				$last_was_tool_call    = false;
-				$reply                 = '';
+				$reply                 = $guarded_terminal_reply;
 				$this->last_loop_phase = 'final_response_received';
 
-				try {
-					$reply = $result->toText();
-				} catch ( \RuntimeException $e ) {
-					$reply = '';
+				if ( '' === $reply ) {
+					try {
+						$reply = $result->toText();
+					} catch ( \RuntimeException $e ) {
+						$reply = '';
+					}
 				}
 
 				// If a prior create/update saved invalid block markup, do not let the
@@ -4155,9 +4162,19 @@ PROMPT;
 			)
 		);
 
+		$stock_remaining    = max( 0, $limits['sd-ai-agent/stock-image'] - $used['sd-ai-agent/stock-image'] );
+		$generate_remaining = max( 0, $limits['sd-ai-agent/generate-image'] - $used['sd-ai-agent/generate-image'] );
+		if ( 0 === $stock_remaining && 0 === $generate_remaining ) {
+			$guidance = __( 'The Setup Assistant media budget is exhausted: stock-image allows two calls total and generate-image allows one. Continue without more image sourcing and do not use URL-fetch or upload fallbacks. If required primary media is unavailable, report that blocker and do not publish a weak text-only homepage.', 'superdav-ai-agent' );
+		} elseif ( 0 === $stock_remaining ) {
+			$guidance = __( 'The Setup Assistant stock-image budget is exhausted after two calls. Do not call stock-image again or use URL-fetch or upload fallbacks. The generate-image fallback remains available for one call; use it only if required, then continue the build.', 'superdav-ai-agent' );
+		} else {
+			$guidance = __( 'The Setup Assistant generate-image budget is exhausted after one call. Do not call generate-image again or use URL-fetch or upload fallbacks. The remaining stock-image allowance may still be used, up to two calls total; otherwise continue without more image sourcing.', 'superdav-ai-agent' );
+		}
+
 		return array(
 			'message'  => new ModelMessage( $kept ),
-			'guidance' => __( 'The Setup Assistant media budget is exhausted: stock-image allows two calls total and generate-image allows one. Continue without more image sourcing and do not use URL-fetch or upload fallbacks. If required primary media is unavailable, report that blocker and do not publish a weak text-only homepage.', 'superdav-ai-agent' ),
+			'guidance' => $guidance,
 			'removed'  => $removed,
 		);
 	}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1948,10 +1948,14 @@ PROMPT;
 				$reply                 = '';
 				$this->last_loop_phase = 'final_response_received';
 
-				try {
-					$reply = $result->toText();
-				} catch ( \RuntimeException $e ) {
-					$reply = '';
+				if ( '' !== $media_budget['guidance'] ) {
+					$reply = $media_budget['guidance'];
+				} else {
+					try {
+						$reply = $result->toText();
+					} catch ( \RuntimeException $e ) {
+						$reply = '';
+					}
 				}
 
 				// If a prior create/update saved invalid block markup, do not let the
@@ -4155,9 +4159,44 @@ PROMPT;
 			)
 		);
 
+		$exhausted_abilities = array();
+		$available_abilities = array();
+		foreach ( $limits as $ability_name => $limit ) {
+			if ( $used[ $ability_name ] >= $limit ) {
+				$exhausted_abilities[] = sprintf(
+					/* translators: 1: media ability name, 2: total permitted calls. */
+					__( '%1$s (%2$d calls total)', 'superdav-ai-agent' ),
+					str_replace( 'sd-ai-agent/', '', $ability_name ),
+					$limit
+				);
+			} else {
+				$available_abilities[] = sprintf(
+					/* translators: 1: media ability name, 2: number of calls remaining. */
+					__( '%1$s (%2$d calls remaining)', 'superdav-ai-agent' ),
+					str_replace( 'sd-ai-agent/', '', $ability_name ),
+					$limit - $used[ $ability_name ]
+				);
+			}
+		}
+
+		$guidance             = sprintf(
+			/* translators: %s: comma-separated list of exhausted media abilities. */
+			__( 'The Setup Assistant media budget is exhausted for: %s.', 'superdav-ai-agent' ),
+			implode( ', ', $exhausted_abilities )
+		);
+		if ( ! empty( $available_abilities ) ) {
+			$guidance .= ' ' . sprintf(
+				/* translators: %s: comma-separated list of remaining media abilities. */
+				__( 'You may still use: %s. Do not use URL-fetch or upload fallbacks.', 'superdav-ai-agent' ),
+				implode( ', ', $available_abilities )
+			);
+		} else {
+			$guidance .= ' ' . __( 'Continue without more image sourcing and do not use URL-fetch or upload fallbacks. If required primary media is unavailable, report that blocker and do not publish a weak text-only homepage.', 'superdav-ai-agent' );
+		}
+
 		return array(
 			'message'  => new ModelMessage( $kept ),
-			'guidance' => __( 'The Setup Assistant media budget is exhausted: stock-image allows two calls total and generate-image allows one. Continue without more image sourcing and do not use URL-fetch or upload fallbacks. If required primary media is unavailable, report that blocker and do not publish a weak text-only homepage.', 'superdav-ai-agent' ),
+			'guidance' => $guidance,
 			'removed'  => $removed,
 		);
 	}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1920,6 +1920,9 @@ PROMPT;
 				continue;
 			}
 
+			$media_budget      = $this->enforce_onboarding_media_budget( $assistant_message );
+			$assistant_message = $media_budget['message'];
+
 			$history_message          = $assistant_message;
 			$history_before_assistant = $this->history;
 			$reuse_plan               = $this->readonly_tool_cache->reuse( $assistant_message );
@@ -1934,6 +1937,12 @@ PROMPT;
 
 			// Check if the model wants to call tools.
 			if ( ! $this->message_has_function_calls( $assistant_message ) ) {
+				if ( '' !== $media_budget['guidance'] && $iterations > 0 ) {
+					$this->history[]       = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
+					$this->last_loop_phase = 'onboarding_media_budget_guarded';
+					continue;
+				}
+
 				// No tool calls — we're done.
 				$last_was_tool_call    = false;
 				$reply                 = '';
@@ -2186,6 +2195,9 @@ PROMPT;
 			$this->append_tool_response_to_history( $truncated_message );
 			$this->log_tool_responses( $truncated_message );
 			$this->readonly_tool_cache->record( $history_message, $truncated_message );
+			if ( '' !== $media_budget['guidance'] ) {
+				$this->history[] = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
+			}
 			$this->last_loop_phase = 'tool_response_recorded';
 			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_RESPONSE_RECORDED, $iterations );
 
@@ -4048,6 +4060,124 @@ PROMPT;
 		);
 
 		return new ModelMessage( $deduped );
+	}
+
+	/**
+	 * Enforce the Setup Assistant's per-run media acquisition budget.
+	 *
+	 * Prompt instructions remain useful guidance, but providers can emit several
+	 * parallel image calls in one turn or retry after a failed generation. Count
+	 * admitted calls in durable history so resumed browser-tool loops preserve the
+	 * same budget, and remove excess calls before they can execute.
+	 *
+	 * @param Message $message Assistant message returned by the provider.
+	 * @return array{message:Message,guidance:string,removed:array<string,int>}
+	 */
+	private function enforce_onboarding_media_budget( Message $message ): array {
+		$unchanged = array(
+			'message'  => $message,
+			'guidance' => '',
+			'removed'  => array(),
+		);
+
+		if ( 'onboarding' !== $this->agent_slug ) {
+			return $unchanged;
+		}
+
+		$limits = array(
+			'sd-ai-agent/stock-image'    => 2,
+			'sd-ai-agent/generate-image' => 1,
+		);
+		$used   = array_fill_keys( array_keys( $limits ), 0 );
+
+		foreach ( $this->history as $history_message ) {
+			foreach ( $history_message->getParts() as $part ) {
+				$call = $part->getFunctionCall();
+				if ( ! $call ) {
+					continue;
+				}
+
+				$ability_name = self::media_ability_name_for_call( $call );
+				if ( null !== $ability_name ) {
+					++$used[ $ability_name ];
+				}
+			}
+		}
+
+		$kept    = array();
+		$removed = array_fill_keys( array_keys( $limits ), 0 );
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call ) {
+				$kept[] = $part;
+				continue;
+			}
+
+			$ability_name = self::media_ability_name_for_call( $call );
+			if ( null === $ability_name ) {
+				$kept[] = $part;
+				continue;
+			}
+
+			if ( $used[ $ability_name ] >= $limits[ $ability_name ] ) {
+				++$removed[ $ability_name ];
+				continue;
+			}
+
+			++$used[ $ability_name ];
+			$kept[] = $part;
+		}
+
+		$removed = array_filter( $removed );
+		if ( empty( $removed ) ) {
+			return $unchanged;
+		}
+		if ( empty( $kept ) ) {
+			$kept[] = new MessagePart( __( 'Media acquisition call blocked by the Setup Assistant budget.', 'superdav-ai-agent' ) );
+		}
+
+		$removed_count       = array_sum( $removed );
+		$this->message_log[] = array(
+			'type'     => 'guardrail',
+			'reason'   => 'onboarding_media_budget_guarded',
+			'count'    => $removed_count,
+			'sequence' => $this->next_activity_sequence(),
+		);
+		AgentEventLog::log(
+			'onboarding_media_budget_guarded',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'       => $this->session_id,
+				'stock_removed'    => $removed['sd-ai-agent/stock-image'] ?? 0,
+				'generate_removed' => $removed['sd-ai-agent/generate-image'] ?? 0,
+				'model_id'         => (string) $this->model_id,
+				'provider_id'      => (string) $this->provider_id,
+			)
+		);
+
+		return array(
+			'message'  => new ModelMessage( $kept ),
+			'guidance' => __( 'The Setup Assistant media budget is exhausted: stock-image allows two calls total and generate-image allows one. Continue without more image sourcing and do not use URL-fetch or upload fallbacks. If required primary media is unavailable, report that blocker and do not publish a weak text-only homepage.', 'superdav-ai-agent' ),
+			'removed'  => $removed,
+		);
+	}
+
+	/** Return the bounded media ability represented by a direct or dispatcher call. */
+	private static function media_ability_name_for_call( FunctionCall $call ): ?string {
+		$tool_name = self::normalize_logged_tool_name( (string) $call->getName() );
+		if ( in_array( $tool_name, array( 'sd-ai-agent/stock-image', 'sd-ai-agent/generate-image' ), true ) ) {
+			return $tool_name;
+		}
+
+		if ( 'sd-ai-agent/ability-call' !== $tool_name ) {
+			return null;
+		}
+
+		$args         = self::normalize_function_call_args( $call->getArgs() );
+		$ability_name = (string) ( $args['ability'] ?? '' );
+		return in_array( $ability_name, array( 'sd-ai-agent/stock-image', 'sd-ai-agent/generate-image' ), true )
+			? $ability_name
+			: null;
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3836,6 +3836,63 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'Media acquisition call blocked',
 			$fully_blocked_parts[0]->getText()
 		);
+
+		$stock_only_result = $method->invoke(
+			$loop,
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'stock-five', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'studio' ) ) ),
+				)
+			)
+		);
+		$this->assertStringContainsString( 'generate-image fallback remains available', $stock_only_result['guidance'] );
+
+		$generation_history = array(
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'generate-first', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'studio' ) ) ),
+				)
+			),
+		);
+		$generation_loop    = new AgentLoop( 'Build a photographer site', array(), $generation_history, array( 'agent_slug' => 'onboarding' ) );
+		$generation_result  = $method->invoke(
+			$generation_loop,
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'generate-fourth', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'event' ) ) ),
+				)
+			)
+		);
+		$this->assertStringContainsString( 'remaining stock-image allowance', $generation_result['guidance'] );
+
+		$terminal_history = array(
+			new UserMessage( array( new MessagePart( 'Earlier media work.' ) ) ),
+			new ModelMessage( array( new MessagePart( new FunctionCall( 'prior-stock-one', 'wpab__sd-ai-agent__stock-image', array() ) ) ) ),
+			new UserMessage( array( new MessagePart( new FunctionResponse( 'prior-stock-one', 'wpab__sd-ai-agent__stock-image', array( 'ok' => true ) ) ) ) ),
+			new ModelMessage( array( new MessagePart( new FunctionCall( 'prior-stock-two', 'wpab__sd-ai-agent__stock-image', array() ) ) ) ),
+			new UserMessage( array( new MessagePart( new FunctionResponse( 'prior-stock-two', 'wpab__sd-ai-agent__stock-image', array( 'ok' => true ) ) ) ) ),
+			new ModelMessage( array( new MessagePart( new FunctionCall( 'prior-generate', 'wpab__sd-ai-agent__generate-image', array() ) ) ) ),
+			new UserMessage( array( new MessagePart( new FunctionResponse( 'prior-generate', 'wpab__sd-ai-agent__generate-image', array( 'ok' => true ) ) ) ) ),
+		);
+		$terminal_loop = new ScriptedAgentLoop(
+			'Finish the photographer site',
+			array(),
+			$terminal_history,
+			array(
+				'agent_slug'    => 'onboarding',
+				'max_iterations' => 1,
+			),
+			array(
+				$this->create_scripted_result(
+					'',
+					new FunctionCall( 'stock-final', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'final' ) )
+				),
+			)
+		);
+		$terminal_result = $terminal_loop->run();
+
+		$this->assertIsArray( $terminal_result );
+		$this->assertStringContainsString( 'media budget is exhausted', $terminal_result['reply'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3742,6 +3742,103 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Setup Assistant media acquisition must stay bounded across direct and
+	 * dispatcher calls, including several calls emitted in one model turn.
+	 */
+	public function test_onboarding_media_budget_removes_excess_calls(): void {
+		if ( ! class_exists( FunctionCall::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$history = array(
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'stock-one', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'wedding' ) ) ),
+				)
+			),
+			new ModelMessage(
+				array(
+					new MessagePart(
+						new FunctionCall(
+							'stock-two',
+							'wpab__sd-ai-agent__ability-call',
+							array(
+								'ability'   => 'sd-ai-agent/stock-image',
+								'arguments' => array( 'keyword' => 'family' ),
+							)
+						)
+					),
+				)
+			),
+		);
+		$loop    = new AgentLoop( 'Build a photographer site', array(), $history, array( 'agent_slug' => 'onboarding' ) );
+		$message = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'stock-three', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'portrait' ) ) ),
+				new MessagePart( new FunctionCall( 'generate-one', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'portrait' ) ) ),
+				new MessagePart( new FunctionCall( 'generate-two', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'wedding' ) ) ),
+				new MessagePart( new FunctionCall( 'other-tool', 'wpab__sd-ai-agent__list-posts', array() ) ),
+			)
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'enforce_onboarding_media_budget' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'sd-ai-agent/stock-image'    => 1,
+				'sd-ai-agent/generate-image' => 1,
+			),
+			$result['removed']
+		);
+		$this->assertStringContainsString( 'media budget is exhausted', $result['guidance'] );
+
+		$kept_names = array();
+		foreach ( $result['message']->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( $call ) {
+				$kept_names[] = $call->getName();
+			}
+		}
+		$this->assertSame(
+			array( 'wpab__sd-ai-agent__generate-image', 'wpab__sd-ai-agent__list-posts' ),
+			$kept_names
+		);
+
+		$exhausted_history   = array_merge(
+			$history,
+			array(
+				new ModelMessage(
+					array(
+						new MessagePart( new FunctionCall( 'generate-used', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'portrait' ) ) ),
+					)
+				),
+			)
+		);
+		$exhausted_loop      = new AgentLoop( 'Build a photographer site', array(), $exhausted_history, array( 'agent_slug' => 'onboarding' ) );
+		$fully_blocked       = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'stock-four', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'event' ) ) ),
+				new MessagePart( new FunctionCall( 'generate-three', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'event' ) ) ),
+			)
+		);
+		$fully_blocked_result = $method->invoke( $exhausted_loop, $fully_blocked );
+
+		$fully_blocked_parts = $fully_blocked_result['message']->getParts();
+		if ( ! is_array( $fully_blocked_parts ) ) {
+			$this->fail( 'Expected guarded message parts to be an array.' );
+		}
+		$this->assertCount( 1, $fully_blocked_parts );
+		$this->assertNull( $fully_blocked_parts[0]->getFunctionCall() );
+		$this->assertStringContainsString(
+			'Media acquisition call blocked',
+			$fully_blocked_parts[0]->getText()
+		);
+	}
+
+	/**
 	 * Denied block-theme scaffolding should stop dependent theme-writing steps.
 	 */
 	public function test_scaffold_block_theme_permission_denial_builds_terminal_recovery_reply(): void {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3794,6 +3794,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 			$result['removed']
 		);
 		$this->assertStringContainsString( 'media budget is exhausted', $result['guidance'] );
+		$this->assertStringContainsString( 'stock-image (2 calls total)', $result['guidance'] );
+		$this->assertStringContainsString( 'generate-image (1 calls total)', $result['guidance'] );
 
 		$kept_names = array();
 		foreach ( $result['message']->getParts() as $part ) {
@@ -3836,6 +3838,98 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'Media acquisition call blocked',
 			$fully_blocked_parts[0]->getText()
 		);
+		$this->assertStringContainsString( 'Continue without more image sourcing', $fully_blocked_result['guidance'] );
+
+		$stock_exhausted_loop   = new AgentLoop( 'Build a photographer site', array(), $history, array( 'agent_slug' => 'onboarding' ) );
+		$stock_exhausted_result = $method->invoke(
+			$stock_exhausted_loop,
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'stock-five', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'event' ) ) ),
+				)
+			)
+		);
+		$this->assertStringContainsString( 'stock-image (2 calls total)', $stock_exhausted_result['guidance'] );
+		$this->assertStringContainsString( 'generate-image (1 calls remaining)', $stock_exhausted_result['guidance'] );
+
+		$generate_exhausted_loop   = new AgentLoop( 'Build a photographer site', array(), $exhausted_history, array( 'agent_slug' => 'onboarding' ) );
+		$generate_exhausted_result = $method->invoke(
+			$generate_exhausted_loop,
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'generate-four', 'wpab__sd-ai-agent__generate-image', array( 'prompt' => 'event' ) ) ),
+				)
+			)
+		);
+		$this->assertStringContainsString( 'generate-image (1 calls total)', $generate_exhausted_result['guidance'] );
+		$this->assertStringContainsString( 'stock-image (1 calls remaining)', $generate_exhausted_result['guidance'] );
+	}
+
+	/**
+	 * A final-turn media guard must not return the provider's tool-only response.
+	 */
+	public function test_onboarding_media_budget_returns_guidance_on_final_iteration(): void {
+		$this->skip_if_sdk_unavailable();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) {
+				if ( false === strpos( $url, 'fake-ai-proxy.test' ) ) {
+					return $preempt;
+				}
+
+				return array(
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => (string) wp_json_encode(
+						array(
+							'id'      => 'chatcmpl-media-budget-final-turn',
+							'object'  => 'chat.completion',
+							'choices' => array(
+								array(
+									'index'         => 0,
+									'message'       => array(
+										'role'       => 'assistant',
+										'content'    => null,
+										'tool_calls' => array(
+											array(
+												'id'       => 'call_stock_blocked',
+												'type'     => 'function',
+												'function' => array(
+													'name'      => 'wpab__sd-ai-agent__stock-image',
+													'arguments' => '{"keyword":"portrait"}',
+												),
+											),
+										),
+									),
+									'finish_reason' => 'tool_calls',
+								),
+							),
+							'usage'   => array( 'prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10 ),
+						)
+					),
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'cookies'  => array(),
+					'filename' => '',
+				);
+			},
+			10,
+			3
+		);
+
+		$history = array(
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'stock-one', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'wedding' ) ) ),
+					new MessagePart( new FunctionCall( 'stock-two', 'wpab__sd-ai-agent__stock-image', array( 'keyword' => 'family' ) ) ),
+				)
+			),
+		);
+		$loop    = new AgentLoop( 'Build a photographer site', array(), $history, array( 'agent_slug' => 'onboarding', 'max_iterations' => 1 ) );
+		$result  = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertNotSame( '', $result['reply'] );
+		$this->assertStringContainsString( 'stock-image (2 calls total)', $result['reply'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- enforce the Setup Assistant's two-stock/one-generation media budget in `AgentLoop`
- count prior admitted calls across direct, dispatcher, and intercepted XML tool-call forms
- remove excess calls before execution, record guardrail telemetry, and give the model bounded recovery guidance
- preserve valid mixed tool calls and a serializable assistant turn when every proposed call is blocked

## Why

A fresh onboarding QA run ignored the prompt-only limit, issued at least five stock-image calls, and retried stock after generation failed. Runtime enforcement is needed so provider behavior cannot exceed the acquisition budget.

## Verification

- `composer lint`
- `vendor/bin/phpunit` — 4,156 tests, 18,817 assertions; 136 skipped, 4 incomplete
- `vendor/bin/phpunit tests/SdAiAgent/Core/AgentLoopTest.php` — 165 tests, 376 assertions; 67 skipped
- `pnpm run lint:js`
- `pnpm run lint:css`
- `pnpm run build`
- `pnpm run check:bundle`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media-use limits during Setup Assistant onboarding: up to two stock images and one generated image.
  * Enforces limits across resumed sessions and different image-request methods.
  * Provides guidance to continue without image fallbacks when limits are reached.

* **Bug Fixes**
  * Prevents excess image requests from being executed while preserving other assistant actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->