### PR TITLE
feat: add privacy-safe customer conversation review

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -97,6 +97,11 @@ Never set a custom font family. The plugin must feel native to the admin environ
 ### General rule
 Use `@wordpress/components` for every interactive element. Do not reach for raw `<button>` or `<input>` elements unless unavoidable (e.g. hidden file inputs). Using WordPress components ensures keyboard accessibility, focus management, and visual consistency come for free.
 
+### Privacy review screens
+- Use a compact filterable summary list with an explicit detail selection; never place transcript text, profile identifiers, tokens, hashes, tool data, or raw provider payloads in list rows.
+- Keep transcript detail text-only, bounded, and visibly separate from its summary. Use pagination to load earlier retained messages instead of rendering an unbounded conversation at once.
+- Deletion and purge controls are destructive secondary buttons. Require a native confirmation dialog or WordPress modal before calling the API, and clearly state that retained content cannot be restored.
+
 ### Buttons
 
 **Primary action** (send, save, confirm):

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -108,6 +108,13 @@ class UnifiedAdminMenu {
 				'position'   => 20,
 				'capability' => self::CAPABILITY,
 			),
+			array(
+				'slug'       => 'customer-conversations',
+				'label'      => __( 'Customer Conversations', 'superdav-ai-agent' ),
+				'icon'       => 'dashicons-admin-comments',
+				'position'   => 25,
+				'capability' => self::CAPABILITY,
+			),
 		);
 
 		// The Connectors page is handled by WP 7.0+ core or Gutenberg 22.8.0+.

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -889,7 +889,6 @@ class Database {
 			agent_id bigint(20) unsigned NOT NULL DEFAULT 0,
 			status varchar(30) NOT NULL DEFAULT 'queued',
 			summary varchar(500) NOT NULL DEFAULT '',
-			transcript longtext NOT NULL,
 			turn_count int(10) unsigned NOT NULL DEFAULT 0,
 			provider_id varchar(100) NOT NULL DEFAULT '',
 			model_id varchar(100) NOT NULL DEFAULT '',

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -23,6 +23,7 @@ namespace SdAiAgent\Core;
 
 use SdAiAgent\Knowledge\KnowledgeDatabase;
 use SdAiAgent\Models\Agent;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
 use SdAiAgent\Models\ConversationTemplate;
 use SdAiAgent\Models\ProviderTrace;
 use SdAiAgent\Models\Skill;
@@ -35,8 +36,9 @@ use SdAiAgent\Tools\CustomTools;
 
 class Database {
 
-	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.9.2';
+	const DB_VERSION_OPTION                         = 'sd_ai_agent_db_version';
+	const DB_VERSION                                = '19.10.0';
+	const CUSTOMER_CONVERSATION_REVIEW_CLEANUP_HOOK = 'sd_ai_agent_customer_conversation_review_cleanup';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -271,6 +273,24 @@ class Database {
 	}
 
 	/**
+	 * Get the privacy-safe customer conversation review projection table name.
+	 */
+	public static function customer_conversation_reviews_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_customer_conversation_reviews';
+	}
+
+	/**
+	 * Get the privacy-safe customer conversation review turns table name.
+	 */
+	public static function customer_conversation_review_turns_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_customer_conversation_review_turns';
+	}
+
+	/**
 	 * Get the skill usage table name.
 	 *
 	 * Tracks which skills are loaded per session/model and records
@@ -306,37 +326,40 @@ class Database {
 		$installed_version = get_option( self::DB_VERSION_OPTION );
 
 		if ( $installed_version === self::DB_VERSION ) {
+			self::ensure_customer_conversation_review_cleanup();
 			return;
 		}
 
-		$table                              = self::table_name();
-		$usage_table                        = self::usage_table_name();
-		$memories_table                     = self::memories_table_name();
-		$skills_table                       = self::skills_table_name();
-		$custom_tools_table                 = self::custom_tools_table_name();
-		$automations_table                  = self::automations_table_name();
-		$automation_logs_table              = self::automation_logs_table_name();
-		$approval_requests_table            = self::approval_requests_table_name();
-		$calendar_reminders_table           = self::calendar_reminders_table_name();
-		$event_automations_table            = self::event_automations_table_name();
-		$conversation_templates_table       = self::conversation_templates_table_name();
-		$git_tracked_files_table            = self::git_tracked_files_table_name();
-		$changes_log_table                  = self::changes_log_table_name();
-		$modified_files_table               = self::modified_files_table_name();
-		$agents_table                       = self::agents_table_name();
-		$shared_sessions_table              = self::shared_sessions_table_name();
-		$benchmark_runs_table               = self::benchmark_runs_table_name();
-		$benchmark_results_table            = self::benchmark_results_table_name();
-		$provider_trace_table               = self::provider_trace_table_name();
-		$generated_plugins_table            = self::generated_plugins_table_name();
-		$active_jobs_table                  = self::active_jobs_table_name();
-		$durable_plans_table                = self::durable_plans_table_name();
-		$durable_plan_steps_table           = self::durable_plan_steps_table_name();
-		$customer_agent_conversations_table = self::customer_agent_conversations_table_name();
-		$customer_agent_jobs_table          = self::customer_agent_jobs_table_name();
-		$skill_usage_table                  = self::skill_usage_table_name();
-		$contact_mappings_table             = self::contact_mappings_table_name();
-		$charset                            = $wpdb->get_charset_collate();
+		$table                                    = self::table_name();
+		$usage_table                              = self::usage_table_name();
+		$memories_table                           = self::memories_table_name();
+		$skills_table                             = self::skills_table_name();
+		$custom_tools_table                       = self::custom_tools_table_name();
+		$automations_table                        = self::automations_table_name();
+		$automation_logs_table                    = self::automation_logs_table_name();
+		$approval_requests_table                  = self::approval_requests_table_name();
+		$calendar_reminders_table                 = self::calendar_reminders_table_name();
+		$event_automations_table                  = self::event_automations_table_name();
+		$conversation_templates_table             = self::conversation_templates_table_name();
+		$git_tracked_files_table                  = self::git_tracked_files_table_name();
+		$changes_log_table                        = self::changes_log_table_name();
+		$modified_files_table                     = self::modified_files_table_name();
+		$agents_table                             = self::agents_table_name();
+		$shared_sessions_table                    = self::shared_sessions_table_name();
+		$benchmark_runs_table                     = self::benchmark_runs_table_name();
+		$benchmark_results_table                  = self::benchmark_results_table_name();
+		$provider_trace_table                     = self::provider_trace_table_name();
+		$generated_plugins_table                  = self::generated_plugins_table_name();
+		$active_jobs_table                        = self::active_jobs_table_name();
+		$durable_plans_table                      = self::durable_plans_table_name();
+		$durable_plan_steps_table                 = self::durable_plan_steps_table_name();
+		$customer_agent_conversations_table       = self::customer_agent_conversations_table_name();
+		$customer_agent_jobs_table                = self::customer_agent_jobs_table_name();
+		$customer_conversation_reviews_table      = self::customer_conversation_reviews_table_name();
+		$customer_conversation_review_turns_table = self::customer_conversation_review_turns_table_name();
+		$skill_usage_table                        = self::skill_usage_table_name();
+		$contact_mappings_table                   = self::contact_mappings_table_name();
+		$charset                                  = $wpdb->get_charset_collate();
 
 		// Knowledge tables.
 		$sql = KnowledgeDatabase::get_schema( $charset );
@@ -858,6 +881,54 @@ class Database {
 			KEY expires_at (expires_at)
 		) {$charset};
 
+		CREATE TABLE {$customer_conversation_reviews_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			review_id varchar(36) NOT NULL,
+			runtime_conversation_id varchar(36) NULL,
+			source varchar(32) NOT NULL,
+			agent_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			status varchar(30) NOT NULL DEFAULT 'queued',
+			summary varchar(500) NOT NULL DEFAULT '',
+			transcript longtext NOT NULL,
+			turn_count int(10) unsigned NOT NULL DEFAULT 0,
+			provider_id varchar(100) NOT NULL DEFAULT '',
+			model_id varchar(100) NOT NULL DEFAULT '',
+			iterations_used int(10) unsigned NOT NULL DEFAULT 0,
+			prompt_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			completion_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			handoff_intent varchar(50) NOT NULL DEFAULT '',
+			error_code varchar(100) NOT NULL DEFAULT '',
+			expires_at datetime NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			deleted_at datetime NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY review_id (review_id),
+			UNIQUE KEY runtime_conversation_id (runtime_conversation_id),
+			KEY source_status_updated (source, status, updated_at),
+			KEY agent_updated (agent_id, updated_at),
+			KEY expires_at (expires_at),
+			KEY review_visible_updated (deleted_at, updated_at),
+			KEY review_visible_source_status_updated (deleted_at, source, status, updated_at),
+			KEY review_visible_created (deleted_at, created_at),
+			FULLTEXT KEY review_summary (summary)
+		) {$charset};
+
+		CREATE TABLE {$customer_conversation_review_turns_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			review_id varchar(36) NOT NULL,
+			source_event_id varchar(64) NOT NULL,
+			role varchar(16) NOT NULL,
+			event_status varchar(30) NOT NULL DEFAULT 'queued',
+			content longtext NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY review_event_role (review_id, source_event_id, role),
+			KEY review_created (review_id, created_at, id),
+			KEY review_event_status (review_id, event_status, created_at, id)
+		) {$charset};
+
 		CREATE TABLE {$skill_usage_table} (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			skill_id bigint(20) unsigned NOT NULL,
@@ -894,6 +965,7 @@ class Database {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+		self::ensure_customer_conversation_review_summary_fulltext_index( $customer_conversation_reviews_table );
 
 		// This defence-in-depth index may be blocked by ambiguous historical
 		// duplicates. Fail soft so unrelated schema repairs, seeds, and the version
@@ -925,6 +997,37 @@ class Database {
 		Agent::seed_defaults();
 
 		update_option( self::DB_VERSION_OPTION, self::DB_VERSION, true );
+		self::ensure_customer_conversation_review_cleanup();
+	}
+
+	/** Schedule bounded cleanup and safe runtime backfill for review projections. */
+	private static function ensure_customer_conversation_review_cleanup(): void {
+		add_action( self::CUSTOMER_CONVERSATION_REVIEW_CLEANUP_HOOK, array( self::class, 'run_customer_conversation_review_cleanup' ) );
+
+		if ( ! wp_next_scheduled( self::CUSTOMER_CONVERSATION_REVIEW_CLEANUP_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', self::CUSTOMER_CONVERSATION_REVIEW_CLEANUP_HOOK );
+		}
+	}
+
+	/** Ensure the review-summary search index exists after dbDelta upgrades. */
+	private static function ensure_customer_conversation_review_summary_fulltext_index( string $table ): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Internal schema introspection for the fixed review projection table.
+		$index_exists = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'review_summary'" );
+		if ( null !== $index_exists ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Adds the required full-text index to the fixed review projection table.
+		$wpdb->query( "ALTER TABLE {$table} ADD FULLTEXT KEY review_summary (summary)" );
+	}
+
+	/** Run one bounded, retry-safe review retention and backfill pass. */
+	public static function run_customer_conversation_review_cleanup(): void {
+		CustomerConversationReviewRepository::purge_expired_reviews();
+		CustomerConversationReviewRepository::reconcile_runtime_reviews();
 	}
 
 	/**

--- a/includes/Core/DurablePlanTextSanitizer.php
+++ b/includes/Core/DurablePlanTextSanitizer.php
@@ -35,9 +35,9 @@ final class DurablePlanTextSanitizer {
 		// Preserve a consistently redacted JSON authorization field before the
 		// generic text rules process the remaining credential labels.
 		$value = (string) preg_replace( '/"authorization"\s*:\s*"(?:\\\\.|[^"\\\\])*"/i', '"authorization": "[redacted]"', $value );
-		$value = (string) preg_replace( '/\b(authorization)\b\s*[:=]\s*(?:bearer\s+)?[^\s,;}\]]+/i', '$1: [redacted]', $value );
+		$value = (string) preg_replace( '/\b(authorization)\b\s*[:=]\s*(?:bearer\s+)?(?:\[redacted\]|[^\s,;}\]]+)/i', '$1: [redacted]', $value );
 		$value = (string) preg_replace(
-			'/(?:"|\')?(api[_-]?key|apikey|access[_-]?token|client[_-]?secret|credential(?:s)?|private[_-]?key|password|secret|token)(?:"|\')?\s*[:=]\s*(?:"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|[^\s,;}\]]+)/i',
+			'/(?:"|\')?(api[_-]?key|apikey|access[_-]?token|client[_-]?secret|credential(?:s)?|private[_-]?key|password|secret|token)(?:"|\')?\s*[:=]\s*(?:"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|\[redacted\]|[^\s,;}\]]+)/i',
 			'$1: [redacted]',
 			$value
 		);

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -386,73 +386,79 @@ class Settings {
 	 */
 	public function get_defaults(): array {
 		return array(
-			'default_provider'                => '',
-			'default_model'                   => '',
-			'max_iterations'                  => 100,
-			'greeting_message'                => '',
-			'system_prompt'                   => '',
-			'auto_memory'                     => true,
-			'tool_permissions'                => array(),
-			'temperature'                     => 0.2,
+			'default_provider'                     => '',
+			'default_model'                        => '',
+			'max_iterations'                       => 100,
+			'greeting_message'                     => '',
+			'system_prompt'                        => '',
+			'auto_memory'                          => true,
+			'tool_permissions'                     => array(),
+			'temperature'                          => 0.2,
 			// 0 = auto-resolve per model via Settings::get_max_output_tokens_for_model().
 			// A user-saved positive value overrides the per-model default (clamped to
 			// MAX_OUTPUT_TOKENS_CEILING at request time). See AgentLoop::send_prompt().
-			'max_output_tokens'               => self::MAX_OUTPUT_TOKENS_AUTO,
-			'context_window_default'          => 128000,
-			'onboarding_complete'             => false,
-			'knowledge_enabled'               => true,
-			'knowledge_auto_index'            => true,
-			'max_history_turns'               => 20,
+			'max_output_tokens'                    => self::MAX_OUTPUT_TOKENS_AUTO,
+			'context_window_default'               => 128000,
+			'onboarding_complete'                  => false,
+			'knowledge_enabled'                    => true,
+			'knowledge_auto_index'                 => true,
+			'max_history_turns'                    => 20,
 			// Local input guards. The byte limit is enforced against the final
 			// serialized HTTP body; the token limit bounds retained conversation
 			// history before the provider builder runs.
-			'provider_request_max_bytes'      => ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES,
-			'provider_request_max_tokens'     => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
-			'suggestion_count'                => 3,
-			'yolo_mode'                       => false,
-			'show_tool_call_details'          => false,
-			'show_on_frontend'                => true,
-			'public_chat_embed_id'            => 'docs',
-			'keyboard_shortcut'               => 'alt+a',
+			'provider_request_max_bytes'           => ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES,
+			'provider_request_max_tokens'          => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
+			'suggestion_count'                     => 3,
+			'yolo_mode'                            => false,
+			'show_tool_call_details'               => false,
+			'show_on_frontend'                     => true,
+			'public_chat_embed_id'                 => 'docs',
+			'keyboard_shortcut'                    => 'alt+a',
 			// Public docs/customer chat is opt-in and uses a server-controlled,
 			// anonymous-safe execution profile. Browser requests cannot override
 			// provider/model/agent/tool choices in this mode.
-			'public_chat_enabled'             => false,
-			'public_chat_allowed_origins'     => array(),
-			'public_chat_provider_id'         => '',
-			'public_chat_model_id'            => '',
-			'public_chat_agent_id'            => 0,
-			'public_chat_collection_ids'      => array(),
-			'public_chat_allowed_abilities'   => array( 'sd-ai-agent/knowledge-search' ),
-			'public_chat_max_iterations'      => 4,
-			'public_chat_message_max_length'  => 2000,
-			'public_chat_rate_limit_per_min'  => 10,
-			'image_generation_size'           => '1024x1024',
-			'image_generation_quality'        => 'standard',
-			'image_generation_style'          => 'vivid',
+			'public_chat_enabled'                  => false,
+			'public_chat_allowed_origins'          => array(),
+			'public_chat_provider_id'              => '',
+			'public_chat_model_id'                 => '',
+			'public_chat_agent_id'                 => 0,
+			'public_chat_collection_ids'           => array(),
+			'public_chat_allowed_abilities'        => array( 'sd-ai-agent/knowledge-search' ),
+			'public_chat_max_iterations'           => 4,
+			'public_chat_message_max_length'       => 2000,
+			'public_chat_rate_limit_per_min'       => 10,
+			// Anonymous transcript review is a separate, explicit collection choice.
+			// It is disabled by default so existing public embeds never start retaining
+			// visitor content merely because this plugin is upgraded.
+			'public_chat_review_recording_enabled' => false,
+			'public_chat_review_retention_days'    => 7,
+			'public_chat_review_disclosure'        => '',
+			'image_generation_size'                => '1024x1024',
+			'image_generation_quality'             => 'standard',
+			'image_generation_style'               => 'vivid',
 			// White-label / branding settings (t075).
-			'agent_name'                      => '',
-			'brand_primary_color'             => '',
-			'brand_text_color'                => '',
-			'brand_logo_url'                  => '',
+			'agent_name'                           => '',
+			'brand_primary_color'                  => '',
+			'brand_text_color'                     => '',
+			'brand_logo_url'                       => '',
 			// Spending limits / budget caps (t110).
-			'budget_daily_cap'                => 0.0,
-			'budget_monthly_cap'              => 0.0,
-			'budget_warning_threshold'        => 80,
-			'budget_exceeded_action'          => 'pause',
+			'budget_daily_cap'                     => 0.0,
+			'budget_monthly_cap'                   => 0.0,
+			'budget_warning_threshold'             => 80,
+			'budget_exceeded_action'               => 'pause',
 			// Provider trace / debug mode (GH#830).
-			'provider_trace_enabled'          => false,
-			'provider_trace_max_rows'         => 200,
+			'provider_trace_enabled'               => false,
+			'provider_trace_max_rows'              => 200,
 			// Prompt caching — provider-side KV-cache opt-in (sd-ai-bjv).
 			// When true, the HttpTraceHandler injects provider-specific
 			// cache markers into outgoing LLM requests (only Anthropic
 			// requires explicit markers today; OpenAI/DeepSeek/etc. cache
 			// automatically). Safe to leave on — workers without cache
 			// support ignore the markers.
-			'prompt_caching_enabled'          => true,
+			'prompt_caching_enabled'               => true,
 			// Skill auto-update settings (t218).
-			'skill_auto_update'               => true,
-			'skill_manifest_url'              => '',
+			'skill_auto_update'                    => true,
+			'skill_manifest_url'                   => '',
 			// Third-party ability visibility mode (sd-ai-3ns / #1405, sd-ai-u21 / #1407).
 			// Controls which abilities are exposed to AI surfaces by AbilityVisibility.
 			// 'legacy'  — opt-out behaviour: everything except ai_hidden is public.
@@ -461,13 +467,13 @@ class Settings {
 			// 'auto'    — full tiered-trust model: namespace allowlist + heuristics.
 			// Default since 1.12.0.
 			// 'strict'  — only meta.mcp.public === true passes. Future use.
-			'third_party_mode'                => 'auto',
+			'third_party_mode'                     => 'auto',
 
 			// Third-party namespace visibility decisions (sd-ai-0zq / #1406).
 			// Maps namespace slugs to visibility decisions: 'allow', 'block', or 'pending'.
 			// Used by ThirdPartyAbilityNoticeHandler to override the heuristic for
 			// unclassified abilities. Format: { 'namespace-slug': 'allow|block|pending' }
-			'third_party_namespace_decisions' => array(),
+			'third_party_namespace_decisions'      => array(),
 		);
 	}
 
@@ -1203,6 +1209,18 @@ class Settings {
 		// Only allow known keys.
 		$allowed = array_keys( $defaults );
 		$data    = array_intersect_key( $data, array_flip( $allowed ) );
+
+		if ( array_key_exists( 'public_chat_review_recording_enabled', $data ) ) {
+			$value                                        = $data['public_chat_review_recording_enabled'];
+			$data['public_chat_review_recording_enabled'] = true === $value || 1 === $value || '1' === $value || 'true' === $value;
+		}
+		if ( array_key_exists( 'public_chat_review_retention_days', $data ) ) {
+			$data['public_chat_review_retention_days'] = max( 1, min( 90, (int) $data['public_chat_review_retention_days'] ) );
+		}
+		if ( array_key_exists( 'public_chat_review_disclosure', $data ) ) {
+			$disclosure                            = sanitize_textarea_field( (string) $data['public_chat_review_disclosure'] );
+			$data['public_chat_review_disclosure'] = function_exists( 'mb_substr' ) ? mb_substr( $disclosure, 0, 500 ) : substr( $disclosure, 0, 500 );
+		}
 
 		// @phpstan-ignore-next-line
 		$merged = array_merge( $current, $data );

--- a/includes/Models/CustomerAgentRuntimeRepository.php
+++ b/includes/Models/CustomerAgentRuntimeRepository.php
@@ -158,6 +158,31 @@ class CustomerAgentRuntimeRepository {
 	}
 
 	/**
+	 * Return the most recently updated job for one private runtime conversation.
+	 *
+	 * The review projection uses this server-side metadata only during bounded
+	 * migration; it never returns the source job or its private payloads.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function get_latest_job_for_conversation( string $conversation_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded server-side migration metadata lookup for one opaque runtime conversation.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT job_id, conversation_id, status, provider_id, model_id, iterations_used, prompt_tokens, completion_tokens, error_code, expires_at, created_at, updated_at FROM %i WHERE conversation_id = %s ORDER BY updated_at DESC, id DESC LIMIT 1',
+				self::jobs_table_name(),
+				$conversation_id
+			),
+			ARRAY_A
+		);
+
+		return self::normalise_row( $row );
+	}
+
+	/**
 	 * Find a job through the idempotency tuple.
 	 *
 	 * @return array<string,mixed>|null
@@ -316,6 +341,16 @@ class CustomerAgentRuntimeRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
+		// The source rows and their review projection must disappear together so a
+		// failed review delete can never leave customer content reviewable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Coordinates a source-scoped privacy deletion across related plugin tables.
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return array(
+				'deleted' => false,
+				'job_ids' => array(),
+			);
+		}
+
 		$raw_ids = $wpdb->get_col(
 			$wpdb->prepare(
 				'SELECT job_id FROM %i WHERE conversation_id = %s',
@@ -323,6 +358,14 @@ class CustomerAgentRuntimeRepository {
 				$conversation_id
 			)
 		);
+		if ( ! is_array( $raw_ids ) || '' !== $wpdb->last_error ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a purge whose source-job lookup failed.
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'deleted' => false,
+				'job_ids' => array(),
+			);
+		}
 		$job_ids = array();
 		foreach ( $raw_ids as $raw_id ) {
 			if ( is_string( $raw_id ) && '' !== $raw_id ) {
@@ -330,13 +373,31 @@ class CustomerAgentRuntimeRepository {
 			}
 		}
 
+		// A runtime close must also remove its separate display-safe review
+		// projection. This never exposes the private runtime row to reviewers.
+		if ( ! CustomerConversationReviewRepository::delete_by_runtime_conversation( $conversation_id ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts source deletion when the review projection cannot be deleted.
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'deleted' => false,
+				'job_ids' => array(),
+			);
+		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purging a private runtime record requires an atomic direct delete.
-		$wpdb->delete( self::jobs_table_name(), array( 'conversation_id' => $conversation_id ), array( '%s' ) );
+		$jobs_deleted = $wpdb->delete( self::jobs_table_name(), array( 'conversation_id' => $conversation_id ), array( '%s' ) );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purging a private runtime record requires an atomic direct delete.
 		$deleted = $wpdb->delete( self::conversations_table_name(), array( 'conversation_id' => $conversation_id ), array( '%s' ) );
+		if ( false === $jobs_deleted || false === $deleted || false === $wpdb->query( 'COMMIT' ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a failed source-scoped runtime purge.
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'deleted' => false,
+				'job_ids' => array(),
+			);
+		}
 
 		return array(
-			'deleted' => false !== $deleted,
+			'deleted' => true,
 			'job_ids' => $job_ids,
 		);
 	}
@@ -370,7 +431,7 @@ class CustomerAgentRuntimeRepository {
 				$integration_hash
 			)
 		);
-		if ( '' !== $wpdb->last_error ) {
+		if ( self::last_database_query_failed() ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a purge whose job ownership read failed.
 			$wpdb->query( 'ROLLBACK' );
 			return array(
@@ -385,6 +446,28 @@ class CustomerAgentRuntimeRepository {
 				$job_ids[] = $raw_id;
 			}
 		}
+		$raw_conversation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT conversation_id FROM %i WHERE integration_hash = %s',
+				self::conversations_table_name(),
+				$integration_hash
+			)
+		);
+		if ( self::last_database_query_failed() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a purge whose conversation ownership read failed.
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'purged'        => false,
+				'conversations' => 0,
+				'job_ids'       => array(),
+			);
+		}
+		$conversation_ids = array();
+		foreach ( $raw_conversation_ids as $raw_conversation_id ) {
+			if ( is_string( $raw_conversation_id ) && '' !== $raw_conversation_id ) {
+				$conversation_ids[] = $raw_conversation_id;
+			}
+		}
 
 		$conversation_count = $wpdb->get_var(
 			$wpdb->prepare(
@@ -395,6 +478,15 @@ class CustomerAgentRuntimeRepository {
 		);
 		if ( null === $conversation_count ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a purge whose conversation ownership read failed.
+			$wpdb->query( 'ROLLBACK' );
+			return array(
+				'purged'        => false,
+				'conversations' => 0,
+				'job_ids'       => array(),
+			);
+		}
+		if ( ! CustomerConversationReviewRepository::delete_by_runtime_conversations( $conversation_ids ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts a purge whose review projection deletion failed.
 			$wpdb->query( 'ROLLBACK' );
 			return array(
 				'purged'        => false,
@@ -421,6 +513,18 @@ class CustomerAgentRuntimeRepository {
 			'conversations' => (int) $conversation_count,
 			'job_ids'       => $job_ids,
 		);
+	}
+
+	/**
+	 * Return whether the latest wpdb request failed.
+	 *
+	 * @phpstan-impure Reads mutable wpdb query state.
+	 */
+	private static function last_database_query_failed(): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		return '' !== $wpdb->last_error;
 	}
 
 	/**

--- a/includes/Models/CustomerConversationReviewRepository.php
+++ b/includes/Models/CustomerConversationReviewRepository.php
@@ -366,22 +366,13 @@ final class CustomerConversationReviewRepository {
 		if ( ! is_array( $review_ids ) ) {
 			return false;
 		}
-		if ( ! self::delete_turns_by_review_ids( $review_ids ) ) {
-			return false;
+		foreach ( $review_ids as $review_id ) {
+			if ( ! is_string( $review_id ) || '' === $review_id || ! self::delete_review_shell( $review_id ) ) {
+				return false;
+			}
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The fixed number of placeholders is generated only from a filtered list of opaque IDs.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Removes review shells only after their source runtime conversations are permanently purged.
-		$result = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM %i WHERE runtime_conversation_id IN ({$placeholders})",
-				self::table_name(),
-				...$ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-
-		return false !== $result;
+		return true;
 	}
 
 	/**
@@ -430,7 +421,6 @@ final class CustomerConversationReviewRepository {
 			'agent_id'                => max( 0, $agent_id ),
 			'status'                  => self::sanitize_status( $status ),
 			'summary'                 => '',
-			'transcript'              => '[]',
 			'turn_count'              => 0,
 			'provider_id'             => self::sanitize_metadata_string( $provider_id, 100 ),
 			'model_id'                => self::sanitize_metadata_string( $model_id, 100 ),
@@ -446,7 +436,7 @@ final class CustomerConversationReviewRepository {
 		$result = $wpdb->insert(
 			self::table_name(),
 			$data,
-			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s' )
 		);
 		if ( false !== $result ) {
 			return true;
@@ -473,28 +463,32 @@ final class CustomerConversationReviewRepository {
 			return false;
 		}
 
-		$content = self::sanitize_turn_text( $content );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A row lock makes delete/completion races deterministic for the minimized review projection.
-		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+		$content     = self::sanitize_turn_text( $content );
+		$transaction = self::begin_transaction();
+		if ( false === $transaction ) {
 			return false;
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one opaque review shell before appending a safe turn.
 		$review = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT review_id, deleted_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
+				'SELECT review_id, deleted_at, expires_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
 				self::table_name(),
 				$review_id
 			),
 			ARRAY_A
 		);
 		if ( ! is_array( $review ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 		if ( ! empty( $review['deleted_at'] ) ) {
-			self::finish_transaction( true );
+			self::finish_transaction( $transaction, true );
 			return true;
+		}
+		if ( (string) ( $review['expires_at'] ?? '' ) < current_time( 'mysql', true ) ) {
+			self::finish_transaction( $transaction, true );
+			return false;
 		}
 
 		$now              = current_time( 'mysql', true );
@@ -517,7 +511,7 @@ final class CustomerConversationReviewRepository {
 			);
 			if ( false === $inserted ) {
 				if ( ! self::turn_exists( $review_id, $source_event_id, $role ) ) {
-					self::finish_transaction( false );
+					self::finish_transaction( $transaction, false );
 					return false;
 				}
 				$inserted = 0;
@@ -525,15 +519,15 @@ final class CustomerConversationReviewRepository {
 		}
 
 		if ( ! self::update_locked_event_status( $review_id, $source_event_id, $status, $now ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 		if ( ! self::update_locked_review( $review_id, $source_event_id, $status, $metadata, $now, (int) $inserted > 0 && 'assistant' === $role ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 
-		return self::finish_transaction( true );
+		return self::finish_transaction( $transaction, true );
 	}
 
 	/**
@@ -553,39 +547,43 @@ final class CustomerConversationReviewRepository {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A row lock prevents a terminal update from recreating an admin-deleted review.
-		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+		$transaction = self::begin_transaction();
+		if ( false === $transaction ) {
 			return false;
 		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one minimized review shell before status-only update.
 		$review = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT review_id, deleted_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
+				'SELECT review_id, deleted_at, expires_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
 				self::table_name(),
 				$review_id
 			),
 			ARRAY_A
 		);
 		if ( ! is_array( $review ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 		if ( ! empty( $review['deleted_at'] ) ) {
-			self::finish_transaction( true );
+			self::finish_transaction( $transaction, true );
 			return true;
+		}
+		if ( (string) ( $review['expires_at'] ?? '' ) < current_time( 'mysql', true ) ) {
+			self::finish_transaction( $transaction, true );
+			return false;
 		}
 
 		$now = current_time( 'mysql', true );
 		if ( ! self::update_locked_event_status( $review_id, $source_event_id, $status, $now ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 		if ( ! self::update_locked_review( $review_id, $source_event_id, $status, $metadata, $now, false ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 
-		return self::finish_transaction( true );
+		return self::finish_transaction( $transaction, true );
 	}
 
 	/** Update every safe turn for a source event to its latest known safe state. */
@@ -791,8 +789,8 @@ final class CustomerConversationReviewRepository {
 		if ( '' === $status ) {
 			return false;
 		}
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Review-row lock ensures deletion wins concurrent completion attempts.
-		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+		$transaction = self::begin_transaction();
+		if ( false === $transaction ) {
 			return false;
 		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one opaque review before clearing safe retained content.
@@ -801,17 +799,17 @@ final class CustomerConversationReviewRepository {
 			ARRAY_A
 		);
 		if ( ! is_array( $review ) ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 		if ( ! empty( $review['deleted_at'] ) ) {
-			return self::finish_transaction( true );
+			return self::finish_transaction( $transaction, true );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Physically removes sanitized turn content while preserving the review-shell tombstone.
 		$turns_deleted = $wpdb->delete( self::turns_table_name(), array( 'review_id' => $review_id ), array( '%s' ) );
 		if ( false === $turns_deleted ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 
@@ -821,7 +819,6 @@ final class CustomerConversationReviewRepository {
 			array(
 				'status'            => $status,
 				'summary'           => '',
-				'transcript'        => '[]',
 				'turn_count'        => 0,
 				'provider_id'       => '',
 				'model_id'          => '',
@@ -834,15 +831,15 @@ final class CustomerConversationReviewRepository {
 				'updated_at'        => $now,
 			),
 			array( 'review_id' => $review_id ),
-			array( '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s' ),
+			array( '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s' ),
 			array( '%s' )
 		);
 		if ( false === $update ) {
-			self::finish_transaction( false );
+			self::finish_transaction( $transaction, false );
 			return false;
 		}
 
-		return self::finish_transaction( true );
+		return self::finish_transaction( $transaction, true );
 	}
 
 	/**
@@ -909,41 +906,72 @@ final class CustomerConversationReviewRepository {
 		);
 	}
 
-	/**
-	 * Permanently remove the safe turns belonging to known review shells.
-	 *
-	 * @phpstan-param array<int|string,mixed> $review_ids
-	 */
-	private static function delete_turns_by_review_ids( array $review_ids ): bool {
+	/** Permanently remove one review shell and its turns under the append/delete lock. */
+	private static function delete_review_shell( string $review_id ): bool {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$ids = array_values( array_filter( $review_ids, static fn( mixed $id ): bool => is_string( $id ) && '' !== $id ) );
-		if ( empty( $ids ) ) {
-			return true;
+		$transaction = self::begin_transaction();
+		if ( false === $transaction ) {
+			return false;
 		}
-		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%s' ) );
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The fixed number of placeholders is generated only from a filtered list of opaque IDs.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permanently removes minimized turn content during underlying runtime purge.
-		$result = $wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM %i WHERE review_id IN ({$placeholders})",
-				self::turns_table_name(),
-				...$ids
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-		return false !== $result;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Uses the same parent-row lock as append and tombstone operations.
+		$locked = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT review_id FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE', self::table_name(), $review_id )
+		);
+		if ( ! is_string( $locked ) ) {
+			return self::finish_transaction( $transaction, true );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Removes minimized turns while their parent shell is locked.
+		$turns_deleted = $wpdb->delete( self::turns_table_name(), array( 'review_id' => $review_id ), array( '%s' ) );
+		if ( false === $turns_deleted ) {
+			self::finish_transaction( $transaction, false );
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Removes the locked review shell after all retained content is gone.
+		$review_deleted = $wpdb->delete( self::table_name(), array( 'review_id' => $review_id ), array( '%s' ) );
+		if ( false === $review_deleted ) {
+			self::finish_transaction( $transaction, false );
+			return false;
+		}
+
+		return self::finish_transaction( $transaction, true );
 	}
 
-	/** Commit or roll back the current local projection transaction. */
-	private static function finish_transaction( bool $commit ): bool {
+	/** Begin a local transaction without committing a caller-owned transaction. */
+	private static function begin_transaction(): string|false {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Ends a narrowly scoped projection write transaction.
-		$result = $wpdb->query( $commit ? 'COMMIT' : 'ROLLBACK' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects a caller-owned transaction, including the WordPress PHPUnit isolation transaction.
+		$in_transaction = (int) $wpdb->get_var( 'SELECT @@in_transaction' );
+		if ( 1 === $in_transaction ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A savepoint preserves the caller's transaction boundary.
+			return false === $wpdb->query( 'SAVEPOINT sd_ai_agent_review_projection' ) ? false : 'savepoint';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Starts a narrowly scoped projection write transaction.
+		return false === $wpdb->query( 'START TRANSACTION' ) ? false : 'transaction';
+	}
+
+	/** Commit or roll back a local transaction or savepoint. */
+	private static function finish_transaction( string $transaction, bool $commit ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		if ( 'savepoint' === $transaction ) {
+			$sql = $commit
+				? 'RELEASE SAVEPOINT sd_ai_agent_review_projection'
+				: 'ROLLBACK TO SAVEPOINT sd_ai_agent_review_projection';
+		} else {
+			$sql = $commit ? 'COMMIT' : 'ROLLBACK';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Ends only the transaction boundary opened by begin_transaction().
+		$result = $wpdb->query( $sql );
 
 		return false !== $result;
 	}

--- a/includes/Models/CustomerConversationReviewRepository.php
+++ b/includes/Models/CustomerConversationReviewRepository.php
@@ -1,0 +1,1206 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Privacy-safe read model for customer-facing conversation review.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Models;
+
+use SdAiAgent\Core\ConversationDisplaySanitizer;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\DurablePlanTextSanitizer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stores a minimized, administrator-only projection of customer conversations.
+ *
+ * Runtime request payloads, profile snapshots, external identifiers, job tokens,
+ * and public session tokens never enter this read model. Each safe turn is stored
+ * independently so retries can be idempotent and deletion can win concurrent
+ * completion writes without recreating retained content.
+ */
+final class CustomerConversationReviewRepository {
+
+	public const SOURCE_PUBLIC_EMBED     = 'public_embed';
+	public const SOURCE_CUSTOMER_RUNTIME = 'customer_runtime';
+	public const REDACTED_PLACEHOLDER    = DurablePlanTextSanitizer::REDACTED_PLACEHOLDER;
+
+	private const MAX_DETAIL_TURNS     = 100;
+	private const MAX_RECONCILED_TURNS = 100;
+	private const MAX_TURN_LENGTH      = 12000;
+	private const MAX_SUMMARY          = 500;
+	private const MAX_PAGE_SIZE        = 50;
+
+	/** Return the customer conversation review projection table name. */
+	public static function table_name(): string {
+		return Database::customer_conversation_reviews_table_name();
+	}
+
+	/** Return the normalized customer conversation review turns table name. */
+	public static function turns_table_name(): string {
+		return Database::customer_conversation_review_turns_table_name();
+	}
+
+	/**
+	 * Create an anonymous public-embed review shell after visitor consent.
+	 *
+	 * The review identifier is stored only in the signed-session transient. It is
+	 * never added to the public token or REST response.
+	 */
+	public static function create_public_review( string $review_id, int $agent_id, string $provider_id, string $model_id, string $expires_at ): bool {
+		return self::create_review(
+			$review_id,
+			null,
+			self::SOURCE_PUBLIC_EMBED,
+			$agent_id,
+			'queued',
+			$provider_id,
+			$model_id,
+			$expires_at
+		);
+	}
+
+	/**
+	 * Create an isolated runtime review shell without copying a private runtime row.
+	 */
+	public static function create_runtime_review( string $review_id, string $runtime_conversation_id, string $provider_id, string $model_id, string $expires_at, int $agent_id = 0 ): bool {
+		return self::create_review(
+			$review_id,
+			$runtime_conversation_id,
+			self::SOURCE_CUSTOMER_RUNTIME,
+			$agent_id,
+			'queued',
+			$provider_id,
+			$model_id,
+			$expires_at
+		);
+	}
+
+	/**
+	 * Append one public-embed turn using a unique job/event identifier.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	public static function append_public_turn( string $review_id, string $source_event_id, string $role, string $content, string $status, array $metadata = array() ): bool {
+		return self::append_turn( $review_id, $source_event_id, $role, $content, $status, $metadata );
+	}
+
+	/**
+	 * Append one runtime turn by its server-only conversation identifier.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	public static function append_runtime_turn( string $runtime_conversation_id, string $source_event_id, string $role, string $content, string $status, array $metadata = array() ): bool {
+		$review_id = self::get_runtime_review_id( $runtime_conversation_id );
+		if ( null === $review_id ) {
+			return false;
+		}
+
+		return self::append_turn( $review_id, $source_event_id, $role, $content, $status, $metadata );
+	}
+
+	/**
+	 * Update a public review event's terminal state without writing response text.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	public static function update_public_review_status( string $review_id, string $source_event_id, string $status, array $metadata = array() ): bool {
+		return self::update_event_status( $review_id, $source_event_id, $status, $metadata );
+	}
+
+	/**
+	 * Update a runtime review event's terminal state without writing raw errors.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	public static function update_runtime_review_status( string $runtime_conversation_id, string $source_event_id, string $status, array $metadata = array() ): bool {
+		$review_id = self::get_runtime_review_id( $runtime_conversation_id );
+		if ( null === $review_id ) {
+			return false;
+		}
+
+		return self::update_event_status( $review_id, $source_event_id, $status, $metadata );
+	}
+
+	/**
+	 * Return one safe review detail DTO or null when it is missing, expired, or deleted.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function get_review( string $review_id, int $turn_limit = self::MAX_DETAIL_TURNS, int $turn_offset = 0 ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$turn_limit  = min( self::MAX_DETAIL_TURNS, max( 1, $turn_limit ) );
+		$turn_offset = min( 10000, max( 0, $turn_offset ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads one minimized internal review projection by opaque public identifier.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT review_id, source, agent_id, status, summary, turn_count, provider_id, model_id, iterations_used, prompt_tokens, completion_tokens, handoff_intent, error_code, expires_at, created_at, updated_at FROM %i WHERE review_id = %s AND deleted_at IS NULL AND expires_at >= %s LIMIT 1',
+				self::table_name(),
+				$review_id,
+				current_time( 'mysql', true )
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Detail loads one bounded page of already-sanitized turns, newest first before restoring transcript order.
+		$turns = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT role, content FROM ( SELECT role, content, created_at, id FROM %i WHERE review_id = %s ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d ) AS recent_turns ORDER BY created_at ASC, id ASC',
+				self::turns_table_name(),
+				$review_id,
+				$turn_limit,
+				$turn_offset
+			),
+			ARRAY_A
+		);
+
+		$row['transcript']             = self::normalise_turn_rows( is_array( $turns ) ? $turns : array() );
+		$detail                        = self::normalise_detail( $row );
+		$detail['transcript_offset']   = $turn_offset;
+		$detail['transcript_limit']    = $turn_limit;
+		$detail['transcript_has_more'] = (int) $detail['turn_count'] > $turn_offset + count( $detail['transcript'] );
+
+		return $detail;
+	}
+
+	/**
+	 * List safe summaries without loading transcript bodies.
+	 *
+	 * @param array<string,mixed> $filters List filters supplied by an admin route.
+	 * @return list<array<string,mixed>>
+	 */
+	public static function list_reviews( array $filters ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		list( $where, $args ) = self::build_filter_query( $filters );
+		$limit                = min( self::MAX_PAGE_SIZE, max( 1, (int) ( $filters['limit'] ?? 20 ) ) );
+		$offset               = max( 0, min( 10000, (int) ( $filters['offset'] ?? 0 ) ) );
+		$sql                  = 'SELECT review_id, source, agent_id, status, summary, turn_count, provider_id, model_id, iterations_used, prompt_tokens, completion_tokens, handoff_intent, error_code, expires_at, created_at, updated_at FROM %i WHERE ' . $where . ' ORDER BY updated_at DESC, id DESC LIMIT %d OFFSET %d';
+		$query_args           = array_merge( array( self::table_name() ), $args, array( $limit, $offset ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Paged read intentionally excludes transcripts and private source identifiers.
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$query_args ), ARRAY_A );
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_map(
+				static fn( array $row ): array => self::normalise_summary( $row ),
+				$rows
+			)
+		);
+	}
+
+	/**
+	 * Count review summaries for the same bounded filter set used by list_reviews().
+	 *
+	 * @param array<string,mixed> $filters List filters supplied by an admin route.
+	 */
+	public static function count_reviews( array $filters ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		list( $where, $args ) = self::build_filter_query( $filters );
+		$sql                  = 'SELECT COUNT(*) FROM %i WHERE ' . $where;
+		$query_args           = array_merge( array( self::table_name() ), $args );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Bounded admin pagination count over the minimized review table.
+		return max( 0, (int) $wpdb->get_var( $wpdb->prepare( $sql, ...$query_args ) ) );
+	}
+
+	/**
+	 * Delete visible customer content while preserving the review source tombstone.
+	 *
+	 * Repeating deletion for an existing tombstone is intentionally idempotent.
+	 */
+	public static function delete_review( string $review_id ): bool {
+		return self::tombstone_review( $review_id, 'deleted' );
+	}
+
+	/** Remove up to a bounded number of retained reviews after explicit admin confirmation. */
+	public static function purge_reviews( int $limit = 500 ): int {
+		return self::purge_matching_reviews( 'deleted_at IS NULL', array(), $limit, 'deleted' );
+	}
+
+	/** Purge expired reviews through a bounded, retry-safe tombstone update. */
+	public static function purge_expired_reviews( int $limit = 100 ): int {
+		return self::purge_matching_reviews( 'deleted_at IS NULL AND expires_at < %s', array( current_time( 'mysql', true ) ), $limit, 'expired' );
+	}
+
+	/**
+	 * Backfill a bounded set of existing runtime conversations into the safe projection.
+	 *
+	 * This reads runtime history only long enough to create the sanitized projection;
+	 * it neither exposes nor rewrites the private runtime payloads.
+	 */
+	public static function reconcile_runtime_reviews( int $limit = 50 ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$limit = max( 1, min( self::MAX_PAGE_SIZE, $limit ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded migration read from private runtime data into a separate sanitized projection.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT runtime.conversation_id, runtime.runtime_history, runtime.expires_at FROM %i AS runtime LEFT JOIN %i AS review ON review.runtime_conversation_id = runtime.conversation_id WHERE review.runtime_conversation_id IS NULL AND runtime.expires_at >= %s ORDER BY runtime.updated_at DESC LIMIT %d',
+				CustomerAgentRuntimeRepository::conversations_table_name(),
+				self::table_name(),
+				current_time( 'mysql', true ),
+				$limit
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $rows ) ) {
+			return 0;
+		}
+
+		$created = 0;
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$conversation_id = (string) ( $row['conversation_id'] ?? '' );
+			if ( '' === $conversation_id ) {
+				continue;
+			}
+
+			$latest_job = CustomerAgentRuntimeRepository::get_latest_job_for_conversation( $conversation_id );
+			$metadata   = is_array( $latest_job )
+				? array(
+					'provider_id'             => (string) ( $latest_job['provider_id'] ?? '' ),
+					'model_id'                => (string) ( $latest_job['model_id'] ?? '' ),
+					'iterations_used'         => (int) ( $latest_job['iterations_used'] ?? 0 ),
+					'prompt_tokens_total'     => (int) ( $latest_job['prompt_tokens'] ?? 0 ),
+					'completion_tokens_total' => (int) ( $latest_job['completion_tokens'] ?? 0 ),
+					'error_code'              => (string) ( $latest_job['error_code'] ?? '' ),
+				)
+				: array();
+			$status     = self::sanitize_status( $latest_job['status'] ?? '' );
+			$status     = '' !== $status ? $status : 'complete';
+
+			if ( ! self::create_runtime_review(
+				wp_generate_uuid4(),
+				$conversation_id,
+				(string) ( $metadata['provider_id'] ?? '' ),
+				(string) ( $metadata['model_id'] ?? '' ),
+				(string) ( $row['expires_at'] ?? current_time( 'mysql', true ) )
+			) ) {
+				continue;
+			}
+
+			$history = json_decode( (string) ( $row['runtime_history'] ?? '[]' ), true );
+			$turns   = self::sanitize_transcript( is_array( $history ) ? $history : array() );
+			foreach ( $turns as $index => $turn ) {
+				self::append_runtime_turn(
+					$conversation_id,
+					hash( 'sha256', $conversation_id . '|' . $index ),
+					$turn['role'],
+					$turn['content'],
+					$status
+				);
+			}
+			$last_event_id = empty( $turns )
+				? hash( 'sha256', $conversation_id . '|status' )
+				: hash( 'sha256', $conversation_id . '|' . ( count( $turns ) - 1 ) );
+			self::update_runtime_review_status( $conversation_id, $last_event_id, $status, $metadata );
+			++$created;
+		}
+
+		return $created;
+	}
+
+	/** Remove review projections when a runtime conversation is destroyed. */
+	public static function delete_by_runtime_conversation( string $runtime_conversation_id ): bool {
+		return self::delete_by_runtime_conversations( array( $runtime_conversation_id ) );
+	}
+
+	/**
+	 * Remove projections for a known set of runtime conversations.
+	 *
+	 * Runtime conversation IDs remain server-only and never enter a review DTO.
+
+	 * @phpstan-param list<string> $runtime_conversation_ids
+	 */
+	public static function delete_by_runtime_conversations( array $runtime_conversation_ids ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$ids = array_values( array_filter( $runtime_conversation_ids, static fn( mixed $id ): bool => is_string( $id ) && '' !== $id ) );
+		if ( empty( $ids ) ) {
+			return true;
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%s' ) );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The fixed number of placeholders is generated only from a filtered list of opaque IDs.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Removes minimized turns only as part of the underlying runtime integration purge.
+		$review_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT review_id FROM %i WHERE runtime_conversation_id IN ({$placeholders})",
+				self::table_name(),
+				...$ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		if ( ! is_array( $review_ids ) ) {
+			return false;
+		}
+		if ( ! self::delete_turns_by_review_ids( $review_ids ) ) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The fixed number of placeholders is generated only from a filtered list of opaque IDs.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Removes review shells only after their source runtime conversations are permanently purged.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i WHERE runtime_conversation_id IN ({$placeholders})",
+				self::table_name(),
+				...$ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return false !== $result;
+	}
+
+	/**
+	 * Reduce arbitrary serialized messages to a compact, text-only review transcript.
+	 *
+	 * @param array<mixed> $messages Potentially provider-shaped messages.
+	 * @return list<array{role:string,content:string}>
+	 */
+	public static function sanitize_transcript( array $messages ): array {
+		$transcript = array();
+
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+			$role = self::normalise_role( $message['role'] ?? '' );
+			if ( null === $role ) {
+				continue;
+			}
+			$text = self::extract_display_text( $message );
+			if ( '' === $text ) {
+				continue;
+			}
+
+			$transcript[] = array(
+				'role'    => $role,
+				'content' => $text,
+			);
+		}
+
+		return array_slice( $transcript, -self::MAX_RECONCILED_TURNS );
+	}
+
+	/**
+	 * Insert a source-bound review shell without clearing an existing tombstone.
+	 */
+	private static function create_review( string $review_id, ?string $runtime_conversation_id, string $source, int $agent_id, string $status, string $provider_id, string $model_id, string $expires_at ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now    = current_time( 'mysql', true );
+		$data   = array(
+			'review_id'               => $review_id,
+			'runtime_conversation_id' => $runtime_conversation_id,
+			'source'                  => self::sanitize_source( $source ),
+			'agent_id'                => max( 0, $agent_id ),
+			'status'                  => self::sanitize_status( $status ),
+			'summary'                 => '',
+			'transcript'              => '[]',
+			'turn_count'              => 0,
+			'provider_id'             => self::sanitize_metadata_string( $provider_id, 100 ),
+			'model_id'                => self::sanitize_metadata_string( $model_id, 100 ),
+			'iterations_used'         => 0,
+			'prompt_tokens'           => 0,
+			'completion_tokens'       => 0,
+			'handoff_intent'          => '',
+			'error_code'              => '',
+			'expires_at'              => $expires_at,
+			'created_at'              => $now,
+			'updated_at'              => $now,
+		);
+		$result = $wpdb->insert(
+			self::table_name(),
+			$data,
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s' )
+		);
+		if ( false !== $result ) {
+			return true;
+		}
+
+		return self::review_exists( $review_id ) || ( null !== $runtime_conversation_id && self::runtime_review_exists( $runtime_conversation_id ) );
+	}
+
+	/**
+	 * Append an idempotent safe-display source event under a review-row lock.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	private static function append_turn( string $review_id, string $source_event_id, string $role, string $content, string $status, array $metadata ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$role            = self::normalise_role( $role );
+		$status          = self::sanitize_status( $status );
+		$source_event_id = self::sanitize_event_id( $source_event_id );
+		if ( null === $role || '' === $status || '' === $source_event_id ) {
+			return false;
+		}
+
+		$content = self::sanitize_turn_text( $content );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A row lock makes delete/completion races deterministic for the minimized review projection.
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one opaque review shell before appending a safe turn.
+		$review = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT review_id, deleted_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
+				self::table_name(),
+				$review_id
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $review ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+		if ( ! empty( $review['deleted_at'] ) ) {
+			self::finish_transaction( true );
+			return true;
+		}
+
+		$now              = current_time( 'mysql', true );
+		$event_created_at = self::event_created_at( $review_id, $source_event_id, $now );
+		$inserted         = 0;
+		if ( '' !== $content ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A normal insert distinguishes an existing source event from malformed or truncated writes.
+			$inserted = $wpdb->query(
+				$wpdb->prepare(
+					'INSERT INTO %i (review_id, source_event_id, role, event_status, content, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s, %s)',
+					self::turns_table_name(),
+					$review_id,
+					$source_event_id,
+					$role,
+					$status,
+					$content,
+					$event_created_at,
+					$now
+				)
+			);
+			if ( false === $inserted ) {
+				if ( ! self::turn_exists( $review_id, $source_event_id, $role ) ) {
+					self::finish_transaction( false );
+					return false;
+				}
+				$inserted = 0;
+			}
+		}
+
+		if ( ! self::update_locked_event_status( $review_id, $source_event_id, $status, $now ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+		if ( ! self::update_locked_review( $review_id, $source_event_id, $status, $metadata, $now, (int) $inserted > 0 && 'assistant' === $role ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+
+		return self::finish_transaction( true );
+	}
+
+	/**
+	 * Update an existing source event's state under the same deletion lock.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	private static function update_event_status( string $review_id, string $source_event_id, string $status, array $metadata ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$status          = self::sanitize_status( $status );
+		$source_event_id = self::sanitize_event_id( $source_event_id );
+		if ( '' === $status || '' === $source_event_id ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- A row lock prevents a terminal update from recreating an admin-deleted review.
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one minimized review shell before status-only update.
+		$review = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT review_id, deleted_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE',
+				self::table_name(),
+				$review_id
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $review ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+		if ( ! empty( $review['deleted_at'] ) ) {
+			self::finish_transaction( true );
+			return true;
+		}
+
+		$now = current_time( 'mysql', true );
+		if ( ! self::update_locked_event_status( $review_id, $source_event_id, $status, $now ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+		if ( ! self::update_locked_review( $review_id, $source_event_id, $status, $metadata, $now, false ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+
+		return self::finish_transaction( true );
+	}
+
+	/** Update every safe turn for a source event to its latest known safe state. */
+	private static function update_locked_event_status( string $review_id, string $source_event_id, string $status, string $now ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Updates only safe event-state metadata under the review-row transaction lock.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET event_status = %s, updated_at = %s WHERE review_id = %s AND source_event_id = %s',
+				self::turns_table_name(),
+				$status,
+				$now,
+				$review_id,
+				$source_event_id
+			)
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Refresh a locked review summary, counts, current event status, and metadata.
+	 *
+	 * Late terminal writes may add token totals, but only the latest customer event
+	 * may replace conversation-level provider/model/error metadata.
+	 *
+	 * Metadata is restricted to safe provider, model, and usage fields.
+	 *
+	 * @phpstan-param array<string,mixed> $metadata
+	 */
+	private static function update_locked_review( string $review_id, string $source_event_id, string $fallback_status, array $metadata, string $now, bool $increment_tokens ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$aggregate        = self::locked_review_aggregate( $review_id, $fallback_status );
+		$is_current_event = '' === $aggregate['source_event_id'] || $source_event_id === $aggregate['source_event_id'];
+		$data             = $is_current_event ? self::review_metadata_data( $metadata, $now ) : array();
+		$formats          = $is_current_event ? self::review_metadata_formats( $metadata ) : array();
+
+		if ( $increment_tokens ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads existing safe aggregate counters while the review row is locked.
+			$totals                    = $wpdb->get_row(
+				$wpdb->prepare(
+					'SELECT prompt_tokens, completion_tokens FROM %i WHERE review_id = %s LIMIT 1',
+					self::table_name(),
+					$review_id
+				),
+				ARRAY_A
+			);
+			$totals                    = is_array( $totals ) ? $totals : array();
+			$has_prompt_tokens         = array_key_exists( 'prompt_tokens', $data );
+			$has_completion_tokens     = array_key_exists( 'completion_tokens', $data );
+			$data['prompt_tokens']     = max( 0, (int) ( $totals['prompt_tokens'] ?? 0 ) ) + max( 0, (int) ( $metadata['prompt_tokens'] ?? 0 ) );
+			$data['completion_tokens'] = max( 0, (int) ( $totals['completion_tokens'] ?? 0 ) ) + max( 0, (int) ( $metadata['completion_tokens'] ?? 0 ) );
+			if ( ! $has_prompt_tokens ) {
+				$formats[] = '%d';
+			}
+			if ( ! $has_completion_tokens ) {
+				$formats[] = '%d';
+			}
+		}
+
+		$data['status']     = $aggregate['status'];
+		$data['summary']    = $aggregate['summary'];
+		$data['turn_count'] = $aggregate['turn_count'];
+		$formats[]          = '%s';
+		$formats[]          = '%s';
+		$formats[]          = '%d';
+
+		$result = $wpdb->update(
+			self::table_name(),
+			$data,
+			array( 'review_id' => $review_id ),
+			$formats,
+			array( '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * @phpstan-param array<string,mixed> $metadata
+	 * @return array<string,mixed>
+	 */
+	private static function review_metadata_data( array $metadata, string $now ): array {
+		$data = array( 'updated_at' => $now );
+		if ( array_key_exists( 'provider_id', $metadata ) ) {
+			$data['provider_id'] = self::sanitize_metadata_string( $metadata['provider_id'], 100 );
+		}
+		if ( array_key_exists( 'model_id', $metadata ) ) {
+			$data['model_id'] = self::sanitize_metadata_string( $metadata['model_id'], 100 );
+		}
+		if ( array_key_exists( 'iterations_used', $metadata ) ) {
+			$data['iterations_used'] = max( 0, (int) $metadata['iterations_used'] );
+		}
+		if ( array_key_exists( 'handoff_intent', $metadata ) ) {
+			$data['handoff_intent'] = self::sanitize_handoff_intent( $metadata['handoff_intent'] );
+		}
+		if ( array_key_exists( 'error_code', $metadata ) ) {
+			$data['error_code'] = self::sanitize_metadata_string( $metadata['error_code'], 100 );
+		}
+		if ( array_key_exists( 'prompt_tokens_total', $metadata ) ) {
+			$data['prompt_tokens'] = max( 0, (int) $metadata['prompt_tokens_total'] );
+		}
+		if ( array_key_exists( 'completion_tokens_total', $metadata ) ) {
+			$data['completion_tokens'] = max( 0, (int) $metadata['completion_tokens_total'] );
+		}
+		if ( array_key_exists( 'expires_at', $metadata ) && is_string( $metadata['expires_at'] ) && '' !== $metadata['expires_at'] ) {
+			$data['expires_at'] = $metadata['expires_at'];
+		}
+		return $data;
+	}
+
+	/**
+	 * @phpstan-param array<string,mixed> $metadata
+	 * @return list<string>
+	 */
+	private static function review_metadata_formats( array $metadata ): array {
+		$formats = array( '%s' );
+		if ( array_key_exists( 'provider_id', $metadata ) ) {
+			$formats[] = '%s';
+		}
+		if ( array_key_exists( 'model_id', $metadata ) ) {
+			$formats[] = '%s';
+		}
+		if ( array_key_exists( 'iterations_used', $metadata ) ) {
+			$formats[] = '%d';
+		}
+		if ( array_key_exists( 'handoff_intent', $metadata ) ) {
+			$formats[] = '%s';
+		}
+		if ( array_key_exists( 'error_code', $metadata ) ) {
+			$formats[] = '%s';
+		}
+		if ( array_key_exists( 'prompt_tokens_total', $metadata ) ) {
+			$formats[] = '%d';
+		}
+		if ( array_key_exists( 'completion_tokens_total', $metadata ) ) {
+			$formats[] = '%d';
+		}
+		if ( array_key_exists( 'expires_at', $metadata ) && is_string( $metadata['expires_at'] ) && '' !== $metadata['expires_at'] ) {
+			$formats[] = '%s';
+		}
+		return $formats;
+	}
+
+	/**
+	 * Return summary/count/status while the parent review row remains locked.
+	 *
+	 * @return array{summary:string,turn_count:int,status:string,source_event_id:string}
+	 */
+	private static function locked_review_aggregate( string $review_id, string $fallback_status ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregates safe turn rows under the existing review-row transaction lock.
+		$turn_count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE review_id = %s', self::turns_table_name(), $review_id )
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Summary is sourced only from the first sanitized customer turn.
+		$summary = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT content FROM %i WHERE review_id = %s AND role = %s ORDER BY created_at ASC, id ASC LIMIT 1',
+				self::turns_table_name(),
+				$review_id,
+				'user'
+			)
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The latest customer event determines visible aggregate status and metadata ownership, not late completion order.
+		$latest_event = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT source_event_id, event_status FROM %i WHERE review_id = %s AND role = %s ORDER BY created_at DESC, id DESC LIMIT 1',
+				self::turns_table_name(),
+				$review_id,
+				'user'
+			),
+			ARRAY_A
+		);
+
+		$status = self::sanitize_status( is_array( $latest_event ) ? ( $latest_event['event_status'] ?? '' ) : '' );
+		if ( '' === $status ) {
+			$status = $fallback_status;
+		}
+
+		return array(
+			'summary'         => self::sanitize_text( is_string( $summary ) ? $summary : '', self::MAX_SUMMARY ),
+			'turn_count'      => max( 0, $turn_count ),
+			'status'          => $status,
+			'source_event_id' => is_array( $latest_event ) && is_string( $latest_event['source_event_id'] ?? null ) ? $latest_event['source_event_id'] : '',
+		);
+	}
+
+	/**
+	 * Tombstone one review while removing all retained content under a row lock.
+	 */
+	private static function tombstone_review( string $review_id, string $status ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$status = self::sanitize_status( $status );
+		if ( '' === $status ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Review-row lock ensures deletion wins concurrent completion attempts.
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return false;
+		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Locks one opaque review before clearing safe retained content.
+		$review = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT review_id, deleted_at FROM %i WHERE review_id = %s LIMIT 1 FOR UPDATE', self::table_name(), $review_id ),
+			ARRAY_A
+		);
+		if ( ! is_array( $review ) ) {
+			self::finish_transaction( false );
+			return false;
+		}
+		if ( ! empty( $review['deleted_at'] ) ) {
+			return self::finish_transaction( true );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Physically removes sanitized turn content while preserving the review-shell tombstone.
+		$turns_deleted = $wpdb->delete( self::turns_table_name(), array( 'review_id' => $review_id ), array( '%s' ) );
+		if ( false === $turns_deleted ) {
+			self::finish_transaction( false );
+			return false;
+		}
+
+		$now    = current_time( 'mysql', true );
+		$update = $wpdb->update(
+			self::table_name(),
+			array(
+				'status'            => $status,
+				'summary'           => '',
+				'transcript'        => '[]',
+				'turn_count'        => 0,
+				'provider_id'       => '',
+				'model_id'          => '',
+				'iterations_used'   => 0,
+				'prompt_tokens'     => 0,
+				'completion_tokens' => 0,
+				'handoff_intent'    => '',
+				'error_code'        => '',
+				'deleted_at'        => $now,
+				'updated_at'        => $now,
+			),
+			array( 'review_id' => $review_id ),
+			array( '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%s', '%s' ),
+			array( '%s' )
+		);
+		if ( false === $update ) {
+			self::finish_transaction( false );
+			return false;
+		}
+
+		return self::finish_transaction( true );
+	}
+
+	/**
+	 * Selects a bounded set before each tombstone receives its own deletion lock.
+	 *
+	 * @phpstan-param list<mixed> $args
+	 */
+	private static function purge_matching_reviews( string $where, array $args, int $limit, string $status ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$limit      = max( 1, min( 1000, $limit ) );
+		$sql        = 'SELECT review_id FROM %i WHERE ' . $where . ' ORDER BY updated_at ASC, id ASC LIMIT %d';
+		$query_args = array_merge( array( self::table_name() ), $args, array( $limit ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Bounded selection lets each tombstone take the same race-safe deletion path.
+		$review_ids = $wpdb->get_col( $wpdb->prepare( $sql, ...$query_args ) );
+		if ( ! is_array( $review_ids ) ) {
+			return 0;
+		}
+
+		$deleted = 0;
+		foreach ( $review_ids as $review_id ) {
+			if ( is_string( $review_id ) && self::tombstone_review( $review_id, $status ) ) {
+				++$deleted;
+			}
+		}
+
+		return $deleted;
+	}
+
+	/** Return the event creation time from the customer turn when it already exists. */
+	private static function event_created_at( string $review_id, string $source_event_id, string $fallback ): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Keeps assistant/event ordering anchored to its original customer message.
+		$created_at = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT created_at FROM %i WHERE review_id = %s AND source_event_id = %s AND role = %s LIMIT 1',
+				self::turns_table_name(),
+				$review_id,
+				$source_event_id,
+				'user'
+			)
+		);
+
+		return is_string( $created_at ) && '' !== $created_at ? $created_at : $fallback;
+	}
+
+	/** Determine whether a duplicate-key retry already persisted this exact turn. */
+	private static function turn_exists( string $review_id, string $source_event_id, string $role ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies only the unique idempotency tuple while the parent review row remains locked.
+		return null !== $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT id FROM %i WHERE review_id = %s AND source_event_id = %s AND role = %s LIMIT 1',
+				self::turns_table_name(),
+				$review_id,
+				$source_event_id,
+				$role
+			)
+		);
+	}
+
+	/**
+	 * Permanently remove the safe turns belonging to known review shells.
+	 *
+	 * @phpstan-param array<int|string,mixed> $review_ids
+	 */
+	private static function delete_turns_by_review_ids( array $review_ids ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$ids = array_values( array_filter( $review_ids, static fn( mixed $id ): bool => is_string( $id ) && '' !== $id ) );
+		if ( empty( $ids ) ) {
+			return true;
+		}
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%s' ) );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The fixed number of placeholders is generated only from a filtered list of opaque IDs.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Permanently removes minimized turn content during underlying runtime purge.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i WHERE review_id IN ({$placeholders})",
+				self::turns_table_name(),
+				...$ids
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return false !== $result;
+	}
+
+	/** Commit or roll back the current local projection transaction. */
+	private static function finish_transaction( bool $commit ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Ends a narrowly scoped projection write transaction.
+		$result = $wpdb->query( $commit ? 'COMMIT' : 'ROLLBACK' );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Build a prepared SQL fragment for bounded review filtering.
+	 *
+	 * @phpstan-param array<string,mixed> $filters
+	 * @phpstan-return array{0:string,1:list<mixed>}
+	 */
+	private static function build_filter_query( array $filters ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$clauses = array( 'deleted_at IS NULL', 'expires_at >= %s' );
+		$args    = array( current_time( 'mysql', true ) );
+		$source  = self::sanitize_source( $filters['source'] ?? '' );
+		if ( '' !== $source ) {
+			$clauses[] = 'source = %s';
+			$args[]    = $source;
+		}
+
+		$status = self::sanitize_status( $filters['status'] ?? '' );
+		if ( '' !== $status ) {
+			$clauses[] = 'status = %s';
+			$args[]    = $status;
+		}
+
+		$agent = self::sanitize_metadata_string( $filters['agent'] ?? '', 100 );
+		if ( '' !== $agent ) {
+			if ( ctype_digit( $agent ) ) {
+				$clauses[] = 'agent_id = %d';
+				$args[]    = (int) $agent;
+			}
+		}
+
+		$date_from = self::normalise_date( $filters['date_from'] ?? '', false );
+		if ( '' !== $date_from ) {
+			$clauses[] = 'created_at >= %s';
+			$args[]    = $date_from;
+		}
+		$date_to = self::normalise_date( $filters['date_to'] ?? '', true );
+		if ( '' !== $date_to ) {
+			$clauses[] = 'created_at <= %s';
+			$args[]    = $date_to;
+		}
+
+		$search = self::sanitize_metadata_string( $filters['search'] ?? '', 100 );
+		if ( '' !== $search ) {
+			$clauses[] = 'MATCH (summary) AGAINST (%s IN NATURAL LANGUAGE MODE)';
+			$args[]    = $search;
+		}
+
+		return array( implode( ' AND ', $clauses ), $args );
+	}
+
+	/**
+	 * Normalize one database row into a transcript-free review summary DTO.
+	 *
+	 * @phpstan-param array<string,mixed> $row
+	 * @phpstan-return array<string,mixed>
+	 */
+	private static function normalise_summary( array $row ): array {
+		return array(
+			'id'                => (string) ( $row['review_id'] ?? '' ),
+			'source'            => self::sanitize_source( $row['source'] ?? '' ),
+			'agent_id'          => max( 0, (int) ( $row['agent_id'] ?? 0 ) ),
+			'status'            => self::sanitize_status( $row['status'] ?? '' ),
+			'preview'           => self::sanitize_text( (string) ( $row['summary'] ?? '' ), self::MAX_SUMMARY ),
+			'turn_count'        => max( 0, (int) ( $row['turn_count'] ?? 0 ) ),
+			'provider_id'       => self::sanitize_metadata_string( $row['provider_id'] ?? '', 100 ),
+			'model_id'          => self::sanitize_metadata_string( $row['model_id'] ?? '', 100 ),
+			'iterations_used'   => max( 0, (int) ( $row['iterations_used'] ?? 0 ) ),
+			'prompt_tokens'     => max( 0, (int) ( $row['prompt_tokens'] ?? 0 ) ),
+			'completion_tokens' => max( 0, (int) ( $row['completion_tokens'] ?? 0 ) ),
+			'handoff_intent'    => self::sanitize_handoff_intent( $row['handoff_intent'] ?? '' ),
+			'error_code'        => self::sanitize_metadata_string( $row['error_code'] ?? '', 100 ),
+			'expires_at'        => (string) ( $row['expires_at'] ?? '' ),
+			'created_at'        => (string) ( $row['created_at'] ?? '' ),
+			'updated_at'        => (string) ( $row['updated_at'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Normalize one database row into a review detail DTO.
+	 *
+	 * @phpstan-param array<string,mixed> $row
+	 * @phpstan-return array<string,mixed>
+	 */
+	private static function normalise_detail( array $row ): array {
+		$detail               = self::normalise_summary( $row );
+		$detail['transcript'] = isset( $row['transcript'] ) && is_array( $row['transcript'] )
+			? self::normalise_turn_rows( $row['transcript'] )
+			: array();
+
+		return $detail;
+	}
+
+	/**
+	 * Normalize one bounded page of sanitized turn rows.
+	 *
+	 * @phpstan-param array<int|string,mixed> $turns
+	 * @return list<array{role:string,content:string}>
+	 */
+	private static function normalise_turn_rows( array $turns ): array {
+		$normalised = array();
+		foreach ( $turns as $turn ) {
+			if ( ! is_array( $turn ) ) {
+				continue;
+			}
+			$role = self::normalise_role( $turn['role'] ?? '' );
+			if ( null === $role ) {
+				continue;
+			}
+			$content = self::sanitize_turn_text( (string) ( $turn['content'] ?? '' ) );
+			if ( '' === $content ) {
+				continue;
+			}
+			$normalised[] = array(
+				'role'    => $role,
+				'content' => $content,
+			);
+		}
+
+		return $normalised;
+	}
+
+	/**
+	 * Extract content-channel display text from one provider-shaped message.
+	 *
+	 * @phpstan-param array<string,mixed> $message
+	 */
+	private static function extract_display_text( array $message ): string {
+		$text = '';
+		if ( isset( $message['content'] ) && is_string( $message['content'] ) ) {
+			$text .= $message['content'];
+		}
+
+		$parts = $message['parts'] ?? null;
+		if ( is_array( $parts ) ) {
+			foreach ( $parts as $part ) {
+				if ( ! is_array( $part ) || ! self::is_content_part( $part ) ) {
+					continue;
+				}
+				if ( isset( $part['text'] ) && is_string( $part['text'] ) ) {
+					$text .= $part['text'];
+				} elseif ( isset( $part['content'] ) && is_string( $part['content'] ) ) {
+					$text .= $part['content'];
+				}
+			}
+		}
+
+		return self::sanitize_turn_text( $text );
+	}
+
+	/**
+	 * Determine whether one provider-shaped part is safe display content.
+	 *
+	 * @phpstan-param array<string,mixed> $part
+	 */
+	private static function is_content_part( array $part ): bool {
+		$channel = $part['channel'] ?? null;
+
+		return null === $channel || '' === $channel || ( is_string( $channel ) && 'content' === strtolower( $channel ) );
+	}
+
+	private static function normalise_role( mixed $role ): ?string {
+		$role = is_string( $role ) ? strtolower( $role ) : '';
+		if ( 'user' === $role ) {
+			return 'user';
+		}
+		if ( in_array( $role, array( 'assistant', 'model' ), true ) ) {
+			return 'assistant';
+		}
+
+		return null;
+	}
+
+	private static function sanitize_text( string $value, int $max_length ): string {
+		return DurablePlanTextSanitizer::sanitize( $value, $max_length );
+	}
+
+	/** Remove hidden reasoning and redact durable secrets before persisting a review turn. */
+	private static function sanitize_turn_text( string $value ): string {
+		return self::sanitize_text(
+			ConversationDisplaySanitizer::sanitize_display_text( $value ),
+			self::MAX_TURN_LENGTH
+		);
+	}
+
+	private static function sanitize_source( mixed $source ): string {
+		$source = is_string( $source ) ? sanitize_key( $source ) : '';
+
+		return in_array( $source, array( self::SOURCE_PUBLIC_EMBED, self::SOURCE_CUSTOMER_RUNTIME ), true ) ? $source : '';
+	}
+
+	private static function sanitize_status( mixed $status ): string {
+		$status = is_string( $status ) ? sanitize_key( $status ) : '';
+
+		return in_array( $status, array( 'queued', 'processing', 'complete', 'failed', 'cancelled', 'deleted', 'expired' ), true ) ? $status : '';
+	}
+
+	private static function sanitize_handoff_intent( mixed $intent ): string {
+		$intent = is_string( $intent ) ? sanitize_key( $intent ) : '';
+
+		return in_array( $intent, array( 'human_support', 'private_data_required', 'insufficient_evidence', 'unsafe_request' ), true ) ? $intent : '';
+	}
+
+	private static function sanitize_event_id( string $source_event_id ): string {
+		$source_event_id = preg_replace( '/[^a-zA-Z0-9_-]/', '', $source_event_id );
+		$source_event_id = is_string( $source_event_id ) ? $source_event_id : '';
+
+		return function_exists( 'mb_substr' ) ? mb_substr( $source_event_id, 0, 64 ) : substr( $source_event_id, 0, 64 );
+	}
+
+	private static function sanitize_metadata_string( mixed $value, int $max_length ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		return self::sanitize_text( (string) $value, $max_length );
+	}
+
+	private static function normalise_date( mixed $date, bool $end_of_day ): string {
+		$date = is_string( $date ) ? $date : '';
+		if ( 1 !== preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return '';
+		}
+		$time = $end_of_day ? ' 23:59:59' : ' 00:00:00';
+		$unix = strtotime( $date . $time . ' UTC' );
+
+		return false === $unix ? '' : gmdate( 'Y-m-d H:i:s', $unix );
+	}
+
+	private static function review_exists( string $review_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies idempotent shell creation by opaque review ID.
+		return null !== $wpdb->get_var(
+			$wpdb->prepare( 'SELECT review_id FROM %i WHERE review_id = %s LIMIT 1', self::table_name(), $review_id )
+		);
+	}
+
+	private static function runtime_review_exists( string $runtime_conversation_id ): bool {
+		return null !== self::get_runtime_review_id( $runtime_conversation_id );
+	}
+
+	private static function get_runtime_review_id( string $runtime_conversation_id ): ?string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Server-only lookup never enters a review DTO.
+		$review_id = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT review_id FROM %i WHERE runtime_conversation_id = %s LIMIT 1', self::table_name(), $runtime_conversation_id )
+		);
+
+		return is_string( $review_id ) && '' !== $review_id ? $review_id : null;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -59,6 +59,7 @@ use SdAiAgent\REST\AutomationController;
 use SdAiAgent\REST\BannerController;
 use SdAiAgent\REST\BlockValidatorController;
 use SdAiAgent\REST\ConnectorsController;
+use SdAiAgent\REST\CustomerConversationController;
 use SdAiAgent\REST\ChangesController;
 use SdAiAgent\REST\FeedbackController;
 use SdAiAgent\REST\KnowledgeController;
@@ -135,6 +136,7 @@ use XWP\DI\Decorators\Module;
 		SessionController::class,
 		SettingsController::class,
 		ConnectorsController::class,
+		CustomerConversationController::class,
 		WebhookController::class,
 	),
 	extendable: true,

--- a/includes/REST/CustomerConversationController.php
+++ b/includes/REST/CustomerConversationController.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Admin-only REST API controller for privacy-safe customer conversation reviews.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\REST;
+
+use SdAiAgent\Models\CustomerConversationReviewRepository;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provides read-only inspection and deletion of sanitized customer reviews.
+ *
+ * Customer-facing execution data, tokens, and source identifiers never cross
+ * this controller boundary. The only mutation routes tombstone retained review
+ * projections; they never resume or execute a customer conversation.
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'customer-conversations',
+	container: 'sd-ai-agent',
+)]
+final class CustomerConversationController extends XWP_REST_Controller {
+
+	use PermissionTrait;
+
+	/** Handle GET /customer-conversations. */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_list_args',
+		guard: 'check_permission',
+	)]
+	public function handle_list_customer_conversations( WP_REST_Request $request ): WP_REST_Response {
+		$filters = array();
+		foreach ( array( 'source', 'status', 'agent', 'date_from', 'date_to', 'search', 'limit', 'offset' ) as $key ) {
+			if ( $request->has_param( $key ) ) {
+				$filters[ $key ] = $request->get_param( $key );
+			}
+		}
+
+		$limit             = min( 50, max( 1, (int) ( $filters['limit'] ?? 20 ) ) );
+		$offset            = min( 10000, max( 0, (int) ( $filters['offset'] ?? 0 ) ) );
+		$filters['limit']  = $limit;
+		$filters['offset'] = $offset;
+
+		return new WP_REST_Response(
+			array(
+				'conversations' => CustomerConversationReviewRepository::list_reviews( $filters ),
+				'total'         => CustomerConversationReviewRepository::count_reviews( $filters ),
+				'limit'         => $limit,
+				'offset'        => $offset,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Handle GET /customer-conversations/{opaque-review-id}.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	#[REST_Route(
+		route: '(?P<id>[a-f0-9-]+)',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_detail_args',
+		guard: 'check_permission',
+	)]
+	public function handle_get_customer_conversation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$review_id = sanitize_text_field( (string) $request->get_param( 'id' ) );
+		$review    = CustomerConversationReviewRepository::get_review(
+			$review_id,
+			(int) $request->get_param( 'turn_limit' ),
+			(int) $request->get_param( 'turn_offset' )
+		);
+		if ( null === $review ) {
+			return $this->not_found_error();
+		}
+
+		return new WP_REST_Response( $review, 200 );
+	}
+
+	/**
+	 * Handle DELETE /customer-conversations/{opaque-review-id}.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	#[REST_Route(
+		route: '(?P<id>[a-f0-9-]+)',
+		methods: WP_REST_Server::DELETABLE,
+		vars: 'get_identifier_args',
+		guard: 'check_permission',
+	)]
+	public function handle_delete_customer_conversation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$review_id = sanitize_text_field( (string) $request->get_param( 'id' ) );
+		if ( ! CustomerConversationReviewRepository::delete_review( $review_id ) ) {
+			return $this->not_found_error();
+		}
+
+		return new WP_REST_Response(
+			array(
+				'deleted' => true,
+				'id'      => $review_id,
+			),
+			200
+			);
+	}
+
+	/**
+	 * Handle POST /customer-conversations/purge after explicit admin confirmation.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	#[REST_Route(
+		route: 'purge',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_purge_args',
+		guard: 'check_permission',
+	)]
+	public function handle_purge_customer_conversations( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		if ( true !== $request->get_param( 'confirm' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_conversation_purge_confirmation_required',
+				__( 'Confirm deletion of retained customer conversations.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$limit = min( 1000, max( 1, (int) $request->get_param( 'limit' ) ) );
+
+		return new WP_REST_Response(
+			array( 'purged' => CustomerConversationReviewRepository::purge_reviews( $limit ) ),
+			200
+		);
+	}
+
+	/**
+	 * REST schema for list filters and bounded offset pagination.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_list_args(): array {
+		return array(
+			'source'    => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'status'    => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'agent'     => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'date_from' => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'date_to'   => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'search'    => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'limit'     => array(
+				'type'              => 'integer',
+				'default'           => 20,
+				'sanitize_callback' => 'absint',
+			),
+			'offset'    => array(
+				'type'              => 'integer',
+				'default'           => 0,
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/**
+	 * REST schema for opaque review IDs.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_identifier_args(): array {
+		return array(
+			'id' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+	}
+
+	/**
+	 * REST schema for one opaque review ID and a bounded transcript page.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_detail_args(): array {
+		$args                = $this->get_identifier_args();
+		$args['turn_limit']  = array(
+			'type'              => 'integer',
+			'default'           => 100,
+			'sanitize_callback' => 'absint',
+		);
+		$args['turn_offset'] = array(
+			'type'              => 'integer',
+			'default'           => 0,
+			'sanitize_callback' => 'absint',
+		);
+
+		return $args;
+	}
+
+	/**
+	 * REST schema for explicit retained-review purge.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_purge_args(): array {
+		return array(
+			'confirm' => array(
+				'required' => true,
+				'type'     => 'boolean',
+			),
+			'limit'   => array(
+				'type'              => 'integer',
+				'default'           => 500,
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/** Return a deliberately generic error for inaccessible review IDs. */
+	private function not_found_error(): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_customer_conversation_not_found',
+			__( 'Customer conversation not found.', 'superdav-ai-agent' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -26,6 +26,7 @@ use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Agent;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
 use SdAiAgent\Models\DTO\ActiveJobRow;
 use SdAiAgent\Models\DurablePlanRepository;
 use WP_Error;
@@ -519,6 +520,13 @@ final class SessionController {
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_public_chat_session' ),
 				'permission_callback' => '__return_true',
+				'args'                => array(
+					'recording_consent' => array(
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => false,
+					),
+				),
 			)
 		);
 
@@ -817,6 +825,11 @@ final class SessionController {
 					'embed_id'    => sanitize_key( (string) $this->settings->get( 'public_chat_embed_id' ) ),
 					'agent_id'    => (int) $config['agent_id'],
 					'collections' => $config['collections'],
+					'recording'   => array(
+						'enabled'        => $enabled && ! empty( $config['review_recording_enabled'] ),
+						'retention_days' => $enabled && ! empty( $config['review_recording_enabled'] ) ? (int) $config['review_retention_days'] : 0,
+						'disclosure'     => $enabled && ! empty( $config['review_recording_enabled'] ) ? (string) $config['review_disclosure'] : '',
+					),
 				),
 				200
 			),
@@ -2163,7 +2176,7 @@ final class SessionController {
 	/**
 	 * Get sanitized public chat settings.
 	 *
-	 * @return array{enabled: bool, origins: list<string>, provider_id: string, model_id: string, agent_id: int, collections: list<string>, abilities: list<string>, iterations: int, message_length: int, rate_limit: int}
+	 * @return array{enabled: bool, origins: list<string>, provider_id: string, model_id: string, agent_id: int, collections: list<string>, abilities: list<string>, iterations: int, message_length: int, rate_limit: int, review_recording_enabled: bool, review_retention_days: int, review_disclosure: string}
 	 */
 	private function get_public_chat_settings(): array {
 		$settings = Settings::instance()->get();
@@ -2176,17 +2189,30 @@ final class SessionController {
 		$origins = $settings['public_chat_allowed_origins'] ?? array();
 		$origins = is_array( $origins ) ? $this->sanitize_public_chat_string_list( $origins, 'sanitize_text_field' ) : array();
 
+		$review_retention_days = max( 1, min( 90, (int) ( $settings['public_chat_review_retention_days'] ?? 7 ) ) );
+		$review_disclosure     = sanitize_textarea_field( (string) ( $settings['public_chat_review_disclosure'] ?? '' ) );
+		if ( '' === $review_disclosure ) {
+			$review_disclosure = sprintf(
+				/* translators: %d: maximum number of days an opted-in anonymous chat is retained. */
+				__( 'This conversation may be recorded for quality review and retained for up to %d days.', 'superdav-ai-agent' ),
+				$review_retention_days
+			);
+		}
+
 		return array(
-			'enabled'        => (bool) ( $settings['public_chat_enabled'] ?? false ),
-			'origins'        => $origins,
-			'provider_id'    => sanitize_text_field( (string) ( $settings['public_chat_provider_id'] ?? '' ) ),
-			'model_id'       => sanitize_text_field( (string) ( $settings['public_chat_model_id'] ?? '' ) ),
-			'agent_id'       => absint( $settings['public_chat_agent_id'] ?? 0 ),
-			'collections'    => $collections,
-			'abilities'      => $allowed,
-			'iterations'     => max( 1, min( 8, (int) ( $settings['public_chat_max_iterations'] ?? 4 ) ) ),
-			'message_length' => max( 1, min( 8000, (int) ( $settings['public_chat_message_max_length'] ?? 2000 ) ) ),
-			'rate_limit'     => max( 1, min( 60, (int) ( $settings['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
+			'enabled'                  => (bool) ( $settings['public_chat_enabled'] ?? false ),
+			'origins'                  => $origins,
+			'provider_id'              => sanitize_text_field( (string) ( $settings['public_chat_provider_id'] ?? '' ) ),
+			'model_id'                 => sanitize_text_field( (string) ( $settings['public_chat_model_id'] ?? '' ) ),
+			'agent_id'                 => absint( $settings['public_chat_agent_id'] ?? 0 ),
+			'collections'              => $collections,
+			'abilities'                => $allowed,
+			'iterations'               => max( 1, min( 8, (int) ( $settings['public_chat_max_iterations'] ?? 4 ) ) ),
+			'message_length'           => max( 1, min( 8000, (int) ( $settings['public_chat_message_max_length'] ?? 2000 ) ) ),
+			'rate_limit'               => max( 1, min( 60, (int) ( $settings['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
+			'review_recording_enabled' => (bool) ( $settings['public_chat_review_recording_enabled'] ?? false ),
+			'review_retention_days'    => $review_retention_days,
+			'review_disclosure'        => $review_disclosure,
 		);
 	}
 
@@ -2360,15 +2386,36 @@ final class SessionController {
 		if ( true !== $available ) {
 			return $available;
 		}
-		$config = $this->get_public_chat_settings();
-		$origin = $this->get_public_chat_request_origin( $request );
+		$config            = $this->get_public_chat_settings();
+		$origin            = $this->get_public_chat_request_origin( $request );
+		$consent           = $request->get_param( 'recording_consent' );
+		$recording_consent = true === $consent || 1 === $consent || '1' === $consent || 'true' === $consent;
 
 		$session_uuid = wp_generate_uuid4();
 		$token        = $this->create_public_chat_token( $session_uuid );
+		$review_id    = '';
+		if ( ! empty( $config['review_recording_enabled'] ) && $recording_consent ) {
+			$candidate_review_id = wp_generate_uuid4();
+			$review_expires_at   = gmdate( 'Y-m-d H:i:s', time() + ( DAY_IN_SECONDS * (int) $config['review_retention_days'] ) );
+			try {
+				if ( CustomerConversationReviewRepository::create_public_review(
+					$candidate_review_id,
+					(int) $config['agent_id'],
+					(string) $config['provider_id'],
+					(string) $config['model_id'],
+					$review_expires_at
+				) ) {
+					$review_id = $candidate_review_id;
+				}
+			} catch ( \Throwable $exception ) {
+				// Review recording is deliberately fail-open for the public chat flow.
+			}
+		}
 		set_transient(
 			$this->public_chat_session_key( $session_uuid ),
 			array(
 				'history'    => array(),
+				'review_id'  => $review_id,
 				'created_at' => time(),
 			),
 			self::PUBLIC_CHAT_SESSION_TTL
@@ -2424,11 +2471,14 @@ final class SessionController {
 		$job_id    = wp_generate_uuid4();
 		$job_token = wp_generate_password( 40, false );
 		$history   = isset( $session['history'] ) && is_array( $session['history'] ) ? $session['history'] : array();
+		$review_id = isset( $session['review_id'] ) && is_string( $session['review_id'] ) ? $session['review_id'] : '';
 
 		$job = array(
+			'job_id'              => $job_id,
 			'public_chat'         => true,
 			'public_session_uuid' => $session_uuid,
 			'public_token_hash'   => hash( 'sha256', $token ),
+			'public_review_id'    => $review_id,
 			'status'              => 'processing',
 			'token'               => $job_token,
 			'user_id'             => 0,
@@ -2452,6 +2502,16 @@ final class SessionController {
 				'anonymous_allowed_collections' => $config['collections'],
 				'anonymous_policy_active'       => true,
 			),
+		);
+		$this->record_public_chat_review_turn(
+			$job,
+			'user',
+			$message,
+			'processing',
+			array(
+				'provider_id' => (string) $config['provider_id'],
+				'model_id'    => (string) $config['model_id'],
+			)
 		);
 
 		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
@@ -2533,6 +2593,71 @@ final class SessionController {
 		}
 
 		return $this->add_public_chat_cors( new WP_REST_Response( $response, 200 ), $origin, $config['origins'] );
+	}
+
+	/**
+	 * Persist one already-safe public-chat turn without exposing the review ID.
+	 *
+	 * The job and metadata contain only server-side public-chat state and safe
+	 * provider/model/usage fields.
+	 *
+	 * @param array<string,mixed> $job      Public transient job.
+	 * @param string              $role     Safe speaker role.
+	 * @param string              $content  Safe turn content.
+	 * @param string              $status   Public turn status.
+	 * @param array<string,mixed> $metadata Safe provider, model, and usage fields.
+	 */
+	private function record_public_chat_review_turn( array $job, string $role, string $content, string $status, array $metadata = array() ): void {
+		if ( ! $this->public_chat_review_recording_enabled() ) {
+			return;
+		}
+
+		$review_id = isset( $job['public_review_id'] ) && is_string( $job['public_review_id'] ) ? $job['public_review_id'] : '';
+		$job_id    = isset( $job['job_id'] ) && is_string( $job['job_id'] ) ? $job['job_id'] : '';
+		if ( '' === $review_id || '' === $job_id ) {
+			return;
+		}
+
+		try {
+			CustomerConversationReviewRepository::append_public_turn( $review_id, $job_id, $role, $content, $status, $metadata );
+		} catch ( \Throwable $exception ) {
+			// Review persistence remains non-blocking for anonymous customer traffic.
+		}
+	}
+
+	/**
+	 * Persist a scrubbed public-chat terminal state without error detail.
+	 *
+	 * @param array<string,mixed> $job Public transient job.
+	 */
+	private function record_public_chat_review_status( array $job, string $status, string $error_code = '' ): void {
+		if ( ! $this->public_chat_review_recording_enabled() ) {
+			return;
+		}
+
+		$review_id = isset( $job['public_review_id'] ) && is_string( $job['public_review_id'] ) ? $job['public_review_id'] : '';
+		$job_id    = isset( $job['job_id'] ) && is_string( $job['job_id'] ) ? $job['job_id'] : '';
+		if ( '' === $review_id || '' === $job_id ) {
+			return;
+		}
+
+		try {
+			CustomerConversationReviewRepository::update_public_review_status(
+				$review_id,
+				$job_id,
+				$status,
+				array( 'error_code' => $error_code )
+			);
+		} catch ( \Throwable $exception ) {
+			// Review persistence remains non-blocking for anonymous customer traffic.
+		}
+	}
+
+	/** Stop new anonymous review writes as soon as site recording is disabled. */
+	private function public_chat_review_recording_enabled(): bool {
+		$config = $this->get_public_chat_settings();
+
+		return ! empty( $config['review_recording_enabled'] );
 	}
 
 	/** Public chat system instruction. */
@@ -3634,6 +3759,7 @@ final class SessionController {
 					'model_id'        => (string) ( $options['model_id'] ?? $params['model_id'] ?? '' ),
 				)
 			);
+			$this->record_public_chat_review_status( $job, 'failed', (string) $diagnostic['reason'] );
 
 			if ( $session_id && ! $is_durable_plan_phase ) {
 				$recovery_error = new WP_Error(
@@ -3686,12 +3812,13 @@ final class SessionController {
 			if ( '' === $failure_data['model_id'] ) {
 				$failure_data['model_id'] = (string) ( $options['model_id'] ?? $params['model_id'] ?? '' );
 			}
-			$diagnostic        = $this->persist_active_job_failure(
+			$diagnostic = $this->persist_active_job_failure(
 				$job_id,
 				$job,
 				ActiveJobFailureDiagnostic::reason_from_error( $result, $failure_data['provider_id'] ),
 				$failure_data
 			);
+			$this->record_public_chat_review_status( $job, 'failed', (string) $diagnostic['reason'] );
 			$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
 			$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
 			$payload_recovery  = $this->normalize_payload_recovery( $error_data['recovery'] ?? null, $session_id );
@@ -3803,14 +3930,31 @@ final class SessionController {
 			$job['result'] = $result;
 
 			if ( ! empty( $job['public_chat'] ) && ! empty( $job['public_session_uuid'] ) ) {
-				$public_history = isset( $result['history'] ) && is_array( $result['history'] ) ? $result['history'] : array();
+				$public_history               = isset( $result['history'] ) && is_array( $result['history'] ) ? $result['history'] : array();
+				$public_session               = get_transient( $this->public_chat_session_key( (string) $job['public_session_uuid'] ) );
+				$public_session               = is_array( $public_session ) ? $public_session : array();
+				$public_session['history']    = $public_history;
+				$public_session['updated_at'] = time();
 				set_transient(
 					$this->public_chat_session_key( (string) $job['public_session_uuid'] ),
-					array(
-						'history'    => $public_history,
-						'updated_at' => time(),
-					),
+					$public_session,
 					self::PUBLIC_CHAT_SESSION_TTL
+				);
+				$token_usage = isset( $result['token_usage'] ) && is_array( $result['token_usage'] ) ? $result['token_usage'] : array();
+				$handoff     = isset( $result['handoff'] ) && is_array( $result['handoff'] ) ? $result['handoff'] : array();
+				$this->record_public_chat_review_turn(
+					$job,
+					'assistant',
+					(string) ( $result['reply'] ?? '' ),
+					'complete',
+					array(
+						'provider_id'       => (string) ( $options['provider_id'] ?? $params['provider_id'] ?? '' ),
+						'model_id'          => (string) ( $options['model_id'] ?? $params['model_id'] ?? '' ),
+						'iterations_used'   => (int) ( $result['iterations_used'] ?? 0 ),
+						'prompt_tokens'     => (int) ( $token_usage['prompt'] ?? 0 ),
+						'completion_tokens' => (int) ( $token_usage['completion'] ?? 0 ),
+						'handoff_intent'    => (string) ( $handoff['intent'] ?? '' ),
+					)
 				);
 			}
 

--- a/includes/Services/CustomerAgentRuntimeService.php
+++ b/includes/Services/CustomerAgentRuntimeService.php
@@ -20,6 +20,7 @@ use SdAiAgent\Core\JobErrorSanitizer;
 use SdAiAgent\Knowledge\KnowledgeDatabase;
 use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Agent;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
 use SdAiAgent\Models\CustomerAgentRuntimeRepository;
 use WP_Error;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -691,6 +692,10 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 			);
 		}
 
+		// Review recording is a separate, fail-open display projection. Its write
+		// must never prevent a constrained customer request from being delivered.
+		$this->record_runtime_review_on_enqueue( $conversation['row'], $profile, $job_id, $message, $expires_at );
+
 		$queued = CustomerAgentRuntimeRepository::get_job( $job_id );
 		if ( null === $queued ) {
 			return new WP_Error(
@@ -761,6 +766,7 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 
 		$now = current_time( 'mysql', true );
 		if ( CustomerAgentRuntimeRepository::mark_cancelled( $job_id, $now ) ) {
+			$this->record_runtime_review_status( $owned_job, 'cancelled' );
 			ActiveJobRepository::record_failure(
 				$job_id,
 				'error',
@@ -1000,14 +1006,25 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 			return;
 		}
 
-		$history_json = wp_json_encode( $history );
+		$review_expires_at = $this->future_mysql_time( self::RETENTION_SECONDS );
+		$history_json      = wp_json_encode( $history );
 		if ( is_string( $history_json ) ) {
 			CustomerAgentRuntimeRepository::update_runtime_history(
 				(string) $job['conversation_id'],
 				$history_json,
-				$this->future_mysql_time( self::RETENTION_SECONDS )
+				$review_expires_at
 			);
 		}
+		$this->record_runtime_review_completion(
+			$job,
+			$response,
+			$profile['provider_id'],
+			(string) ( $result['model_id'] ?? $profile['model_id'] ),
+			(int) ( $result['iterations_used'] ?? 0 ),
+			(int) ( $tokens['prompt'] ?? 0 ),
+			(int) ( $tokens['completion'] ?? 0 ),
+			$review_expires_at
+		);
 		ActiveJobRepository::update_status( $job_id, 'complete' );
 		$completed_job = CustomerAgentRuntimeRepository::get_job( $job_id );
 		if ( null !== $completed_job ) {
@@ -1761,6 +1778,7 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 		$job_id  = (string) $job['job_id'];
 		$message = __( 'The customer-agent request timed out before a reply was available.', 'superdav-ai-agent' );
 		if ( CustomerAgentRuntimeRepository::mark_timed_out( $job_id, current_time( 'mysql', true ), 'sd_ai_agent_customer_agent_timeout', $message ) ) {
+			$this->record_runtime_review_status( $job, 'failed', 'sd_ai_agent_customer_agent_timeout' );
 			ActiveJobRepository::record_failure(
 				$job_id,
 				'error',
@@ -1788,6 +1806,7 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 		$message                               = $this->customer_safe_error_message( $detail );
 		$diagnostic_context['last_safe_phase'] = 'customer_agent_runtime';
 		if ( CustomerAgentRuntimeRepository::mark_failed( $job_id, current_time( 'mysql', true ), $error_code, $message ) ) {
+			$this->record_runtime_review_status( $job, 'failed', $error_code );
 			ActiveJobRepository::record_failure(
 				$job_id,
 				'error',
@@ -1821,6 +1840,99 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 			'created'         => $created,
 			'expires_at'      => (string) $job['expires_at'],
 		);
+	}
+
+	/**
+	 * Create the isolated review projection for a newly queued customer turn.
+	 *
+	 * @param array<string,mixed> $conversation Durable runtime conversation row.
+	 * @param array<string,mixed> $profile      Resolved constrained profile.
+	 */
+	private function record_runtime_review_on_enqueue( array $conversation, array $profile, string $job_id, string $message, string $expires_at ): void {
+		try {
+			$profile_key     = (string) ( $profile['profile_key'] ?? '' );
+			$agent           = '' !== $profile_key ? Agent::get_by_managed_profile_key( $profile_key ) : null;
+			$agent_id        = null !== $agent ? (int) $agent->id : 0;
+			$conversation_id = (string) ( $conversation['conversation_id'] ?? '' );
+			CustomerConversationReviewRepository::create_runtime_review(
+				wp_generate_uuid4(),
+				$conversation_id,
+				(string) ( $profile['provider_id'] ?? '' ),
+				(string) ( $profile['model_id'] ?? '' ),
+				$expires_at,
+				$agent_id
+			);
+			CustomerConversationReviewRepository::append_runtime_turn(
+				$conversation_id,
+				$job_id,
+				'user',
+				$message,
+				'queued',
+				array(
+					'provider_id' => (string) ( $profile['provider_id'] ?? '' ),
+					'model_id'    => (string) ( $profile['model_id'] ?? '' ),
+					'expires_at'  => $expires_at,
+				)
+			);
+		} catch ( \Throwable $exception ) {
+			// Review persistence is intentionally non-blocking for customer traffic.
+		}
+	}
+
+	/**
+	 * Write the completed display projection after the runtime conditional update wins.
+	 *
+	 * @param array<string,mixed>                                                 $job      Durable runtime job row.
+	 * @param array{reply:string,handoff:array{intent:string,reason:string}|null} $response Safe response data.
+	 */
+	private function record_runtime_review_completion( array $job, array $response, string $provider_id, string $model_id, int $iterations_used, int $prompt_tokens, int $completion_tokens, string $expires_at ): void {
+		$handoff_intent = is_array( $response['handoff'] ?? null ) && is_string( $response['handoff']['intent'] ?? null )
+			? $response['handoff']['intent']
+			: '';
+
+		try {
+			CustomerConversationReviewRepository::append_runtime_turn(
+				(string) ( $job['conversation_id'] ?? '' ),
+				(string) ( $job['job_id'] ?? '' ),
+				'assistant',
+				(string) ( $response['reply'] ?? '' ),
+				'complete',
+				array(
+					'provider_id'       => $provider_id,
+					'model_id'          => $model_id,
+					'iterations_used'   => $iterations_used,
+					'prompt_tokens'     => $prompt_tokens,
+					'completion_tokens' => $completion_tokens,
+					'handoff_intent'    => $handoff_intent,
+					'expires_at'        => $expires_at,
+				)
+			);
+		} catch ( \Throwable $exception ) {
+			// Review persistence is intentionally non-blocking for customer traffic.
+		}
+	}
+
+	/**
+	 * Persist a safe terminal review status without retaining exception detail.
+	 *
+	 * @param array<string,mixed> $job Durable runtime job row.
+	 */
+	private function record_runtime_review_status( array $job, string $status, string $error_code = '' ): void {
+		try {
+			CustomerConversationReviewRepository::update_runtime_review_status(
+				(string) ( $job['conversation_id'] ?? '' ),
+				(string) ( $job['job_id'] ?? '' ),
+				$status,
+				array(
+					'provider_id' => (string) ( $job['provider_id'] ?? '' ),
+					'model_id'    => (string) ( $job['model_id'] ?? '' ),
+					'error_code'  => $error_code,
+					'expires_at'  => (string) ( $job['expires_at'] ?? '' ),
+				)
+			);
+		} catch ( \Throwable $exception ) {
+			// Review persistence is intentionally non-blocking for customer traffic.
+		}
 	}
 
 	/**

--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -19,6 +19,21 @@ describe( 'embed widget', () => {
 		delete global.fetch;
 	} );
 
+	/**
+	 * Flush queued mocked fetch promises.
+	 *
+	 * @return {Promise<void>} Resolved after queued promise callbacks.
+	 */
+	async function flushRequests() {
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	}
+
 	test( 'resolves script data attributes without WordPress globals', () => {
 		const script = document.createElement( 'script' );
 		script.dataset.apiBase = 'https://example.test/wp-json/sd-ai-agent/v1';
@@ -86,6 +101,99 @@ describe( 'embed widget', () => {
 			'https://example.test/wp-json/sd-ai-agent/v1/public-chat/config',
 			expect.objectContaining( { credentials: 'omit' } )
 		);
+	} );
+
+	test( 'does not create a recorded session until a visitor explicitly chooses it', async () => {
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/public-chat/config' ) ) {
+				return Promise.resolve( {
+					ok: true,
+					json: () =>
+						Promise.resolve( {
+							enabled: true,
+							recording: {
+								enabled: true,
+								disclosure:
+									'Opt in before this chat is retained for review.',
+							},
+						} ),
+				} );
+			}
+
+			return Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { token: 'public-token' } ),
+			} );
+		} );
+
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			mount: '#mount',
+		} );
+		await flushRequests();
+
+		expect(
+			root.querySelector( '.sdaa-embed__recording-choice' ).textContent
+		).toContain( 'Opt in before this chat is retained for review.' );
+		expect(
+			global.fetch.mock.calls.filter( ( [ url ] ) =>
+				url.endsWith( '/public-chat/session' )
+			)
+		).toHaveLength( 0 );
+
+		root.querySelector( '[data-recording-consent="false"]' ).click();
+		await flushRequests();
+
+		const sessionRequest = global.fetch.mock.calls.find( ( [ url ] ) =>
+			url.endsWith( '/public-chat/session' )
+		);
+		expect( sessionRequest[ 1 ].body ).toBe(
+			JSON.stringify( { recording_consent: false } )
+		);
+	} );
+
+	test( 'sends explicit recording consent only after the visitor agrees', async () => {
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/public-chat/config' ) ) {
+				return Promise.resolve( {
+					ok: true,
+					json: () =>
+						Promise.resolve( {
+							enabled: true,
+							recording: {
+								enabled: true,
+								disclosure: 'Recording is optional.',
+							},
+						} ),
+				} );
+			}
+
+			return Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { token: 'public-token' } ),
+			} );
+		} );
+
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			mount: '#mount',
+		} );
+		await flushRequests();
+
+		root.querySelector( '[data-recording-consent="true"]' ).click();
+		await flushRequests();
+
+		const sessionRequest = global.fetch.mock.calls.find( ( [ url ] ) =>
+			url.endsWith( '/public-chat/session' )
+		);
+		expect( sessionRequest[ 1 ].body ).toBe(
+			JSON.stringify( { recording_consent: true } )
+		);
+		expect(
+			root.querySelector( '.sdaa-embed__recording-choice' )
+		).toBeNull();
 	} );
 
 	test( 'starts collapsed and close button collapses the panel', () => {
@@ -156,7 +264,21 @@ describe( 'embed widget', () => {
 		expect( form.requestSubmit ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'renders assistant markdown and makes source URLs clickable', () => {
+	test( 'renders assistant markdown and makes source URLs clickable', async () => {
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/public-chat/config' ) ) {
+				return Promise.resolve( {
+					ok: true,
+					json: () => Promise.resolve( { enabled: true } ),
+				} );
+			}
+
+			return Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { token: 'public-token' } ),
+			} );
+		} );
+
 		const root = module.mountEmbed( {
 			...module.resolveConfig( null, {} ),
 			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
@@ -164,6 +286,7 @@ describe( 'embed widget', () => {
 				'Read **Setup Wizard**. Source: https://example.test/docs/setup.',
 			mount: '#mount',
 		} );
+		await flushRequests();
 
 		const message = root.querySelector( '.sdaa-embed__message--assistant' );
 		const sourceLink = message.querySelector( 'a' );

--- a/src/embed-widget/index.js
+++ b/src/embed-widget/index.js
@@ -503,7 +503,13 @@ export function createPublicClient( config ) {
 
 	return {
 		config: () => request( '/public-chat/config', { method: 'GET' } ),
-		session: () => request( '/public-chat/session', { method: 'POST' } ),
+		session: ( recordingConsent = false ) =>
+			request( '/public-chat/session', {
+				method: 'POST',
+				body: JSON.stringify( {
+					recording_consent: recordingConsent,
+				} ),
+			} ),
 		send: ( message, sessionToken ) =>
 			request( '/public-chat/run', {
 				method: 'POST',
@@ -562,7 +568,10 @@ export function mountEmbed( config ) {
 	const messages = root.querySelector( '.sdaa-embed__messages' );
 	const form = root.querySelector( '.sdaa-embed__form' );
 	const input = root.querySelector( '.sdaa-embed__input' );
+	const sendButton = form.querySelector( '.sdaa-embed__send' );
 	let sessionToken = '';
+	input.disabled = true;
+	sendButton.disabled = true;
 
 	const autosizeInput = () => {
 		input.style.height = 'auto';
@@ -588,14 +597,82 @@ export function mountEmbed( config ) {
 		return item;
 	};
 
-	addMessage( 'assistant', config.greeting );
 	autosizeInput();
 
 	const setUnavailable = ( message = STRINGS.unavailable ) => {
 		root.classList.add( 'is-unavailable' );
 		input.disabled = true;
-		form.querySelector( 'button' ).disabled = true;
+		sendButton.disabled = true;
 		addMessage( 'system', message );
+	};
+
+	const startSession = async ( recordingConsent, choice ) => {
+		try {
+			const session = await client.session( recordingConsent );
+			sessionToken = session?.token || '';
+			if ( ! sessionToken ) {
+				setUnavailable();
+				return;
+			}
+
+			choice?.remove();
+			input.disabled = false;
+			sendButton.disabled = false;
+			addMessage( 'assistant', config.greeting );
+			if ( ! panel.hidden ) {
+				input.focus();
+			}
+		} catch {
+			setUnavailable();
+		}
+	};
+
+	const addRecordingChoice = ( recording ) => {
+		const choice = document.createElement( 'section' );
+		choice.className = 'sdaa-embed__recording-choice';
+		choice.setAttribute( 'aria-label', 'Conversation recording choice' );
+
+		const disclosure = document.createElement( 'p' );
+		disclosure.textContent =
+			typeof recording?.disclosure === 'string' && recording.disclosure
+				? recording.disclosure
+				: 'You can choose whether this conversation is retained for quality review.';
+		choice.appendChild( disclosure );
+
+		const note = document.createElement( 'p' );
+		note.className = 'sdaa-embed__recording-choice-note';
+		note.textContent =
+			'Choose an option before starting. Starting without recording keeps this chat out of administrator review.';
+		choice.appendChild( note );
+
+		const actions = document.createElement( 'div' );
+		actions.className = 'sdaa-embed__recording-actions';
+		const startWithoutRecording = document.createElement( 'button' );
+		startWithoutRecording.type = 'button';
+		startWithoutRecording.className = 'sdaa-embed__recording-decline';
+		startWithoutRecording.dataset.recordingConsent = 'false';
+		startWithoutRecording.textContent = 'Start without recording';
+		const agreeAndStart = document.createElement( 'button' );
+		agreeAndStart.type = 'button';
+		agreeAndStart.className = 'sdaa-embed__recording-accept';
+		agreeAndStart.dataset.recordingConsent = 'true';
+		agreeAndStart.textContent = 'Agree and start chat';
+		actions.append( startWithoutRecording, agreeAndStart );
+		choice.appendChild( actions );
+		messages.appendChild( choice );
+		messages.scrollTop = messages.scrollHeight;
+
+		const chooseRecording = ( recordingConsent ) => {
+			startWithoutRecording.disabled = true;
+			agreeAndStart.disabled = true;
+			startSession( recordingConsent, choice );
+		};
+		startWithoutRecording.addEventListener( 'click', () =>
+			chooseRecording( false )
+		);
+		agreeAndStart.addEventListener( 'click', () =>
+			chooseRecording( true )
+		);
 	};
 
 	client
@@ -606,12 +683,12 @@ export function mountEmbed( config ) {
 				return;
 			}
 
-			return client.session().then( ( session ) => {
-				sessionToken = session?.token || '';
-				if ( ! sessionToken ) {
-					setUnavailable();
-				}
-			} );
+			if ( serverConfig?.recording?.enabled ) {
+				addRecordingChoice( serverConfig.recording );
+				return;
+			}
+
+			return startSession( false );
 		} )
 		.catch( () => setUnavailable() );
 

--- a/src/embed-widget/style.css
+++ b/src/embed-widget/style.css
@@ -119,6 +119,53 @@
 	white-space: pre-wrap;
 }
 
+.sdaa-embed__recording-choice {
+	margin: 0 0 12px;
+	padding: 12px;
+	border: 1px solid var(--sdaa-embed-border);
+	border-radius: 12px;
+	background: var(--sdaa-embed-surface);
+	line-height: 1.45;
+}
+
+.sdaa-embed__recording-choice p {
+	margin: 0;
+}
+
+.sdaa-embed__recording-choice-note {
+	margin-top: 8px !important;
+	color: var(--sdaa-embed-muted);
+	font-size: 13px;
+}
+
+.sdaa-embed__recording-actions {
+	display: flex;
+	margin-top: 12px;
+	gap: 8px;
+}
+
+.sdaa-embed__recording-actions button {
+	flex: 1;
+	padding: 8px 10px;
+	border: 1px solid var(--sdaa-embed-border);
+	border-radius: 999px;
+	background: var(--sdaa-embed-surface);
+	color: var(--sdaa-embed-text);
+	cursor: pointer;
+	font: inherit;
+}
+
+.sdaa-embed__recording-actions .sdaa-embed__recording-accept {
+	border-color: var(--sdaa-embed-primary);
+	background: var(--sdaa-embed-primary);
+	color: #fff;
+}
+
+.sdaa-embed__recording-actions button:disabled {
+	cursor: wait;
+	opacity: 0.65;
+}
+
 .sdaa-embed__message--assistant p,
 .sdaa-embed__message--assistant ul,
 .sdaa-embed__message--assistant ol,

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -514,6 +514,15 @@ export default function SettingsApp() {
 		);
 	}
 
+	const publicChatReviewRetentionDays =
+		local.public_chat_review_retention_days || 7;
+	const publicChatReviewDisclosure =
+		local.public_chat_review_disclosure || '';
+	const updatePublicChatReviewRetention = ( value ) =>
+		updateField( 'public_chat_review_retention_days', value || 1 );
+	const updatePublicChatReviewDisclosure = ( value ) =>
+		updateField( 'public_chat_review_disclosure', value );
+
 	// Build provider/model options.
 	const providerOptions = [
 		{ label: __( '(default)', 'sd-ai-agent' ), value: '' },
@@ -684,6 +693,73 @@ export default function SettingsApp() {
 															}
 															__nextHasNoMarginBottom
 														/>
+													</td>
+												</tr>
+												<tr>
+													<th scope="row">
+														{ __(
+															'Anonymous Chat Review',
+															'superdav-ai-agent'
+														) }
+													</th>
+													<td>
+														<ToggleControl
+															label={ __(
+																'Allow visitors to opt in to anonymous chat review',
+																'superdav-ai-agent'
+															) }
+															checked={
+																!! local.public_chat_review_recording_enabled
+															}
+															onChange={ ( v ) =>
+																updateField(
+																	'public_chat_review_recording_enabled',
+																	v
+																)
+															}
+															help={ __(
+																'Visitors must explicitly consent before an anonymous public-chat transcript is retained for administrator review.',
+																'superdav-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+														{ local.public_chat_review_recording_enabled && (
+															<div className="sdaa-settings-public-review-controls">
+																<RangeControl
+																	label={ __(
+																		'Retention period (days)',
+																		'superdav-ai-agent'
+																	) }
+																	value={
+																		publicChatReviewRetentionDays
+																	}
+																	initialPosition={
+																		7
+																	}
+																	min={ 1 }
+																	max={ 90 }
+																	onChange={
+																		updatePublicChatReviewRetention
+																	}
+																/>
+																<TextareaControl
+																	label={ __(
+																		'Visitor disclosure',
+																		'superdav-ai-agent'
+																	) }
+																	value={
+																		publicChatReviewDisclosure
+																	}
+																	onChange={
+																		updatePublicChatReviewDisclosure
+																	}
+																	help={ __(
+																		'Leave blank to use the retention-aware default disclosure. The visitor sees this before starting chat.',
+																		'superdav-ai-agent'
+																	) }
+																/>
+															</div>
+														) }
 													</td>
 												</tr>
 												<tr>

--- a/src/unified-admin/router.js
+++ b/src/unified-admin/router.js
@@ -21,6 +21,11 @@ const AbilitiesRoute = lazy( () =>
 const ChangesRoute = lazy( () =>
 	import( /* webpackChunkName: "route-changes" */ './routes/changes' )
 );
+const CustomerConversationsRoute = lazy( () =>
+	import(
+		/* webpackChunkName: "route-customer-conversations" */ './routes/customer-conversations'
+	)
+);
 const SettingsRoute = lazy( () =>
 	import( /* webpackChunkName: "route-settings" */ './routes/settings' )
 );
@@ -71,6 +76,9 @@ export default function Router( { route } ) {
 
 		case 'changes':
 			return <ChangesRoute />;
+
+		case 'customer-conversations':
+			return <CustomerConversationsRoute />;
 
 		case 'connectors':
 			redirectConnectors();

--- a/src/unified-admin/routes/customer-conversations.css
+++ b/src/unified-admin/routes/customer-conversations.css
@@ -1,0 +1,136 @@
+.sd-ai-agent-customer-conversations {
+	max-width: 1280px;
+}
+
+.sd-ai-agent-customer-conversations__header,
+.sd-ai-agent-customer-conversations__detail-header,
+.sd-ai-agent-customer-conversations__pagination {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.sd-ai-agent-customer-conversations__header {
+	margin-bottom: 16px;
+}
+
+.sd-ai-agent-customer-conversations__header p,
+.sd-ai-agent-customer-conversations__detail > p {
+	max-width: 760px;
+	margin: 8px 0 0;
+	color: #50575e;
+}
+
+.sd-ai-agent-customer-conversations__filters {
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 150px, 1fr ) );
+	align-items: end;
+	gap: 12px;
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	background: #f6f7f7;
+}
+
+.sd-ai-agent-customer-conversations__filters .components-base-control {
+	margin-bottom: 0;
+}
+
+.sd-ai-agent-customer-conversations__layout {
+	display: grid;
+	grid-template-columns: minmax( 0, 2fr ) minmax( 300px, 1fr );
+	gap: 16px;
+	margin-top: 16px;
+}
+
+.sd-ai-agent-customer-conversations__list-meta {
+	margin-bottom: 8px;
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sd-ai-agent-customer-conversations__table-wrap {
+	overflow-x: auto;
+	border: 1px solid #dcdcde;
+}
+
+.sd-ai-agent-customer-conversations__table-wrap td {
+	vertical-align: middle;
+}
+
+.sd-ai-agent-customer-conversations__table-wrap td:nth-child( 3 ) {
+	min-width: 220px;
+	overflow-wrap: anywhere;
+}
+
+.sd-ai-agent-customer-conversations__loading,
+.sd-ai-agent-customer-conversations__empty,
+.sd-ai-agent-customer-conversations__detail {
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	background: #fff;
+}
+
+.sd-ai-agent-customer-conversations__pagination {
+	justify-content: flex-end;
+	margin-top: 12px;
+}
+
+.sd-ai-agent-customer-conversations__detail {
+	min-height: 240px;
+}
+
+.sd-ai-agent-customer-conversations__detail-header {
+	margin-bottom: 12px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.sd-ai-agent-customer-conversations__detail-header span {
+	display: block;
+	margin-top: 4px;
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sd-ai-agent-customer-conversations__transcript {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 12px 0;
+}
+
+.sd-ai-agent-customer-conversations__turn {
+	padding: 10px 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+	overflow-wrap: anywhere;
+}
+
+.sd-ai-agent-customer-conversations__turn--user {
+	border-color: #c5d9ed;
+	background: #f0f6fc;
+}
+
+.sd-ai-agent-customer-conversations__turn p {
+	margin: 6px 0 0;
+	white-space: pre-wrap;
+}
+
+@media (max-width: 900px) {
+	.sd-ai-agent-customer-conversations__layout {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media (max-width: 600px) {
+	.sd-ai-agent-customer-conversations__header {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.sd-ai-agent-customer-conversations__header .components-button {
+		width: 100%;
+		justify-content: center;
+	}
+}

--- a/src/unified-admin/routes/customer-conversations.js
+++ b/src/unified-admin/routes/customer-conversations.js
@@ -1,0 +1,640 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	Notice,
+	SelectControl,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './customer-conversations.css';
+
+const PAGE_SIZE = 20;
+
+const sourceOptions = [
+	{ label: __( 'All sources', 'superdav-ai-agent' ), value: '' },
+	{ label: __( 'Public chat', 'superdav-ai-agent' ), value: 'public_embed' },
+	{
+		label: __( 'Customer runtime', 'superdav-ai-agent' ),
+		value: 'customer_runtime',
+	},
+];
+
+const statusOptions = [
+	{ label: __( 'All statuses', 'superdav-ai-agent' ), value: '' },
+	{ label: __( 'Queued', 'superdav-ai-agent' ), value: 'queued' },
+	{
+		label: __( 'Processing', 'superdav-ai-agent' ),
+		value: 'processing',
+	},
+	{ label: __( 'Complete', 'superdav-ai-agent' ), value: 'complete' },
+	{ label: __( 'Failed', 'superdav-ai-agent' ), value: 'failed' },
+	{ label: __( 'Cancelled', 'superdav-ai-agent' ), value: 'cancelled' },
+];
+
+/**
+ * Render an administrator-only, sanitized conversation review interface.
+ *
+ * @return {JSX.Element} Customer conversation review route.
+ */
+export default function CustomerConversationsRoute() {
+	const [ draftFilters, setDraftFilters ] = useState( createInitialFilters );
+	const [ filters, setFilters ] = useState( createInitialFilters );
+	const [ offset, setOffset ] = useState( 0 );
+	const [ reviews, setReviews ] = useState( [] );
+	const [ total, setTotal ] = useState( 0 );
+	const [ loading, setLoading ] = useState( true );
+	const [ selected, setSelected ] = useState( null );
+	const [ detailLoading, setDetailLoading ] = useState( false );
+	const [ notice, setNotice ] = useState( null );
+	const [ confirmation, setConfirmation ] = useState( null );
+
+	const loadReviews = useCallback( async () => {
+		setLoading( true );
+		try {
+			const params = new URLSearchParams( {
+				limit: String( PAGE_SIZE ),
+				offset: String( offset ),
+			} );
+			Object.entries( filters ).forEach( ( [ key, value ] ) => {
+				if ( value ) {
+					params.set( key, value );
+				}
+			} );
+			const response = await apiFetch( {
+				path: `/sd-ai-agent/v1/customer-conversations?${ params.toString() }`,
+			} );
+			setReviews(
+				Array.isArray( response?.conversations )
+					? response.conversations
+					: []
+			);
+			setTotal( Number( response?.total ) || 0 );
+		} catch {
+			setReviews( [] );
+			setTotal( 0 );
+			setNotice( {
+				status: 'error',
+				message: __(
+					'Unable to load customer conversations.',
+					'superdav-ai-agent'
+				),
+			} );
+		} finally {
+			setLoading( false );
+		}
+	}, [ filters, offset ] );
+
+	useEffect( () => {
+		loadReviews();
+	}, [ loadReviews ] );
+
+	const loadDetail = useCallback(
+		async ( id, turnOffset = 0, appendOlderTurns = false ) => {
+			setDetailLoading( true );
+			try {
+				const response = await apiFetch( {
+					path: `/sd-ai-agent/v1/customer-conversations/${ encodeURIComponent(
+						id
+					) }?turn_limit=100&turn_offset=${ turnOffset }`,
+				} );
+				setSelected( ( current ) => {
+					if ( ! appendOlderTurns || current?.id !== response?.id ) {
+						return response;
+					}
+
+					return {
+						...response,
+						transcript: [
+							...( response.transcript || [] ),
+							...( current.transcript || [] ),
+						],
+					};
+				} );
+			} catch {
+				setNotice( {
+					status: 'error',
+					message: __(
+						'Unable to load this customer conversation.',
+						'superdav-ai-agent'
+					),
+				} );
+			} finally {
+				setDetailLoading( false );
+			}
+		},
+		[]
+	);
+
+	const applyFilters = ( event ) => {
+		event.preventDefault();
+		setOffset( 0 );
+		setFilters( draftFilters );
+	};
+
+	const updateDraftFilter = ( key, value ) => {
+		setDraftFilters( ( current ) => ( { ...current, [ key ]: value } ) );
+	};
+
+	const deleteReview = async () => {
+		if ( ! selected ) {
+			return;
+		}
+
+		try {
+			await apiFetch( {
+				path: `/sd-ai-agent/v1/customer-conversations/${ encodeURIComponent(
+					selected.id
+				) }`,
+				method: 'DELETE',
+			} );
+			setSelected( null );
+			setNotice( {
+				status: 'success',
+				message: __(
+					'Customer conversation deleted.',
+					'superdav-ai-agent'
+				),
+			} );
+			loadReviews();
+		} catch {
+			setNotice( {
+				status: 'error',
+				message: __(
+					'Unable to delete this customer conversation.',
+					'superdav-ai-agent'
+				),
+			} );
+		}
+	};
+
+	const purgeReviews = async () => {
+		try {
+			const response = await apiFetch( {
+				path: '/sd-ai-agent/v1/customer-conversations/purge',
+				method: 'POST',
+				data: { confirm: true, limit: 1000 },
+			} );
+			setSelected( null );
+			setNotice( {
+				status: 'success',
+				message: sprintf(
+					/* translators: %d: number of deleted retained customer conversations. */
+					__(
+						'Deleted %d retained customer conversations.',
+						'superdav-ai-agent'
+					),
+					Number( response?.purged ) || 0
+				),
+			} );
+			loadReviews();
+		} catch {
+			setNotice( {
+				status: 'error',
+				message: __(
+					'Unable to purge retained customer conversations.',
+					'superdav-ai-agent'
+				),
+			} );
+		}
+	};
+
+	const confirmAction = () => {
+		const action = confirmation;
+		setConfirmation( null );
+		if ( action === 'delete' ) {
+			deleteReview();
+			return;
+		}
+		if ( action === 'purge' ) {
+			purgeReviews();
+		}
+	};
+
+	let reviewList = null;
+	if ( loading ) {
+		reviewList = (
+			<div className="sd-ai-agent-customer-conversations__loading">
+				<Spinner />
+			</div>
+		);
+	} else if ( reviews.length === 0 ) {
+		reviewList = (
+			<p className="sd-ai-agent-customer-conversations__empty">
+				{ __(
+					'No retained customer conversations match these filters.',
+					'superdav-ai-agent'
+				) }
+			</p>
+		);
+	} else {
+		reviewList = <ReviewList reviews={ reviews } onSelect={ loadDetail } />;
+	}
+
+	return (
+		<div className="sdaa-route sd-ai-agent-customer-conversations">
+			<div className="sd-ai-agent-customer-conversations__header">
+				<div>
+					<h2>
+						{ __( 'Customer Conversations', 'superdav-ai-agent' ) }
+					</h2>
+					<p>
+						{ __(
+							'Review only sanitized, retained conversation content. Customer identifiers, tokens, tool data, and raw provider payloads are not shown here.',
+							'superdav-ai-agent'
+						) }
+					</p>
+				</div>
+				<Button
+					variant="secondary"
+					isDestructive
+					onClick={ () => setConfirmation( 'purge' ) }
+				>
+					{ __(
+						'Purge retained conversations',
+						'superdav-ai-agent'
+					) }
+				</Button>
+			</div>
+
+			{ notice && (
+				<Notice
+					status={ notice.status }
+					isDismissible
+					onDismiss={ () => setNotice( null ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
+
+			<FilterControls
+				filters={ draftFilters }
+				onChange={ updateDraftFilter }
+				onSubmit={ applyFilters }
+			/>
+
+			<div className="sd-ai-agent-customer-conversations__layout">
+				<section
+					aria-label={ __(
+						'Conversation summaries',
+						'superdav-ai-agent'
+					) }
+				>
+					<div className="sd-ai-agent-customer-conversations__list-meta">
+						{ sprintf(
+							/* translators: %d: number of retained conversations. */
+							__(
+								'%d retained conversations',
+								'superdav-ai-agent'
+							),
+							total
+						) }
+					</div>
+					{ reviewList }
+					<div className="sd-ai-agent-customer-conversations__pagination">
+						<Button
+							variant="secondary"
+							disabled={ offset === 0 || loading }
+							onClick={ () =>
+								setOffset( Math.max( 0, offset - PAGE_SIZE ) )
+							}
+						>
+							{ __( 'Previous', 'superdav-ai-agent' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							disabled={ offset + PAGE_SIZE >= total || loading }
+							onClick={ () => setOffset( offset + PAGE_SIZE ) }
+						>
+							{ __( 'Next', 'superdav-ai-agent' ) }
+						</Button>
+					</div>
+				</section>
+
+				<ConversationDetail
+					detail={ selected }
+					loading={ detailLoading }
+					onClose={ () => setSelected( null ) }
+					onDelete={ () => setConfirmation( 'delete' ) }
+					onLoadEarlier={ () =>
+						loadDetail(
+							selected.id,
+							Number( selected.transcript_offset ) +
+								Number( selected.transcript_limit ),
+							true
+						)
+					}
+				/>
+			</div>
+
+			{ confirmation && (
+				<ConfirmationModal
+					action={ confirmation }
+					onCancel={ () => setConfirmation( null ) }
+					onConfirm={ confirmAction }
+				/>
+			) }
+		</div>
+	);
+}
+
+/**
+ * Render review filter controls.
+ *
+ * @param {Object}   props          Filter control props.
+ * @param {Object}   props.filters  Current draft filters.
+ * @param {Function} props.onChange Filter change callback.
+ * @param {Function} props.onSubmit Filter submit callback.
+ * @return {JSX.Element} Filter controls.
+ */
+function FilterControls( { filters, onChange, onSubmit } ) {
+	return (
+		<form
+			className="sd-ai-agent-customer-conversations__filters"
+			onSubmit={ onSubmit }
+		>
+			<SelectControl
+				label={ __( 'Source', 'superdav-ai-agent' ) }
+				value={ filters.source }
+				options={ sourceOptions }
+				onChange={ ( value ) => onChange( 'source', value ) }
+			/>
+			<SelectControl
+				label={ __( 'Status', 'superdav-ai-agent' ) }
+				value={ filters.status }
+				options={ statusOptions }
+				onChange={ ( value ) => onChange( 'status', value ) }
+			/>
+			<TextControl
+				label={ __( 'Agent ID', 'superdav-ai-agent' ) }
+				type="number"
+				min="0"
+				value={ filters.agent }
+				onChange={ ( value ) => onChange( 'agent', value ) }
+			/>
+			<TextControl
+				label={ __( 'Search previews', 'superdav-ai-agent' ) }
+				value={ filters.search }
+				onChange={ ( value ) => onChange( 'search', value ) }
+			/>
+			<TextControl
+				label={ __( 'From date', 'superdav-ai-agent' ) }
+				type="date"
+				value={ filters.date_from }
+				onChange={ ( value ) => onChange( 'date_from', value ) }
+			/>
+			<TextControl
+				label={ __( 'To date', 'superdav-ai-agent' ) }
+				type="date"
+				value={ filters.date_to }
+				onChange={ ( value ) => onChange( 'date_to', value ) }
+			/>
+			<Button variant="primary" type="submit">
+				{ __( 'Apply filters', 'superdav-ai-agent' ) }
+			</Button>
+		</form>
+	);
+}
+
+/**
+ * Render a sanitized review summary table.
+ *
+ * @param {Object}   props          Summary list props.
+ * @param {Array}    props.reviews  Sanitized review summaries.
+ * @param {Function} props.onSelect Detail selection callback.
+ * @return {JSX.Element} Review summary table.
+ */
+function ReviewList( { reviews, onSelect } ) {
+	return (
+		<div className="sd-ai-agent-customer-conversations__table-wrap">
+			<table className="widefat striped">
+				<thead>
+					<tr>
+						<th scope="col">
+							{ __( 'Source', 'superdav-ai-agent' ) }
+						</th>
+						<th scope="col">
+							{ __( 'Status', 'superdav-ai-agent' ) }
+						</th>
+						<th scope="col">
+							{ __( 'Preview', 'superdav-ai-agent' ) }
+						</th>
+						<th scope="col">
+							{ __( 'Turns', 'superdav-ai-agent' ) }
+						</th>
+						<th scope="col">
+							{ __( 'Updated', 'superdav-ai-agent' ) }
+						</th>
+						<th scope="col">
+							<span className="screen-reader-text">
+								{ __( 'Actions', 'superdav-ai-agent' ) }
+							</span>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ reviews.map( ( review ) => (
+						<tr key={ review.id }>
+							<td>{ formatSource( review.source ) }</td>
+							<td>{ review.status || '—' }</td>
+							<td>{ review.preview || '—' }</td>
+							<td>{ Number( review.turn_count ) || 0 }</td>
+							<td>{ formatDate( review.updated_at ) }</td>
+							<td>
+								<Button
+									variant="tertiary"
+									onClick={ () => onSelect( review.id ) }
+								>
+									{ __( 'View', 'superdav-ai-agent' ) }
+								</Button>
+							</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+/**
+ * Render one bounded, sanitized review transcript.
+ *
+ * @param {Object}   props               Detail panel props.
+ * @param {Object}   props.detail        Sanitized review detail.
+ * @param {boolean}  props.loading       Whether a detail request is in progress.
+ * @param {Function} props.onClose       Detail close callback.
+ * @param {Function} props.onDelete      Deletion callback.
+ * @param {Function} props.onLoadEarlier Earlier-transcript callback.
+ * @return {JSX.Element} Detail panel.
+ */
+function ConversationDetail( {
+	detail,
+	loading,
+	onClose,
+	onDelete,
+	onLoadEarlier,
+} ) {
+	return (
+		<aside
+			className="sd-ai-agent-customer-conversations__detail"
+			aria-label={ __( 'Conversation detail', 'superdav-ai-agent' ) }
+		>
+			{ loading && <Spinner /> }
+			{ ! detail && ! loading && (
+				<p>
+					{ __(
+						'Select a conversation to view its sanitized transcript.',
+						'superdav-ai-agent'
+					) }
+				</p>
+			) }
+			{ detail && (
+				<>
+					<div className="sd-ai-agent-customer-conversations__detail-header">
+						<div>
+							<strong>{ formatSource( detail.source ) }</strong>
+							<span>{ detail.status || '—' }</span>
+						</div>
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Close', 'superdav-ai-agent' ) }
+						</Button>
+					</div>
+					{ detail.transcript_has_more && (
+						<Button
+							variant="secondary"
+							disabled={ loading }
+							onClick={ onLoadEarlier }
+						>
+							{ __(
+								'Load earlier messages',
+								'superdav-ai-agent'
+							) }
+						</Button>
+					) }
+					<div className="sd-ai-agent-customer-conversations__transcript">
+						{ ( detail.transcript || [] ).map( ( turn, index ) => (
+							<div
+								className={ `sd-ai-agent-customer-conversations__turn sd-ai-agent-customer-conversations__turn--${ turn.role }` }
+								key={ `${ turn.role }-${ index }` }
+							>
+								<strong>{ formatRole( turn.role ) }</strong>
+								<p>{ turn.content }</p>
+							</div>
+						) ) }
+					</div>
+					<Button
+						variant="secondary"
+						isDestructive
+						onClick={ onDelete }
+					>
+						{ __(
+							'Delete this conversation',
+							'superdav-ai-agent'
+						) }
+					</Button>
+				</>
+			) }
+		</aside>
+	);
+}
+
+/**
+ * Render confirmation before permanently deleting retained content.
+ *
+ * @param {Object}   props           Confirmation modal props.
+ * @param {string}   props.action    Destructive action identifier.
+ * @param {Function} props.onCancel  Cancellation callback.
+ * @param {Function} props.onConfirm Confirmation callback.
+ * @return {JSX.Element} Destructive-action confirmation modal.
+ */
+function ConfirmationModal( { action, onCancel, onConfirm } ) {
+	const isPurge = action === 'purge';
+	const title = isPurge
+		? __( 'Purge retained conversations?', 'superdav-ai-agent' )
+		: __( 'Delete retained conversation?', 'superdav-ai-agent' );
+	let message = __(
+		'This retained customer conversation will be permanently deleted. This cannot be undone.',
+		'superdav-ai-agent'
+	);
+	if ( isPurge ) {
+		message = __(
+			'All currently retained customer conversations will be permanently deleted. This cannot be undone.',
+			'superdav-ai-agent'
+		);
+	}
+
+	return (
+		<Modal title={ title } onRequestClose={ onCancel }>
+			<p>{ message }</p>
+			<div className="sd-ai-agent-customer-conversations__modal-actions">
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'superdav-ai-agent' ) }
+				</Button>
+				<Button variant="primary" isDestructive onClick={ onConfirm }>
+					{ __( 'Delete permanently', 'superdav-ai-agent' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}
+
+/**
+ * @return {Object} Empty review filters.
+ */
+function createInitialFilters() {
+	return {
+		source: '',
+		status: '',
+		agent: '',
+		search: '',
+		date_from: '',
+		date_to: '',
+	};
+}
+
+/**
+ * @param {string} source Stored safe source enum.
+ * @return {string} Human-readable source label.
+ */
+function formatSource( source ) {
+	if ( source === 'public_embed' ) {
+		return __( 'Public chat', 'superdav-ai-agent' );
+	}
+	if ( source === 'customer_runtime' ) {
+		return __( 'Customer runtime', 'superdav-ai-agent' );
+	}
+
+	return __( 'Unknown', 'superdav-ai-agent' );
+}
+
+/**
+ * @param {string} role Stored safe turn role.
+ * @return {string} Human-readable turn role.
+ */
+function formatRole( role ) {
+	return role === 'assistant'
+		? __( 'Assistant', 'superdav-ai-agent' )
+		: __( 'Visitor', 'superdav-ai-agent' );
+}
+
+/**
+ * @param {string} value UTC MySQL timestamp.
+ * @return {string} Localized timestamp or a neutral fallback.
+ */
+function formatDate( value ) {
+	if ( ! value ) {
+		return '—';
+	}
+
+	const date = new Date( `${ value }Z` );
+	return Number.isNaN( date.getTime() ) ? '—' : date.toLocaleString();
+}

--- a/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -114,6 +114,16 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 		$this->assertContains( 'settings', $slugs );
 	}
 
+	/** Customer-conversation review remains an administrator-only menu route. */
+	public function test_get_menu_items_includes_customer_conversations(): void {
+		$items = UnifiedAdminMenu::getMenuItems();
+		$item  = array_values( array_filter( $items, static fn( array $menu_item ): bool => 'customer-conversations' === $menu_item['slug'] ) );
+
+		$this->assertCount( 1, $item );
+		$this->assertSame( 25, $item[0]['position'] );
+		$this->assertSame( UnifiedAdminMenu::CAPABILITY, $item[0]['capability'] );
+	}
+
 	/**
 	 * Test each menu item has required keys.
 	 */

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -502,6 +502,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 			$this->assertContains( $column, $review_columns, "Customer conversation review table missing column '{$column}'." );
 		}
 		$this->assertNotContains( 'profile_id', $review_columns, 'Review projections must not retain runtime profile identifiers.' );
+		$this->assertNotContains( 'transcript', $review_columns, 'Review transcripts must remain normalized in the bounded turns table.' );
 
 		$turn_columns = $this->get_column_names( CustomerConversationReviewRepository::turns_table_name() );
 		foreach ( [ 'review_id', 'source_event_id', 'role', 'event_status', 'content', 'created_at' ] as $column ) {

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -22,6 +22,7 @@ use SdAiAgent\Bootstrap\CustomerAgentRuntimeHandler;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Knowledge\KnowledgeDatabase;
 use SdAiAgent\Models\Agent;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
 use WP_UnitTestCase;
 use XWP\DI\Decorators\Action;
 
@@ -69,6 +70,8 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'sd_ai_agent_durable_plan_steps',
 		'sd_ai_agent_customer_agent_conversations',
 		'sd_ai_agent_customer_agent_jobs',
+		'sd_ai_agent_customer_conversation_reviews',
+		'sd_ai_agent_customer_conversation_review_turns',
 		'sd_ai_agent_skill_usage',
 		'sd_ai_agent_contact_mappings',
 	];
@@ -486,6 +489,28 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		foreach ( [ 'job_id', 'conversation_id', 'external_message_hash', 'status', 'request_payload', 'result_payload', 'error_code', 'deadline_at', 'expires_at' ] as $column ) {
 			$this->assertContains( $column, $job_columns, "Customer-agent job table missing column '{$column}'." );
 		}
+	}
+
+	/** Customer review projection tables exclude runtime profile identifiers. */
+	public function test_customer_conversation_review_tables_have_safe_columns_and_indexes(): void {
+		global $wpdb;
+
+		Database::install();
+
+		$review_columns = $this->get_column_names( CustomerConversationReviewRepository::table_name() );
+		foreach ( [ 'review_id', 'runtime_conversation_id', 'source', 'agent_id', 'summary', 'turn_count', 'expires_at', 'deleted_at' ] as $column ) {
+			$this->assertContains( $column, $review_columns, "Customer conversation review table missing column '{$column}'." );
+		}
+		$this->assertNotContains( 'profile_id', $review_columns, 'Review projections must not retain runtime profile identifiers.' );
+
+		$turn_columns = $this->get_column_names( CustomerConversationReviewRepository::turns_table_name() );
+		foreach ( [ 'review_id', 'source_event_id', 'role', 'event_status', 'content', 'created_at' ] as $column ) {
+			$this->assertContains( $column, $turn_columns, "Customer conversation review turns table missing column '{$column}'." );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only schema index introspection.
+		$summary_index = $wpdb->get_row( $wpdb->prepare( 'SHOW INDEX FROM %i WHERE Key_name = %s', CustomerConversationReviewRepository::table_name(), 'review_summary' ) );
+		$this->assertNotNull( $summary_index, 'Customer conversation review summaries require a FULLTEXT search index.' );
 	}
 
 	/** Managed customer-agent metadata is explicit and indexed for lifecycle lookup. */

--- a/tests/SdAiAgent/Models/CustomerConversationReviewRepositoryTest.php
+++ b/tests/SdAiAgent/Models/CustomerConversationReviewRepositoryTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for privacy-safe customer conversation review projections.
+ *
+ * @package SdAiAgent\Tests\Models
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Models;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
+use WP_UnitTestCase;
+
+/** Covers sanitization, redaction, projection boundaries, and tombstones. */
+final class CustomerConversationReviewRepositoryTest extends WP_UnitTestCase {
+
+	/** Install and clear the review tables before each test. */
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( Database::DB_VERSION_OPTION );
+		Database::install();
+		$this->clear_reviews();
+	}
+
+	/** Remove review rows after each test. */
+	public function tear_down(): void {
+		$this->clear_reviews();
+		parent::tear_down();
+	}
+
+	/** Direct turns remove hidden reasoning and durable credential values. */
+	public function test_direct_turns_strip_hidden_reasoning_and_redact_credentials(): void {
+		$review_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_public_review(
+				$review_id,
+				7,
+				'provider',
+				'model',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS )
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_public_turn(
+				$review_id,
+				'event-1',
+				'assistant',
+				'Visible answer <thinking>private chain of thought</thinking> Authorization: Bearer review-secret.',
+				'complete'
+			)
+		);
+
+		$review = CustomerConversationReviewRepository::get_review( $review_id );
+		$this->assertIsArray( $review );
+		$this->assertSame( 'Visible answer  Authorization: [redacted]', $review['transcript'][0]['content'] );
+		$this->assertStringNotContainsString( 'private chain of thought', $review['transcript'][0]['content'] );
+		$this->assertStringNotContainsString( 'review-secret', $review['transcript'][0]['content'] );
+		$this->assertArrayNotHasKey( 'runtime_conversation_id', $review );
+		$this->assertArrayNotHasKey( 'profile_id', $review );
+	}
+
+	/** Runtime summaries never expose the private source conversation identifier. */
+	public function test_runtime_summary_omits_private_source_identifiers_and_transcripts(): void {
+		$review_id       = wp_generate_uuid4();
+		$conversation_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_runtime_review(
+				$review_id,
+				$conversation_id,
+				'provider',
+				'model',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS ),
+				42
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_runtime_turn(
+				$conversation_id,
+				'event-1',
+				'user',
+				'Customer-visible question',
+				'queued'
+			)
+		);
+
+		$summaries = CustomerConversationReviewRepository::list_reviews(
+			array(
+				'source' => CustomerConversationReviewRepository::SOURCE_CUSTOMER_RUNTIME,
+				'agent'  => '42',
+			)
+		);
+		$this->assertCount( 1, $summaries );
+		$this->assertSame( $review_id, $summaries[0]['id'] );
+		$this->assertArrayNotHasKey( 'runtime_conversation_id', $summaries[0] );
+		$this->assertArrayNotHasKey( 'transcript', $summaries[0] );
+		$this->assertStringNotContainsString( $conversation_id, (string) wp_json_encode( $summaries[0] ) );
+		$this->assertCount(
+			0,
+			CustomerConversationReviewRepository::list_reviews(
+				array( 'agent' => '43' )
+			)
+		);
+	}
+
+	/** Tombstones delete retained turns and prevent later retry writes from restoring them. */
+	public function test_delete_tombstones_content_idempotently(): void {
+		$review_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_public_review(
+				$review_id,
+				0,
+				'',
+				'',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS )
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_public_turn(
+				$review_id,
+				'event-1',
+				'user',
+				'Remove this retained text.',
+				'complete'
+			)
+		);
+
+		$this->assertTrue( CustomerConversationReviewRepository::delete_review( $review_id ) );
+		$this->assertTrue( CustomerConversationReviewRepository::delete_review( $review_id ) );
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_public_turn(
+				$review_id,
+				'event-1',
+				'assistant',
+				'Retry must not restore text.',
+				'complete'
+			)
+		);
+		$this->assertNull( CustomerConversationReviewRepository::get_review( $review_id ) );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies a test tombstone physically removed retained turn content.
+		$turn_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE review_id = %s',
+				CustomerConversationReviewRepository::turns_table_name(),
+				$review_id
+			)
+		);
+		$this->assertSame( 0, $turn_count );
+	}
+
+	/** Expired review content is physically removed while the shell becomes a tombstone. */
+	public function test_expiry_cleanup_tombstones_retained_content(): void {
+		$review_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_public_review(
+				$review_id,
+				0,
+				'',
+				'',
+				gmdate( 'Y-m-d H:i:s', time() - HOUR_IN_SECONDS )
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_public_turn(
+				$review_id,
+				'event-1',
+				'user',
+				'Expired retained text.',
+				'complete'
+			)
+		);
+
+		$this->assertSame( 1, CustomerConversationReviewRepository::purge_expired_reviews() );
+		$this->assertNull( CustomerConversationReviewRepository::get_review( $review_id ) );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies expiry cleanup removed bounded retained turn content.
+		$turn_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE review_id = %s',
+				CustomerConversationReviewRepository::turns_table_name(),
+				$review_id
+			)
+		);
+		$this->assertSame( 0, $turn_count );
+	}
+
+	/** Destroying a runtime source removes its review projection rather than retaining it. */
+	public function test_runtime_source_cleanup_removes_its_review_projection(): void {
+		$review_id       = wp_generate_uuid4();
+		$conversation_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_runtime_review(
+				$review_id,
+				$conversation_id,
+				'provider',
+				'model',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS )
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_runtime_turn(
+				$conversation_id,
+				'event-1',
+				'user',
+				'Runtime content to remove.',
+				'complete'
+			)
+		);
+
+		$this->assertTrue(
+			CustomerConversationReviewRepository::delete_by_runtime_conversation(
+				$conversation_id
+			)
+		);
+		$this->assertNull( CustomerConversationReviewRepository::get_review( $review_id ) );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies source lifecycle cleanup removes the projection shell.
+		$review_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE review_id = %s',
+				CustomerConversationReviewRepository::table_name(),
+				$review_id
+			)
+		);
+		$this->assertSame( 0, $review_count );
+	}
+
+	/** Clear dependent turns before their review shells. */
+	private function clear_reviews(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of minimized review turns.
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				CustomerConversationReviewRepository::turns_table_name()
+			)
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of review shells.
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				CustomerConversationReviewRepository::table_name()
+			)
+		);
+	}
+}

--- a/tests/SdAiAgent/Models/CustomerConversationReviewRepositoryTest.php
+++ b/tests/SdAiAgent/Models/CustomerConversationReviewRepositoryTest.php
@@ -161,7 +161,7 @@ final class CustomerConversationReviewRepositoryTest extends WP_UnitTestCase {
 				0,
 				'',
 				'',
-				gmdate( 'Y-m-d H:i:s', time() - HOUR_IN_SECONDS )
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS )
 			)
 		);
 		$this->assertTrue(
@@ -174,10 +174,28 @@ final class CustomerConversationReviewRepositoryTest extends WP_UnitTestCase {
 			)
 		);
 
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Moves a retained test review past its expiry boundary after content was validly written.
+		$wpdb->update(
+			CustomerConversationReviewRepository::table_name(),
+			array( 'expires_at' => gmdate( 'Y-m-d H:i:s', time() - HOUR_IN_SECONDS ) ),
+			array( 'review_id' => $review_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+		$this->assertFalse(
+			CustomerConversationReviewRepository::append_public_turn(
+				$review_id,
+				'event-2',
+				'assistant',
+				'Late content must not be retained.',
+				'complete'
+			)
+		);
+
 		$this->assertSame( 1, CustomerConversationReviewRepository::purge_expired_reviews() );
 		$this->assertNull( CustomerConversationReviewRepository::get_review( $review_id ) );
 
-		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verifies expiry cleanup removed bounded retained turn content.
 		$turn_count = (int) $wpdb->get_var(
 			$wpdb->prepare(

--- a/tests/SdAiAgent/REST/CustomerConversationControllerTest.php
+++ b/tests/SdAiAgent/REST/CustomerConversationControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the customer conversation review controller.
+ *
+ * @package SdAiAgent\Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
+use SdAiAgent\REST\CustomerConversationController;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+/** Covers administrator authorization and the safe review-controller DTO boundary. */
+final class CustomerConversationControllerTest extends WP_UnitTestCase {
+
+	private CustomerConversationController $controller;
+
+	private int $admin_id;
+
+	private int $subscriber_id;
+
+	/** Set up the controller, custom tables, and test users. */
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( Database::DB_VERSION_OPTION );
+		Database::install();
+		$this->clear_reviews();
+		$this->controller    = new CustomerConversationController();
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/** Clear custom review rows. */
+	public function tear_down(): void {
+		$this->clear_reviews();
+		parent::tear_down();
+	}
+
+	/** The shared controller guard accepts only administrators. */
+	public function test_permission_guard_requires_manage_options(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( $this->controller->check_permission() );
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	/** Admin list and detail responses exclude private runtime source identifiers. */
+	public function test_admin_list_and_detail_return_only_sanitized_review_data(): void {
+		wp_set_current_user( $this->admin_id );
+		$review_id       = wp_generate_uuid4();
+		$conversation_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_runtime_review(
+				$review_id,
+				$conversation_id,
+				'provider',
+				'model',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS ),
+				5
+			)
+		);
+		$this->assertTrue(
+			CustomerConversationReviewRepository::append_runtime_turn(
+				$conversation_id,
+				'event-1',
+				'user',
+				'Customer-visible question',
+				'queued'
+			)
+		);
+
+		$list = $this->controller->handle_list_customer_conversations(
+			new WP_REST_Request( 'GET', '/sd-ai-agent/v1/customer-conversations' )
+		);
+		$this->assertSame( 200, $list->get_status() );
+		$this->assertSame( $review_id, $list->get_data()['conversations'][0]['id'] );
+		$this->assertStringNotContainsString( $conversation_id, (string) wp_json_encode( $list->get_data() ) );
+		$this->assertArrayNotHasKey( 'transcript', $list->get_data()['conversations'][0] );
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/sd-ai-agent/v1/customer-conversations/' . $review_id
+		);
+		$request->set_param( 'id', $review_id );
+		$detail = $this->controller->handle_get_customer_conversation( $request );
+		$this->assertSame( 200, $detail->get_status() );
+		$this->assertStringNotContainsString( $conversation_id, (string) wp_json_encode( $detail->get_data() ) );
+		$this->assertSame( 'Customer-visible question', $detail->get_data()['transcript'][0]['content'] );
+	}
+
+	/** Purge rejects omitted confirmation and deletes reviews only after confirmation. */
+	public function test_purge_requires_confirmation_and_tombstones_retained_reviews(): void {
+		wp_set_current_user( $this->admin_id );
+		$review_id = wp_generate_uuid4();
+		$this->assertTrue(
+			CustomerConversationReviewRepository::create_public_review(
+				$review_id,
+				0,
+				'',
+				'',
+				gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS )
+			)
+		);
+
+		$unconfirmed = $this->controller->handle_purge_customer_conversations(
+			new WP_REST_Request( 'POST', '/sd-ai-agent/v1/customer-conversations/purge' )
+		);
+		$this->assertWPError( $unconfirmed );
+		$this->assertSame(
+			'sd_ai_agent_customer_conversation_purge_confirmation_required',
+			$unconfirmed->get_error_code()
+		);
+
+		$request = new WP_REST_Request(
+			'POST',
+			'/sd-ai-agent/v1/customer-conversations/purge'
+		);
+		$request->set_param( 'confirm', true );
+		$request->set_param( 'limit', 1 );
+		$confirmed = $this->controller->handle_purge_customer_conversations( $request );
+		$this->assertSame( 200, $confirmed->get_status() );
+		$this->assertSame( 1, $confirmed->get_data()['purged'] );
+		$this->assertNull( CustomerConversationReviewRepository::get_review( $review_id ) );
+	}
+
+	/** Remove dependent turns before review shells. */
+	private function clear_reviews(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of minimized review turns.
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				CustomerConversationReviewRepository::turns_table_name()
+			)
+		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of review shells.
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				CustomerConversationReviewRepository::table_name()
+			)
+		);
+	}
+}

--- a/tests/SdAiAgent/REST/PublicChatControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicChatControllerTest.php
@@ -37,6 +37,7 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 		do_action( 'rest_api_init' );
 
 		parent::set_up();
+		$this->clear_customer_conversation_reviews();
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/PublicChatControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicChatControllerTest.php
@@ -12,6 +12,7 @@ namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Models\ActiveJobRepository;
+use SdAiAgent\Models\CustomerConversationReviewRepository;
 use SdAiAgent\REST\RestController;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -44,6 +45,7 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 	public function tear_down(): void {
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		$this->clear_customer_conversation_reviews();
 		delete_option( Settings::OPTION_NAME );
 
 		parent::tear_down();
@@ -168,6 +170,53 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 
 		ActiveJobRepository::delete( $data['job_id'] );
 		delete_transient( RestController::JOB_PREFIX . $data['job_id'] );
+	}
+
+	/** Public recording is disclosed and stored only after explicit session consent. */
+	public function test_public_review_recording_requires_explicit_session_consent(): void {
+		$this->enable_public_chat();
+		Settings::instance()->update(
+			array(
+				'public_chat_review_recording_enabled' => true,
+				'public_chat_review_retention_days'    => 14,
+				'public_chat_review_disclosure'        => 'Opt in before this chat is retained for review.',
+			)
+		);
+
+		$config = $this->dispatch( 'GET', '/sd-ai-agent/v1/public-chat/config' );
+		$this->assertSame( 200, $config->get_status() );
+		$this->assertSame(
+			array(
+				'enabled'        => true,
+				'retention_days' => 14,
+				'disclosure'     => 'Opt in before this chat is retained for review.',
+			),
+			$config->get_data()['recording']
+		);
+
+		$without_consent = $this->dispatch( 'POST', '/sd-ai-agent/v1/public-chat/session', array( 'recording_consent' => false ) );
+		$this->assertSame( 201, $without_consent->get_status() );
+		$this->assertArrayNotHasKey( 'review_id', $without_consent->get_data() );
+		$this->assertCount( 0, CustomerConversationReviewRepository::list_reviews( array() ) );
+
+		$with_consent = $this->dispatch( 'POST', '/sd-ai-agent/v1/public-chat/session', array( 'recording_consent' => true ) );
+		$this->assertSame( 201, $with_consent->get_status() );
+		$this->assertArrayNotHasKey( 'review_id', $with_consent->get_data() );
+
+		$reviews = CustomerConversationReviewRepository::list_reviews( array() );
+		$this->assertCount( 1, $reviews );
+		$this->assertSame( CustomerConversationReviewRepository::SOURCE_PUBLIC_EMBED, $reviews[0]['source'] );
+		$this->assertStringNotContainsString( $reviews[0]['id'], $with_consent->get_data()['token'] );
+	}
+
+	/** Remove test-only review projections and turns. */
+	private function clear_customer_conversation_reviews(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of the dependent minimized turn rows.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', CustomerConversationReviewRepository::turns_table_name() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup of the customer-review projection rows.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', CustomerConversationReviewRepository::table_name() ) );
 	}
 
 	/** An operator may disable all public tools without silently restoring knowledge search. */

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -168,6 +168,9 @@ class RestControllerTest extends WP_UnitTestCase {
 			'/sd-ai-agent/v1/public-chat/session',
 			'/sd-ai-agent/v1/public-chat/run',
 			'/sd-ai-agent/v1/public-chat/job/(?P<id>[a-f0-9-]+)',
+			'/sd-ai-agent/v1/customer-conversations',
+			'/sd-ai-agent/v1/customer-conversations/(?P<id>[a-f0-9-]+)',
+			'/sd-ai-agent/v1/customer-conversations/purge',
 			'/sd-ai-agent/v1/job/(?P<id>[a-f0-9-]+)',
 			'/sd-ai-agent/v1/process',
 			'/sd-ai-agent/v1/abilities',
@@ -229,6 +232,27 @@ class RestControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/abilities' );
 		$this->assertStatus( 200, $response );
 		$this->assertIsArray( $response->get_data() );
+	}
+
+	/** Customer conversation review routes remain limited to administrators. */
+	public function test_customer_conversation_reviews_require_manage_options(): void {
+		wp_set_current_user( 0 );
+		$this->assertStatus(
+			401,
+			$this->dispatch( 'GET', '/sd-ai-agent/v1/customer-conversations' )
+		);
+
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertStatus(
+			403,
+			$this->dispatch( 'GET', '/sd-ai-agent/v1/customer-conversations' )
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertStatus(
+			200,
+			$this->dispatch( 'GET', '/sd-ai-agent/v1/customer-conversations' )
+		);
 	}
 
 	// ─── /providers ──────────────────────────────────────────────────────────

--- a/uninstall.php
+++ b/uninstall.php
@@ -37,6 +37,8 @@ $sd_ai_agent_tables = [
 	$wpdb->prefix . 'sd_ai_agent_benchmark_runs',
 	$wpdb->prefix . 'sd_ai_agent_benchmark_results',
 	$wpdb->prefix . 'sd_ai_agent_skill_usage',
+	$wpdb->prefix . 'sd_ai_agent_customer_conversation_reviews',
+	$wpdb->prefix . 'sd_ai_agent_customer_conversation_review_turns',
 ];
 
 foreach ( $sd_ai_agent_tables as $sd_ai_agent_table ) {
@@ -81,6 +83,7 @@ $sd_ai_agent_cron_hooks = [
 	'sd_ai_agent_run_event_automation',
 	'sd_ai_agent_site_scan',
 	'sd_ai_agent_reindex',
+	'sd_ai_agent_customer_conversation_review_cleanup',
 ];
 
 foreach ( $sd_ai_agent_cron_hooks as $sd_ai_agent_hook ) {


### PR DESCRIPTION
Resolves #2545

## Summary

- adds an admin-only Customer Conversations list and sanitized transcript detail view
- uses a dedicated normalized review projection rather than exposing runtime rows or normal user sessions
- keeps anonymous public-chat retention disabled by default and requires an explicit widget recording choice before durable storage
- projects already-durable customer-runtime history into the review model, as required for safe upgrade visibility
- provides bounded pagination, expiry cleanup, source-scoped deletion, explicit purge confirmation, and server-side redaction
- preserves customer-runtime execution, idempotency, authorization, and seven-day operational retention contracts

## Architecture decision

The implementation uses a dedicated normalized review projection. Customer and assistant display text is sanitized before projection persistence; private runtime payloads, signed tokens, source hashes, profile snapshots, tool payloads, and internal identifiers are not exposed by review DTOs. Projection writes fail open so review storage cannot block customer responses.

Anonymous widget recording is a separate opt-in setting and remains disabled on install and upgrade. Existing durable customer-runtime records are reconciled in bounded batches because #2545 explicitly requires safely classifiable retained runtime conversations to become reviewable.

## Repair notes

The recovered worker branch initially leaked nested transaction boundaries into WordPress PHPUnit isolation. Commit `a9372a66` changes repository transactions to use savepoints when a caller already owns the transaction. It also rejects writes after expiry, serializes runtime-source deletion against append operations, removes an unused denormalized transcript column, and adds regression coverage.

## Worker self-verification
- PHPUnit: Tests: 4167, Assertions: 18906, Errors: 0, Failures: 0, Skipped: 136, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

The prior Playwright CI jobs failed while building the shared `wp-env` Docker environment, before application assertions. A fresh CI run is required on this pushed commit.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol spent 4h 37m and 1,045,170 tokens on this with the user in an interactive session.