### PR TITLE
fix: normalize onboarding stock fallback

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4250,24 +4250,26 @@ PROMPT;
 	}
 
 	/** Convert the second bounded stock search into the documented automatic-import fallback. */
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Project variable naming guidance requires camelCase.
 	private static function convert_stock_image_search_to_auto_import( FunctionCall $call ): FunctionCall {
-		$args          = self::normalize_function_call_args( $call->getArgs() );
-		$is_dispatcher = 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() );
-		$stock_args    = $is_dispatcher && isset( $args['arguments'] ) && is_array( $args['arguments'] )
+		$args         = self::normalize_function_call_args( $call->getArgs() );
+		$isDispatcher = 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() );
+		$stockArgs    = $isDispatcher && isset( $args['arguments'] ) && is_array( $args['arguments'] )
 			? $args['arguments']
 			: $args;
 
-		unset( $stock_args['action'], $stock_args['provider'], $stock_args['image_id'], $stock_args['limit'] );
-		$stock_args['keyword'] = self::shorten_stock_image_keyword( (string) ( $stock_args['keyword'] ?? '' ) );
+		unset( $stockArgs['action'], $stockArgs['provider'], $stockArgs['image_id'], $stockArgs['limit'] );
+		$stockArgs['keyword'] = self::shorten_stock_image_keyword( (string) ( $stockArgs['keyword'] ?? '' ) );
 
-		if ( $is_dispatcher ) {
-			$args['arguments'] = $stock_args;
+		if ( $isDispatcher ) {
+			$args['arguments'] = $stockArgs;
 		} else {
-			$args = $stock_args;
+			$args = $stockArgs;
 		}
 
 		return new FunctionCall( (string) $call->getId(), (string) $call->getName(), $args );
 	}
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	/** Keep automatic-import fallback searches concrete instead of over-specific. */
 	private static function shorten_stock_image_keyword( string $keyword ): string {

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4111,8 +4111,9 @@ PROMPT;
 			}
 		}
 
-		$kept    = array();
-		$removed = array_fill_keys( array_keys( $limits ), 0 );
+		$kept      = array();
+		$removed   = array_fill_keys( array_keys( $limits ), 0 );
+		$rewritten = 0;
 		foreach ( $message->getParts() as $part ) {
 			$call = $part->getFunctionCall();
 			if ( ! $call ) {
@@ -4131,13 +4132,46 @@ PROMPT;
 				continue;
 			}
 
+			if (
+				'sd-ai-agent/stock-image' === $ability_name
+				&& 1 === $used[ $ability_name ]
+				&& self::is_stock_image_search_call( $call )
+			) {
+				$part = new MessagePart( self::convert_stock_image_search_to_auto_import( $call ) );
+				++$rewritten;
+			}
+
 			++$used[ $ability_name ];
 			$kept[] = $part;
 		}
 
 		$removed = array_filter( $removed );
+		if ( $rewritten > 0 ) {
+			$this->message_log[] = array(
+				'type'     => 'guardrail',
+				'reason'   => 'onboarding_stock_fallback_normalized',
+				'count'    => $rewritten,
+				'sequence' => $this->next_activity_sequence(),
+			);
+			AgentEventLog::log(
+				'onboarding_stock_fallback_normalized',
+				AgentEventLog::SEVERITY_INFO,
+				array(
+					'session_id'  => $this->session_id,
+					'count'       => $rewritten,
+					'model_id'    => (string) $this->model_id,
+					'provider_id' => (string) $this->provider_id,
+				)
+			);
+		}
 		if ( empty( $removed ) ) {
-			return $unchanged;
+			return $rewritten > 0
+				? array(
+					'message'  => new ModelMessage( $kept ),
+					'guidance' => '',
+					'removed'  => array(),
+				)
+				: $unchanged;
 		}
 		if ( empty( $kept ) ) {
 			$kept[] = new MessagePart( __( 'Media acquisition call blocked by the Setup Assistant budget.', 'superdav-ai-agent' ) );
@@ -4203,6 +4237,46 @@ PROMPT;
 			'guidance' => $guidance,
 			'removed'  => $removed,
 		);
+	}
+
+	/** Return whether a direct or dispatcher stock-image call requests search mode. */
+	private static function is_stock_image_search_call( FunctionCall $call ): bool {
+		$args = self::normalize_function_call_args( $call->getArgs() );
+		if ( 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() ) ) {
+			$args = isset( $args['arguments'] ) && is_array( $args['arguments'] ) ? $args['arguments'] : array();
+		}
+
+		return 'search' === (string) ( $args['action'] ?? '' );
+	}
+
+	/** Convert the second bounded stock search into the documented automatic-import fallback. */
+	private static function convert_stock_image_search_to_auto_import( FunctionCall $call ): FunctionCall {
+		$args          = self::normalize_function_call_args( $call->getArgs() );
+		$is_dispatcher = 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() );
+		$stock_args    = $is_dispatcher && isset( $args['arguments'] ) && is_array( $args['arguments'] )
+			? $args['arguments']
+			: $args;
+
+		unset( $stock_args['action'], $stock_args['provider'], $stock_args['image_id'], $stock_args['limit'] );
+		$stock_args['keyword'] = self::shorten_stock_image_keyword( (string) ( $stock_args['keyword'] ?? '' ) );
+
+		if ( $is_dispatcher ) {
+			$args['arguments'] = $stock_args;
+		} else {
+			$args = $stock_args;
+		}
+
+		return new FunctionCall( (string) $call->getId(), (string) $call->getName(), $args );
+	}
+
+	/** Keep automatic-import fallback searches concrete instead of over-specific. */
+	private static function shorten_stock_image_keyword( string $keyword ): string {
+		$words = preg_split( '/\s+/', trim( $keyword ) );
+		if ( ! is_array( $words ) ) {
+			return trim( $keyword );
+		}
+
+		return implode( ' ', array_slice( array_filter( $words ), 0, 3 ) );
 	}
 
 	/** Return the bounded media ability represented by a direct or dispatcher call. */

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3780,15 +3780,15 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $result['removed'] );
 		$parts = $result['message']->getParts();
 		$this->assertCount( 2, $parts );
-		$first_args  = $parts[0]->getFunctionCall()->getArgs();
-		$second_args = $parts[1]->getFunctionCall()->getArgs();
-		$this->assertSame( 'search', $first_args['action'] );
-		$this->assertArrayNotHasKey( 'action', $second_args );
-		$this->assertArrayNotHasKey( 'provider', $second_args );
-		$this->assertArrayNotHasKey( 'limit', $second_args );
-		$this->assertSame( 'portrait photography studio', $second_args['keyword'] );
+		$firstArgs  = $parts[0]->getFunctionCall()->getArgs();
+		$secondArgs = $parts[1]->getFunctionCall()->getArgs();
+		$this->assertSame( 'search', $firstArgs['action'] );
+		$this->assertArrayNotHasKey( 'action', $secondArgs );
+		$this->assertArrayNotHasKey( 'provider', $secondArgs );
+		$this->assertArrayNotHasKey( 'limit', $secondArgs );
+		$this->assertSame( 'portrait photography studio', $secondArgs['keyword'] );
 
-		$dispatcher_loop = new AgentLoop(
+		$dispatcherLoop = new AgentLoop(
 			'Build a photographer site',
 			array(),
 			array(
@@ -3800,8 +3800,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 			),
 			array( 'agent_slug' => 'onboarding' )
 		);
-		$dispatcher_result = $method->invoke(
-			$dispatcher_loop,
+		$dispatcherResult = $method->invoke(
+			$dispatcherLoop,
 			new ModelMessage(
 				array(
 					new MessagePart(
@@ -3818,12 +3818,12 @@ class AgentLoopTest extends WP_UnitTestCase {
 			)
 		);
 
-		$dispatcher_call = $dispatcher_result['message']->getParts()[0]->getFunctionCall();
-		$dispatcher_args = $dispatcher_call->getArgs();
-		$this->assertSame( 'sd-ai-agent/stock-image', $dispatcher_args['ability'] );
-		$this->assertArrayNotHasKey( 'action', $dispatcher_args['arguments'] );
-		$this->assertArrayNotHasKey( 'provider', $dispatcher_args['arguments'] );
-		$this->assertSame( 'outdoor family portrait', $dispatcher_args['arguments']['keyword'] );
+		$dispatcherCall = $dispatcherResult['message']->getParts()[0]->getFunctionCall();
+		$dispatcherArgs = $dispatcherCall->getArgs();
+		$this->assertSame( 'sd-ai-agent/stock-image', $dispatcherArgs['ability'] );
+		$this->assertArrayNotHasKey( 'action', $dispatcherArgs['arguments'] );
+		$this->assertArrayNotHasKey( 'provider', $dispatcherArgs['arguments'] );
+		$this->assertSame( 'outdoor family portrait', $dispatcherArgs['arguments']['keyword'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3742,6 +3742,91 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The second bounded stock call must import automatically instead of spending
+	 * the final stock slot on another candidate search.
+	 */
+	public function test_onboarding_media_budget_normalizes_second_stock_search(): void {
+		if ( ! class_exists( FunctionCall::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'enforce_onboarding_media_budget' );
+		$method->setAccessible( true );
+
+		$loop   = new AgentLoop( 'Build a photographer site', array(), array(), array( 'agent_slug' => 'onboarding' ) );
+		$result = $method->invoke(
+			$loop,
+			new ModelMessage(
+				array(
+					new MessagePart(
+						new FunctionCall(
+							'stock-search-one',
+							'wpab__sd-ai-agent__stock-image',
+							array( 'action' => 'search', 'keyword' => 'wedding couple photography elegant natural light', 'limit' => 12 )
+						)
+					),
+					new MessagePart(
+						new FunctionCall(
+							'stock-search-two',
+							'wpab__sd-ai-agent__stock-image',
+							array( 'action' => 'search', 'provider' => 'openverse', 'keyword' => 'portrait photography studio natural light', 'limit' => 12 )
+						)
+					),
+				)
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result['removed'] );
+		$parts = $result['message']->getParts();
+		$this->assertCount( 2, $parts );
+		$first_args  = $parts[0]->getFunctionCall()->getArgs();
+		$second_args = $parts[1]->getFunctionCall()->getArgs();
+		$this->assertSame( 'search', $first_args['action'] );
+		$this->assertArrayNotHasKey( 'action', $second_args );
+		$this->assertArrayNotHasKey( 'provider', $second_args );
+		$this->assertArrayNotHasKey( 'limit', $second_args );
+		$this->assertSame( 'portrait photography studio', $second_args['keyword'] );
+
+		$dispatcher_loop = new AgentLoop(
+			'Build a photographer site',
+			array(),
+			array(
+				new ModelMessage(
+					array(
+						new MessagePart( new FunctionCall( 'prior-stock-search', 'wpab__sd-ai-agent__stock-image', array( 'action' => 'search', 'keyword' => 'wedding' ) ) ),
+					)
+				),
+			),
+			array( 'agent_slug' => 'onboarding' )
+		);
+		$dispatcher_result = $method->invoke(
+			$dispatcher_loop,
+			new ModelMessage(
+				array(
+					new MessagePart(
+						new FunctionCall(
+							'dispatcher-stock-search',
+							'wpab__sd-ai-agent__ability-call',
+							array(
+								'ability'   => 'sd-ai-agent/stock-image',
+								'arguments' => array( 'action' => 'search', 'provider' => 'openverse', 'keyword' => 'outdoor family portrait golden hour' ),
+							)
+						)
+					),
+				)
+			)
+		);
+
+		$dispatcher_call = $dispatcher_result['message']->getParts()[0]->getFunctionCall();
+		$dispatcher_args = $dispatcher_call->getArgs();
+		$this->assertSame( 'sd-ai-agent/stock-image', $dispatcher_args['ability'] );
+		$this->assertArrayNotHasKey( 'action', $dispatcher_args['arguments'] );
+		$this->assertArrayNotHasKey( 'provider', $dispatcher_args['arguments'] );
+		$this->assertSame( 'outdoor family portrait', $dispatcher_args['arguments']['keyword'] );
+	}
+
+	/**
 	 * Setup Assistant media acquisition must stay bounded across direct and
 	 * dispatcher calls, including several calls emitted in one model turn.
 	 */


### PR DESCRIPTION
## Summary

- convert the Setup Assistant's second bounded `stock-image` search into the documented automatic-import fallback
- remove search-only arguments and shorten over-specific fallback keywords before dispatch
- preserve direct and `ability-call` dispatcher behavior and emit privacy-safe normalization telemetry

## Problem

Fresh photographer onboarding reproduced two parallel `action: search` calls. Both returned zero candidates, exhausting the two-call stock budget without attempting the required automatic import. Image generation was unavailable on the tenant plan, so the Setup Assistant correctly stopped before publishing a weak text-only homepage.

The prompt already required search first and automatic import second, but prompt guidance did not deterministically enforce that sequence.

## Implementation

- `includes/Core/AgentLoop.php`: when the second admitted onboarding stock call is still a search, remove `action`, `provider`, `image_id`, and `limit`, shorten the keyword to three concrete terms, and dispatch it through the ability's existing automatic-import path.
- `tests/SdAiAgent/Core/AgentLoopTest.php`: cover parallel direct calls and a resumed dispatcher call.

## Worker self-verification

- PHPUnit: Tests: 4157, Assertions: 18835, Errors: 0, Failures: 0, Skipped: 136, Incomplete: 4
- Focused: AgentLoopTest — Tests: 166, Assertions: 394, Skipped: 67
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

The full suite was run against an isolated clean WordPress test database after the shared local test database was found to contain stale custom-table rows from earlier interrupted runs.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding media handling by automatically importing images after the second stock-image search.
  * Simplified search terms during automatic imports for more consistent results.
  * Prevented unnecessary budget-blocking responses when searches are converted to imports.

* **Tests**
  * Added coverage for both direct and dispatcher-based media requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->