### PR TITLE
fix: respect Openverse anonymous search limit

### DIFF
--- a/includes/Abilities/ImageSources/OpenverseImageSource.php
+++ b/includes/Abilities/ImageSources/OpenverseImageSource.php
@@ -68,7 +68,8 @@ class OpenverseImageSource implements ImageSourceInterface {
 	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		$query_args = [
 			'q'         => $keyword,
-			'page_size' => min( $per_page, 50 ),
+			// Anonymous Openverse requests reject page sizes above 20 with HTTP 401.
+			'page_size' => min( $per_page, 20 ),
 			'mature'    => 'false',
 		];
 


### PR DESCRIPTION
## Summary

- cap anonymous Openverse image searches at the API's supported 20-result page size
- prevent broad candidate searches from receiving HTTP 401 and being surfaced as empty stock results

## Runtime evidence

- `page_size=48` through the installed Openverse source returned HTTP 401 with `page_size may not exceed 20 for anonymous requests`
- the same query through WordPress with a supported page size returned HTTP 200
- this failure caused the photographer onboarding candidate search to return no usable candidates before the automatic-import fallback

## Worker self-verification

- PHPUnit: Tests: 4169, Assertions: 18931, Errors: 0, Failures: 0, Skipped: 136, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol
