### PR TITLE
fix: accept web-ready Openverse hero images

### DIFF
--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -388,7 +388,7 @@ class ImageSourceFactory {
 		$usage  = sanitize_key( $usage );
 
 		$role_minimums = array(
-			'hero'      => array( 1920, 900 ),
+			'hero'      => array( 1024, 576 ),
 			'gallery'   => array( 1200, 800 ),
 			'content'   => array( 1200, 675 ),
 			'thumbnail' => array( 600, 400 ),

--- a/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
+++ b/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
@@ -163,6 +163,21 @@ class ImageSourceFactoryTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'watermark', implode( ' ', $watermarked['reasons'] ) );
 	}
 
+	/** A web-ready Openverse landscape can serve as a hero without being rejected. */
+	public function test_hero_quality_floor_accepts_web_ready_landscape_source(): void {
+		$result = ImageSourceFactory::assess_candidate_quality(
+			[
+				'width'  => 1024,
+				'height' => 768,
+				'title'  => 'Wedding couple portrait',
+			],
+			'hero'
+		);
+
+		$this->assertTrue( $result['eligible'] );
+		$this->assertStringContainsString( 'meets the hero technical floor', implode( ' ', $result['reasons'] ) );
+	}
+
 	/** Gallery assets enforce the documented landscape aspect-ratio floor. */
 	public function test_gallery_quality_floor_rejects_portrait_source(): void {
 		$result = ImageSourceFactory::assess_candidate_quality(


### PR DESCRIPTION
## Summary

- lower the hero image quality floor to the web-ready 1024×576 baseline
- allow usable licensed Openverse landscapes to participate in onboarding
- cover a 1024×768 hero candidate with a focused regression test

## Verification

- `pnpm run verify`
- focused `ImageSourceFactoryTest`: 9 tests, 36 assertions
- PHPCS on the changed files

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hero images can now meet a lower minimum resolution of 1024×576, allowing more suitable landscape images to be accepted.
  * Added validation for qualifying Openverse landscape images, including expected quality feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->