### PR TITLE
fix: block tenant theme scaffolding

### DIFF
--- a/advanced-plugin/includes/Abilities/ScaffoldBlockThemeAbility.php
+++ b/advanced-plugin/includes/Abilities/ScaffoldBlockThemeAbility.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Core\Filesystem\FileModGate;
 use SdAiAgent\DesignSystem\ArtifactReleaseManager;
 use SdAiAgent\Services\BlockThemeProjectValidator;
 use WP_Error;
@@ -149,6 +150,11 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 		$overwrite = ! empty( $input['overwrite'] );
 
 		$theme_root = self::theme_root();
+		$allowed    = FileModGate::assert_allowed( $theme_root );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Pre-flight check before WP_Filesystem is initialised; mirrors PluginInstaller pattern.
 		if ( ! is_dir( $theme_root ) || ! is_writable( $theme_root ) ) {
 			return new WP_Error(

--- a/advanced-plugin/includes/Bootstrap/AbilitiesHandler.php
+++ b/advanced-plugin/includes/Bootstrap/AbilitiesHandler.php
@@ -19,6 +19,7 @@ use SdAiAgent\Abilities\UserManagementAbilities;
 use SdAiAgent\Abilities\WordPressAdvancedAbilities;
 use SdAiAgent\Abilities\WpCliAbilities;
 use SdAiAgent\Abilities\WpRestAbilities;
+use SdAiAgent\Core\Filesystem\FileModGate;
 use SdAiAgent\PluginBuilder\PluginSandbox;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
@@ -71,7 +72,7 @@ final class AbilitiesHandler {
 	 * Register the advanced-only block-theme scaffolder ability.
 	 */
 	private function register_scaffold_block_theme(): void {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) || ! FileModGate::shared_code_modifications_allowed() ) {
 			return;
 		}
 

--- a/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
@@ -43,6 +43,26 @@ class ScaffoldBlockThemeAbilityTest extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	// ── tenant safety ─────────────────────────────────────────────────────
+
+	/** Customer sites cannot scaffold shared themes. */
+	public function test_scaffold_rejects_shared_theme_mutation_when_tenant_gate_is_closed(): void {
+		$slug    = $this->unique_slug( 'tenant-denied' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+		$deny    = static fn(): bool => false;
+
+		add_filter( 'sd_ai_agent_allow_shared_code_modifications', $deny );
+		try {
+			$result = $ability->run( [ 'slug' => $slug, 'name' => 'Tenant Denied Theme' ] );
+		} finally {
+			remove_filter( 'sd_ai_agent_allow_shared_code_modifications', $deny );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_shared_code_mod_not_allowed', $result->get_error_code() );
+		$this->assertDirectoryDoesNotExist( trailingslashit( get_theme_root() ) . $slug );
+	}
+
 	// ── version coercion ──────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

- omit the shared block-theme scaffolder from customer multisite ability manifests
- enforce the same tenant boundary at execution time as defense in depth
- verify a denied scaffold creates no theme directory

## Context

A fresh customer-site onboarding run proposed `sd-ai-agent/scaffold-block-theme`. That ability writes into the network-shared themes directory, so the proposal was denied before execution. This change applies the existing `FileModGate` policy to the previously uncovered advanced scaffolder.

## Worker self-verification
- PHPUnit: focused ScaffoldBlockThemeAbilityTest — Tests: 18, Assertions: 64, Errors: 0, Failures: 0
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

The full suite completed 4,171 tests with one unrelated existing failure in `AutomationLogsTest::test_list_for_automation_ordered_desc`. The same focused failure reproduces on unchanged `main` (`Failed asserting that 454 is greater than 455`). The first full attempt was also disrupted by concurrent test-database schema resets; a clean rerun reduced the result to only this reproduced `main` failure.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when creating block themes by preventing changes to shared theme locations without permission.
  * Block theme scaffolding now reports a clear error when the requested location is not allowed.
  * Prevented unauthorized theme directories from being created.

* **Tests**
  * Added coverage to verify blocked theme creation behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->