### PR TITLE
Fix subsite context for stock image imports

### DIFF
--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -746,11 +746,11 @@ class ImageSourceFactory {
 
 		$attachment_id = media_handle_sideload( $file_array, $post_id, $title );
 
-		if ( $switched ) {
-			restore_current_blog();
-		}
-
 		if ( is_wp_error( $attachment_id ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+
 			if ( file_exists( $tmp_file ) ) {
 				unlink( $tmp_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 			}
@@ -770,6 +770,10 @@ class ImageSourceFactory {
 		}
 
 		$attachment_url = wp_get_attachment_url( $attachment_id );
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
 
 		return [
 			'attachment_id'   => $attachment_id,


### PR DESCRIPTION
## Summary

- Keep the target multisite blog active while stock-import metadata is stored.
- Resolve the imported attachment URL before restoring the originating blog.
- Preserve existing context restoration on sideload failures.

## Why

Cross-site onboarding imported the file into the requested subsite, then restored the originating site too early. Attribution, alt metadata, and the returned URL were consequently resolved against the wrong site's attachment table and upload base URL, producing broken image markup.

## Verification

- `/home/dave/Git/tgc.church-live/site/vendor/bin/phpcs includes/Abilities/ImageSources/ImageSourceFactory.php`
- `php -l includes/Abilities/ImageSources/ImageSourceFactory.php`
- PHPStan scoped to `includes/Abilities/ImageSources/ImageSourceFactory.php`: no errors
- `git diff --check`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol
