### PR TITLE
fix: preserve setup stock fallback subject

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4091,11 +4091,12 @@ PROMPT;
 			return $unchanged;
 		}
 
-		$limits = array(
+		$limits             = array(
 			'sd-ai-agent/stock-image'    => 2,
 			'sd-ai-agent/generate-image' => 1,
 		);
-		$used   = array_fill_keys( array_keys( $limits ), 0 );
+		$used               = array_fill_keys( array_keys( $limits ), 0 );
+		$primary_stock_args = null;
 
 		foreach ( $this->history as $history_message ) {
 			foreach ( $history_message->getParts() as $part ) {
@@ -4106,6 +4107,9 @@ PROMPT;
 
 				$ability_name = self::media_ability_name_for_call( $call );
 				if ( null !== $ability_name ) {
+					if ( 'sd-ai-agent/stock-image' === $ability_name && null === $primary_stock_args ) {
+						$primary_stock_args = self::stock_image_args_for_call( $call );
+					}
 					++$used[ $ability_name ];
 				}
 			}
@@ -4132,13 +4136,18 @@ PROMPT;
 				continue;
 			}
 
-			if (
-				'sd-ai-agent/stock-image' === $ability_name
-				&& 1 === $used[ $ability_name ]
-				&& self::is_stock_image_search_call( $call )
-			) {
-				$part = new MessagePart( self::convert_stock_image_search_to_auto_import( $call ) );
-				++$rewritten;
+			if ( 'sd-ai-agent/stock-image' === $ability_name ) {
+				if ( 0 === $used[ $ability_name ] && null === $primary_stock_args ) {
+					$primary_stock_args = self::stock_image_args_for_call( $call );
+				} elseif (
+					1 === $used[ $ability_name ]
+					&& ! self::is_stock_image_candidate_import_call( $call )
+				) {
+					$part = new MessagePart(
+						self::normalize_stock_image_auto_import_fallback( $call, $primary_stock_args ?? array() )
+					);
+					++$rewritten;
+				}
 			}
 
 			++$used[ $ability_name ];
@@ -4239,26 +4248,45 @@ PROMPT;
 		);
 	}
 
-	/** Return whether a direct or dispatcher stock-image call requests search mode. */
-	private static function is_stock_image_search_call( FunctionCall $call ): bool {
+	/** Return the stock-image arguments from a direct or dispatcher call. */
+	private static function stock_image_args_for_call( FunctionCall $call ): array {
 		$args = self::normalize_function_call_args( $call->getArgs() );
 		if ( 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() ) ) {
-			$args = isset( $args['arguments'] ) && is_array( $args['arguments'] ) ? $args['arguments'] : array();
+			return isset( $args['arguments'] ) && is_array( $args['arguments'] ) ? $args['arguments'] : array();
 		}
 
-		return 'search' === (string) ( $args['action'] ?? '' );
+		return $args;
 	}
 
-	/** Convert the second bounded stock search into the documented automatic-import fallback. */
+	/** Return whether a stock-image call imports a reviewed provider candidate. */
+	private static function is_stock_image_candidate_import_call( FunctionCall $call ): bool {
+		$args = self::stock_image_args_for_call( $call );
+
+		return 'import' === (string) ( $args['action'] ?? '' )
+			&& '' !== (string) ( $args['provider'] ?? '' )
+			&& '' !== (string) ( $args['image_id'] ?? '' );
+	}
+
+	/**
+	 * Normalize the second bounded stock call into the documented automatic-import fallback.
+	 *
+	 * @param FunctionCall         $call             Proposed second stock call.
+	 * @param array<string, mixed> $primaryStockArgs Arguments from the first bounded stock search.
+	 */
 	// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Project variable naming guidance requires camelCase.
-	private static function convert_stock_image_search_to_auto_import( FunctionCall $call ): FunctionCall {
+	private static function normalize_stock_image_auto_import_fallback( FunctionCall $call, array $primaryStockArgs ): FunctionCall {
 		$args         = self::normalize_function_call_args( $call->getArgs() );
 		$isDispatcher = 'sd-ai-agent/ability-call' === self::normalize_logged_tool_name( (string) $call->getName() );
 		$stockArgs    = $isDispatcher && isset( $args['arguments'] ) && is_array( $args['arguments'] )
 			? $args['arguments']
 			: $args;
 
-		unset( $stockArgs['action'], $stockArgs['provider'], $stockArgs['image_id'], $stockArgs['limit'] );
+		unset( $stockArgs['action'], $stockArgs['provider'], $stockArgs['image_id'], $stockArgs['limit'], $stockArgs['min_width'], $stockArgs['min_height'] );
+		foreach ( array( 'keyword', 'usage', 'orientation' ) as $key ) {
+			if ( '' !== (string) ( $primaryStockArgs[ $key ] ?? '' ) ) {
+				$stockArgs[ $key ] = $primaryStockArgs[ $key ];
+			}
+		}
 		$stockArgs['keyword'] = self::shorten_stock_image_keyword( (string) ( $stockArgs['keyword'] ?? '' ) );
 
 		if ( $isDispatcher ) {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3762,7 +3762,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 						new FunctionCall(
 							'stock-search-one',
 							'wpab__sd-ai-agent__stock-image',
-							array( 'action' => 'search', 'keyword' => 'wedding couple photography elegant natural light', 'limit' => 12 )
+							array( 'action' => 'search', 'keyword' => 'newlywed couple', 'usage' => 'hero', 'orientation' => 'landscape', 'min_width' => 1200, 'limit' => 12 )
 						)
 					),
 					new MessagePart(
@@ -3786,7 +3786,10 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'action', $secondArgs );
 		$this->assertArrayNotHasKey( 'provider', $secondArgs );
 		$this->assertArrayNotHasKey( 'limit', $secondArgs );
-		$this->assertSame( 'portrait photography studio', $secondArgs['keyword'] );
+		$this->assertArrayNotHasKey( 'min_width', $secondArgs );
+		$this->assertSame( 'newlywed couple', $secondArgs['keyword'] );
+		$this->assertSame( 'hero', $secondArgs['usage'] );
+		$this->assertSame( 'landscape', $secondArgs['orientation'] );
 
 		$dispatcherLoop = new AgentLoop(
 			'Build a photographer site',
@@ -3810,7 +3813,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 							'wpab__sd-ai-agent__ability-call',
 							array(
 								'ability'   => 'sd-ai-agent/stock-image',
-								'arguments' => array( 'action' => 'search', 'provider' => 'openverse', 'keyword' => 'outdoor family portrait golden hour' ),
+								'arguments' => array( 'keyword' => 'outdoor family portrait golden hour', 'usage' => 'gallery', 'orientation' => 'portrait' ),
 							)
 						)
 					),
@@ -3823,7 +3826,28 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd-ai-agent/stock-image', $dispatcherArgs['ability'] );
 		$this->assertArrayNotHasKey( 'action', $dispatcherArgs['arguments'] );
 		$this->assertArrayNotHasKey( 'provider', $dispatcherArgs['arguments'] );
-		$this->assertSame( 'outdoor family portrait', $dispatcherArgs['arguments']['keyword'] );
+		$this->assertSame( 'wedding', $dispatcherArgs['arguments']['keyword'] );
+		$this->assertSame( 'gallery', $dispatcherArgs['arguments']['usage'] );
+		$this->assertSame( 'portrait', $dispatcherArgs['arguments']['orientation'] );
+
+		$candidateImportResult = $method->invoke(
+			$dispatcherLoop,
+			new ModelMessage(
+				array(
+					new MessagePart(
+						new FunctionCall(
+							'candidate-import',
+							'wpab__sd-ai-agent__stock-image',
+							array( 'action' => 'import', 'provider' => 'openverse', 'image_id' => 'reviewed-image', 'keyword' => 'wedding' )
+						)
+					),
+				)
+			)
+		);
+		$candidateImportArgs = $candidateImportResult['message']->getParts()[0]->getFunctionCall()->getArgs();
+		$this->assertSame( 'import', $candidateImportArgs['action'] );
+		$this->assertSame( 'openverse', $candidateImportArgs['provider'] );
+		$this->assertSame( 'reviewed-image', $candidateImportArgs['image_id'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- remember the first bounded Setup Assistant stock-search arguments
- normalize any non-candidate second stock call into an automatic import using the first keyword, usage, and orientation
- preserve reviewed provider/image-ID imports while removing extra fallback dimension filters

## Observed failure
A fresh photographer onboarding run found 11 eligible Openverse candidates for `wedding couple`, but the model spent its second and final stock slot on an automatic import for a different `portrait session` gallery query. That returned no image and blocked the build. Prompt guidance already required reusing the first search; this change enforces that bounded fallback deterministically.

## Worker self-verification
- PHPUnit: Tests: 4205, Assertions: 19231, Errors: 0, Failures: 0, Skipped: 136, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Focused verification
- media-budget tests: 2 tests, 30 assertions
- candidate-import preservation test included in the focused guard coverage
- scoped PHPCS: clean

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding stock-image handling by consistently preserving search keywords, usage, and orientation.
  * Prevented search-specific fields from being carried into standard image calls.
  * Improved handling of direct and dispatched image requests, including candidate imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->