### PR TITLE
GH#2566: feat: add Monitor/Pulse settings UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -209,6 +209,16 @@ System notices:
 - Hover: `border-color: --wp-admin-theme-color`, `box-shadow: 0 2px 8px rgba(0,0,0,.06)`
 - No transform or scale on hover — keep transitions to colour/border only
 
+### Monitor/Pulse settings
+
+- Keep **Scheduled Tasks** and **Monitor/Pulse** as separate settings surfaces. Tasks perform work on every schedule; a Monitor assesses a checklist and only notifies when attention is needed.
+- A newly saved Monitor, template-derived Monitor, or edited disabled Monitor is visibly a **Disabled draft**. Show the consent explanation before its configuration metadata and never imply that saving, editing, revisiting the page, or checking a draft schedules it.
+- A disabled card has one primary opt-in action: **Enable monitoring**. **Check now** is a secondary action available only on a disabled draft and must be labelled as a one-off check, not a scheduling shortcut.
+- Show outcome, cadence, owner, tool profile, notification policy, last check, and next expected time in a compact definition list. Explain that WP-Cron timing is traffic-dependent; do not use an expected time as a health or on-time promise.
+- Outcome badges use semantic WordPress admin colours: quiet/success, attention-needed/warning, and blocked/error. Keep the latest summary and error bounded, text-only, and visually distinct from configuration controls.
+- Keep durable log inspection behind an explicit **Inspect logs** action. Delete remains a destructive secondary action with a native confirmation dialog.
+- On compact screens, stack Monitor headers, action rows, form fields, notification-channel controls, and detail metadata into one column without hiding consent or outcome context.
+
 ### SD AI Account Card
 
 - Show the verified linked user's display name, masked email, and a concise “Email verified” status above wallet details.

--- a/includes/Automations/AutomationRunner.php
+++ b/includes/Automations/AutomationRunner.php
@@ -110,12 +110,38 @@ class AutomationRunner {
 	}
 
 	/**
-	 * Run an automation (fired by WP Cron or manually).
+	 * Run an enabled automation (fired by WP Cron or the regular manual action).
 	 *
 	 * @param int $automation_id Automation ID.
 	 * @return array<string, mixed>|null Run result or null when the automation does not exist.
 	 */
 	public static function run( int $automation_id ): ?array {
+		return self::run_internal( $automation_id, false );
+	}
+
+	/**
+	 * Run one disabled Monitor draft without enabling or scheduling it.
+	 *
+	 * This is intentionally a separate entry point so normal cron and manual task
+	 * deliveries retain their disabled-run block. The REST controller exposes it
+	 * only to authorized administrators after confirming the stored definition is
+	 * a disabled Monitor.
+	 *
+	 * @param int $automation_id Monitor automation ID.
+	 * @return array<string, mixed>|null Run result or null when the automation does not exist.
+	 */
+	public static function run_manual_monitor_draft( int $automation_id ): ?array {
+		return self::run_internal( $automation_id, true );
+	}
+
+	/**
+	 * Execute an automation under the normal or narrowly authorized draft contract.
+	 *
+	 * @param int  $automation_id              Automation ID.
+	 * @param bool $allow_manual_monitor_draft Whether this request is the controller-authorized draft path.
+	 * @return array<string, mixed>|null Run result or null when the automation does not exist.
+	 */
+	private static function run_internal( int $automation_id, bool $allow_manual_monitor_draft ): ?array {
 		$automation = Automations::get( $automation_id );
 		if ( ! $automation ) {
 			return null;
@@ -141,7 +167,19 @@ class AutomationRunner {
 			return null;
 		}
 
-		if ( empty( $automation['enabled'] ) ) {
+		$is_manual_monitor_draft = $allow_manual_monitor_draft
+			&& Automations::is_monitor( $automation )
+			&& empty( $automation['enabled'] );
+
+		if ( $allow_manual_monitor_draft && ! $is_manual_monitor_draft ) {
+			return self::record_blocked_delivery(
+				$automation,
+				$run_id,
+				__( 'Only a disabled Monitor draft can use the manual check path.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( empty( $automation['enabled'] ) && ! $is_manual_monitor_draft ) {
 			return self::record_blocked_delivery(
 				$automation,
 				$run_id,
@@ -150,7 +188,7 @@ class AutomationRunner {
 		}
 
 		$lease_expires_at = self::get_lease_expiration( $automation );
-		$claim_state      = self::claim_run_with_lifecycle( $automation, $run_id, $lease_expires_at );
+		$claim_state      = self::claim_run_with_lifecycle( $automation, $run_id, $lease_expires_at, $is_manual_monitor_draft );
 		if ( 'failed' === $claim_state ) {
 			return self::build_fallback_result(
 				$automation,
@@ -487,12 +525,13 @@ class AutomationRunner {
 	/**
 	 * Atomically persist the claimed log and the matching automation claim.
 	 *
-	 * @param array<string, mixed> $automation       Automation definition.
-	 * @param string               $run_id           Correlation UUID for this delivery.
-	 * @param string               $lease_expires_at UTC MySQL expiration datetime.
+	 * @param array<string, mixed> $automation              Automation definition.
+	 * @param string               $run_id                  Correlation UUID for this delivery.
+	 * @param string               $lease_expires_at        UTC MySQL expiration datetime.
+	 * @param bool                 $is_manual_monitor_draft Whether this is one authorized disabled Monitor check.
 	 * @return 'claimed'|'contended'|'failed'
 	 */
-	private static function claim_run_with_lifecycle( array $automation, string $run_id, string $lease_expires_at ): string {
+	private static function claim_run_with_lifecycle( array $automation, string $run_id, string $lease_expires_at, bool $is_manual_monitor_draft = false ): string {
 		$automation_id = (int) ( $automation['id'] ?? 0 );
 		if ( $automation_id <= 0 || ! Automations::begin_lifecycle_transaction() ) {
 			return 'failed';
@@ -503,7 +542,7 @@ class AutomationRunner {
 				'automation_id'    => $automation_id,
 				'run_id'           => $run_id,
 				'owner_user_id'    => (int) ( $automation['owner_user_id'] ?? 0 ),
-				'trigger_type'     => 'scheduled',
+				'trigger_type'     => $is_manual_monitor_draft ? 'manual' : 'scheduled',
 				'status'           => 'pending',
 				'lifecycle_status' => 'claimed',
 				'lease_expires_at' => $lease_expires_at,
@@ -514,7 +553,10 @@ class AutomationRunner {
 			return 'failed';
 		}
 
-		if ( ! Automations::claim_run( $automation_id, $run_id, $lease_expires_at ) ) {
+		$claimed = $is_manual_monitor_draft
+			? self::claim_manual_monitor_draft_run( $automation_id, $run_id, $lease_expires_at )
+			: Automations::claim_run( $automation_id, $run_id, $lease_expires_at );
+		if ( ! $claimed ) {
 			Automations::rollback_lifecycle_transaction();
 			return 'contended';
 		}
@@ -525,6 +567,38 @@ class AutomationRunner {
 		}
 
 		return 'claimed';
+	}
+
+	/**
+	 * Claim exactly one disabled Monitor draft without mutating its enabled state.
+	 *
+	 * The ordinary model claim intentionally requires enabled=1. This parallel
+	 * predicate is scoped to the controller-authorized draft run and preserves the
+	 * same active-run fence while also proving no recurring schedule was enabled.
+	 *
+	 * @param int    $automation_id    Automation ID.
+	 * @param string $run_id           Correlation UUID for this delivery.
+	 * @param string $lease_expires_at UTC MySQL expiration datetime.
+	 */
+	private static function claim_manual_monitor_draft_run( int $automation_id, string $run_id, string $lease_expires_at ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- The lifecycle transaction atomically claims one disabled Monitor draft without changing its enabled state.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET active_run_id = %s, execution_status = 'claimed', lease_expires_at = %s, updated_at = %s WHERE id = %d AND enabled = 0 AND mode = %s AND active_run_id = ''",
+				Automations::table_name(),
+				$run_id,
+				$lease_expires_at,
+				$now,
+				$automation_id,
+				Automations::MONITOR_MODE
+			)
+		);
+
+		return false !== $result && $result > 0;
 	}
 
 	/** Transition both claimed lifecycle rows to running together. */

--- a/includes/REST/AutomationController.php
+++ b/includes/REST/AutomationController.php
@@ -154,10 +154,15 @@ final class AutomationController {
 				'callback'            => array( $this, 'handle_run_automation' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
-					'id' => array(
+					'id'                   => array(
 						'required'          => true,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
+					),
+					'manual_monitor_draft' => array(
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => false,
 					),
 				),
 			)
@@ -463,8 +468,24 @@ final class AutomationController {
 	 * Manually run a scheduled automation.
 	 */
 	public function handle_run_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$id     = self::get_int_param( $request, 'id' );
-		$result = AutomationRunner::run( $id );
+		$id         = self::get_int_param( $request, 'id' );
+		$automation = Automations::get( $id );
+		if ( null === $automation ) {
+			return new WP_Error( 'not_found', __( 'Automation not found.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
+		}
+
+		$manual_monitor_draft = (bool) $request->get_param( 'manual_monitor_draft' );
+		if ( $manual_monitor_draft && ( ! Automations::is_monitor( $automation ) || ! empty( $automation['enabled'] ) ) ) {
+			return new WP_Error(
+				'sd_ai_agent_automation_manual_draft_requires_disabled_monitor',
+				__( 'Check now is available only for a disabled Monitor/Pulse draft.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = $manual_monitor_draft
+			? AutomationRunner::run_manual_monitor_draft( $id )
+			: AutomationRunner::run( $id );
 
 		if ( null === $result ) {
 			return new WP_Error( 'not_found', __( 'Automation not found.', 'superdav-ai-agent' ), array( 'status' => 404 ) );

--- a/src/settings-page/automations-manager.js
+++ b/src/settings-page/automations-manager.js
@@ -15,6 +15,10 @@ import {
 import { __ } from '@wordpress/i18n';
 import { trash, pencil, plus } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import MonitorManager from './monitor-manager';
 
 const CHANNEL_TYPE_OPTIONS = [
 	{ label: __( 'Slack', 'sd-ai-agent' ), value: 'slack' },
@@ -289,15 +293,22 @@ export default function AutomationsManager() {
 		setEditId( null );
 	}, [] );
 
+	const scheduledTasks = automations.filter(
+		( automation ) => automation.mode !== 'monitor'
+	);
+	const taskTemplates = templates.filter(
+		( template ) => template.mode !== 'monitor'
+	);
+
 	return (
 		<div className="sdaa-automations-manager">
 			<div className="sdaa-skill-header">
 				<div>
-					<h3>{ __( 'Scheduled Automations', 'sd-ai-agent' ) }</h3>
+					<h3>{ __( 'Scheduled Tasks', 'superdav-ai-agent' ) }</h3>
 					<p className="description">
 						{ __(
-							'Cron-based AI tasks that run on a schedule.',
-							'sd-ai-agent'
+							'Cron-based AI tasks that do work on every scheduled run.',
+							'superdav-ai-agent'
 						) }
 					</p>
 				</div>
@@ -327,14 +338,14 @@ export default function AutomationsManager() {
 			) }
 
 			{ ! showForm &&
-				templates.length > 0 &&
-				automations.length === 0 && (
+				taskTemplates.length > 0 &&
+				scheduledTasks.length === 0 && (
 					<div style={ { marginBottom: '16px' } }>
 						<h4>
 							{ __( 'Quick Start Templates', 'sd-ai-agent' ) }
 						</h4>
 						<div className="sdaa-skill-cards">
-							{ templates.map( ( tpl, idx ) => (
+							{ taskTemplates.map( ( tpl, idx ) => (
 								<div key={ idx } className="sdaa-skill-card">
 									<div className="sdaa-skill-card-header">
 										<div className="sdaa-skill-card-title">
@@ -552,12 +563,12 @@ export default function AutomationsManager() {
 				</p>
 			) }
 
-			{ loaded && automations.length > 0 && (
+			{ loaded && scheduledTasks.length > 0 && (
 				<div
 					className="sdaa-skill-cards"
 					style={ { marginTop: '16px' } }
 				>
-					{ automations.map( ( auto ) => (
+					{ scheduledTasks.map( ( auto ) => (
 						<div
 							key={ auto.id }
 							className={ `sdaa-skill-card ${
@@ -726,6 +737,8 @@ export default function AutomationsManager() {
 					) ) }
 				</div>
 			) }
+
+			<MonitorManager />
 		</div>
 	);
 }

--- a/src/settings-page/monitor-manager.js
+++ b/src/settings-page/monitor-manager.js
@@ -1,0 +1,1026 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import {
+	BaseControl,
+	Button,
+	Notice,
+	SelectControl,
+	Spinner,
+	TextareaControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { pencil, plus, trash } from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
+
+const SCHEDULE_OPTIONS = [
+	{ label: __( 'Hourly', 'superdav-ai-agent' ), value: 'hourly' },
+	{
+		label: __( 'Twice Daily', 'superdav-ai-agent' ),
+		value: 'twicedaily',
+	},
+	{ label: __( 'Daily', 'superdav-ai-agent' ), value: 'daily' },
+	{ label: __( 'Weekly', 'superdav-ai-agent' ), value: 'weekly' },
+];
+
+const TOOL_PROFILE_OPTIONS = [
+	{ label: __( 'Default tool policy', 'superdav-ai-agent' ), value: '' },
+	{
+		label: __( 'Site health (least privilege)', 'superdav-ai-agent' ),
+		value: 'site-health',
+	},
+];
+
+const CHANNEL_TYPE_OPTIONS = [
+	{ label: __( 'Slack', 'superdav-ai-agent' ), value: 'slack' },
+	{ label: __( 'Discord', 'superdav-ai-agent' ), value: 'discord' },
+];
+
+/** Return a blank notification channel definition. */
+function emptyChannel() {
+	return { type: 'slack', webhook_url: '', enabled: true };
+}
+
+/** Return a Monitor form definition that cannot schedule recurring work. */
+function emptyMonitorForm() {
+	return {
+		name: '',
+		description: '',
+		prompt: '',
+		monitor_scratch: '',
+		schedule: 'daily',
+		tool_profile: '',
+		max_iterations: 10,
+		notification_channels: [],
+		mode: 'monitor',
+		enabled: false,
+	};
+}
+
+/**
+ * Return whether an API automation record uses the Monitor contract.
+ *
+ * @param {Object} automation Automation record.
+ * @return {boolean} Whether the record is a Monitor.
+ */
+function isMonitor( automation ) {
+	return automation?.mode === 'monitor';
+}
+
+/**
+ * Return the human-readable outcome or execution status for a Monitor.
+ *
+ * @param {Object} monitor Monitor record.
+ * @return {string} Localized outcome label.
+ */
+function getOutcomeLabel( monitor ) {
+	if ( [ 'claimed', 'running' ].includes( monitor.execution_status ) ) {
+		return __( 'Running', 'superdav-ai-agent' );
+	}
+
+	const labels = {
+		quiet: __( 'Quiet', 'superdav-ai-agent' ),
+		notify: __( 'Attention needed', 'superdav-ai-agent' ),
+		blocked: __( 'Blocked', 'superdav-ai-agent' ),
+		error: __( 'Error', 'superdav-ai-agent' ),
+	};
+
+	return (
+		labels[ monitor.last_monitor_outcome ] ||
+		__( 'Not checked yet', 'superdav-ai-agent' )
+	);
+}
+
+/**
+ * Return cautious, API-backed WP-Cron timing guidance for a Monitor.
+ *
+ * @param {Object} monitor Monitor record.
+ * @return {string} Localized timing guidance.
+ */
+function getTimingMessage( monitor ) {
+	if ( ! monitor.enabled ) {
+		return __(
+			'No recurring check is scheduled while this draft is disabled.',
+			'superdav-ai-agent'
+		);
+	}
+
+	if ( ! monitor.next_run_at ) {
+		return __(
+			'WP-Cron has not reported the next expected check yet. This is not a healthy/on-time signal.',
+			'superdav-ai-agent'
+		);
+	}
+
+	const expectedTime = Date.parse(
+		`${ monitor.next_run_at.replace( ' ', 'T' ) }Z`
+	);
+	if ( ! Number.isNaN( expectedTime ) && expectedTime < Date.now() ) {
+		return __(
+			'The next expected check time has passed, so WP-Cron may be delayed.',
+			'superdav-ai-agent'
+		);
+	}
+
+	return __(
+		'WP-Cron is traffic-dependent. This expected time is not a health or on-time guarantee.',
+		'superdav-ai-agent'
+	);
+}
+
+/**
+ * Render the saved-draft Monitor configuration form.
+ *
+ * @param {Object}      root0                 Component props.
+ * @param {Object}      root0.form            Current Monitor definition.
+ * @param {number|null} root0.editId          Existing Monitor ID, if editing.
+ * @param {boolean}     root0.saving          Whether the form is saving.
+ * @param {Function}    root0.onChange        Update a form field.
+ * @param {Function}    root0.onAddChannel    Add a notification channel.
+ * @param {Function}    root0.onUpdateChannel Update one notification channel.
+ * @param {Function}    root0.onRemoveChannel Remove one notification channel.
+ * @param {Function}    root0.onSubmit        Save the draft.
+ * @param {Function}    root0.onCancel        Close the form.
+ * @return {JSX.Element} Monitor form.
+ */
+function MonitorForm( {
+	form,
+	editId,
+	saving,
+	onChange,
+	onAddChannel,
+	onUpdateChannel,
+	onRemoveChannel,
+	onSubmit,
+	onCancel,
+} ) {
+	return (
+		<div className="sd-ai-agent-monitor-form">
+			<Notice status="warning" isDismissible={ false }>
+				{ __(
+					'New Monitors are saved as disabled drafts. Saving an existing Monitor does not change its enabled state. Recurring checks begin only when you choose Enable monitoring.',
+					'superdav-ai-agent'
+				) }
+			</Notice>
+			<TextControl
+				label={ __( 'Monitor name', 'superdav-ai-agent' ) }
+				value={ form.name }
+				onChange={ ( value ) => onChange( 'name', value ) }
+				__nextHasNoMarginBottom
+			/>
+			<TextControl
+				label={ __( 'Description', 'superdav-ai-agent' ) }
+				value={ form.description }
+				onChange={ ( value ) => onChange( 'description', value ) }
+				__nextHasNoMarginBottom
+			/>
+			<TextareaControl
+				label={ __( 'Check instructions', 'superdav-ai-agent' ) }
+				value={ form.prompt }
+				onChange={ ( value ) => onChange( 'prompt', value ) }
+				rows={ 5 }
+				help={ __(
+					'Describe what the Monitor should assess. It reports quietly unless attention is needed.',
+					'superdav-ai-agent'
+				) }
+			/>
+			<TextareaControl
+				label={ __( 'Checklist / scratchpad', 'superdav-ai-agent' ) }
+				value={ form.monitor_scratch }
+				onChange={ ( value ) => onChange( 'monitor_scratch', value ) }
+				rows={ 4 }
+				help={ __(
+					'Optional checklist context stored with this Monitor. An empty checklist completes quietly without an AI request.',
+					'superdav-ai-agent'
+				) }
+			/>
+			<div className="sd-ai-agent-monitor-form-grid">
+				<SelectControl
+					label={ __( 'Cadence', 'superdav-ai-agent' ) }
+					value={ form.schedule }
+					options={ SCHEDULE_OPTIONS }
+					onChange={ ( value ) => onChange( 'schedule', value ) }
+					__nextHasNoMarginBottom
+				/>
+				<SelectControl
+					label={ __( 'Tool profile', 'superdav-ai-agent' ) }
+					value={ form.tool_profile }
+					options={ TOOL_PROFILE_OPTIONS }
+					onChange={ ( value ) => onChange( 'tool_profile', value ) }
+					__nextHasNoMarginBottom
+				/>
+				<TextControl
+					label={ __( 'Max iterations', 'superdav-ai-agent' ) }
+					type="number"
+					min={ 1 }
+					max={ 50 }
+					value={ form.max_iterations }
+					onChange={ ( value ) =>
+						onChange(
+							'max_iterations',
+							parseInt( value, 10 ) || 10
+						)
+					}
+					__nextHasNoMarginBottom
+				/>
+			</div>
+			<BaseControl
+				id="sd-ai-agent-monitor-notification-channels"
+				label={ __( 'Notification channels', 'superdav-ai-agent' ) }
+				help={ __(
+					'Only a validated attention-needed outcome sends a notification.',
+					'superdav-ai-agent'
+				) }
+				__nextHasNoMarginBottom
+			>
+				{ ( form.notification_channels || [] ).map(
+					( channel, index ) => (
+						<div
+							key={ index }
+							className="sd-ai-agent-monitor-channel"
+						>
+							<SelectControl
+								label={
+									index === 0
+										? __(
+												'Channel type',
+												'superdav-ai-agent'
+										  )
+										: undefined
+								}
+								value={ channel.type }
+								options={ CHANNEL_TYPE_OPTIONS }
+								onChange={ ( value ) =>
+									onUpdateChannel( index, 'type', value )
+								}
+								__nextHasNoMarginBottom
+							/>
+							<TextControl
+								label={
+									index === 0
+										? __(
+												'Webhook URL',
+												'superdav-ai-agent'
+										  )
+										: undefined
+								}
+								value={ channel.webhook_url }
+								onChange={ ( value ) =>
+									onUpdateChannel(
+										index,
+										'webhook_url',
+										value
+									)
+								}
+								__nextHasNoMarginBottom
+							/>
+							<ToggleControl
+								label={ __( 'Enabled', 'superdav-ai-agent' ) }
+								checked={ Boolean( channel.enabled ) }
+								onChange={ ( value ) =>
+									onUpdateChannel( index, 'enabled', value )
+								}
+								__nextHasNoMarginBottom
+							/>
+							<Button
+								icon={ trash }
+								label={ __(
+									'Remove notification channel',
+									'superdav-ai-agent'
+								) }
+								onClick={ () => onRemoveChannel( index ) }
+								isDestructive
+								size="small"
+							/>
+						</div>
+					)
+				) }
+				<Button
+					variant="tertiary"
+					icon={ plus }
+					onClick={ onAddChannel }
+					size="small"
+				>
+					{ __( 'Add channel', 'superdav-ai-agent' ) }
+				</Button>
+			</BaseControl>
+			<div className="sd-ai-agent-monitor-form-actions">
+				<Button
+					variant="primary"
+					onClick={ onSubmit }
+					disabled={
+						saving || ! form.name.trim() || ! form.prompt.trim()
+					}
+				>
+					{ saving ? <Spinner /> : null }
+					{ editId
+						? __( 'Save Monitor', 'superdav-ai-agent' )
+						: __( 'Save Monitor draft', 'superdav-ai-agent' ) }
+				</Button>
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'superdav-ai-agent' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Render a Monitor/Pulse status card and its separate enable/check actions.
+ *
+ * @param {Object}      root0            Component props.
+ * @param {Object}      root0.monitor    Monitor record.
+ * @param {number|null} root0.running    Monitor currently executing a check.
+ * @param {Array}       root0.logs       Loaded durable logs.
+ * @param {number|null} root0.viewLogsId Monitor whose logs are visible.
+ * @param {Function}    root0.onEnable   Enable recurring monitoring.
+ * @param {Function}    root0.onDisable  Disable recurring monitoring.
+ * @param {Function}    root0.onCheckNow Run a disabled draft once.
+ * @param {Function}    root0.onViewLogs Toggle durable log visibility.
+ * @param {Function}    root0.onEdit     Edit the Monitor definition.
+ * @param {Function}    root0.onDelete   Delete the Monitor definition.
+ * @return {JSX.Element} Monitor status card.
+ */
+function MonitorCard( {
+	monitor,
+	running,
+	logs,
+	viewLogsId,
+	onEnable,
+	onDisable,
+	onCheckNow,
+	onViewLogs,
+	onEdit,
+	onDelete,
+} ) {
+	const notificationCount = ( monitor.notification_channels || [] ).filter(
+		( channel ) => channel.enabled
+	).length;
+	const isRunning = [ 'claimed', 'running' ].includes(
+		monitor.execution_status
+	);
+	const outcome =
+		monitor.last_monitor_outcome || monitor.execution_status || 'idle';
+
+	return (
+		<article
+			className={ `sd-ai-agent-monitor-card ${
+				! monitor.enabled ? 'sd-ai-agent-monitor-card--disabled' : ''
+			}` }
+		>
+			<div className="sd-ai-agent-monitor-card-header">
+				<div>
+					<h4>{ monitor.name }</h4>
+					<p className="description">
+						{ monitor.description || monitor.prompt }
+					</p>
+				</div>
+				<span
+					className={ `sd-ai-agent-monitor-status sd-ai-agent-monitor-status--${ outcome }` }
+				>
+					{ getOutcomeLabel( monitor ) }
+				</span>
+			</div>
+
+			{ ! monitor.enabled && (
+				<div className="sd-ai-agent-monitor-consent">
+					<strong>
+						{ __( 'Disabled draft', 'superdav-ai-agent' ) }
+					</strong>
+					<p>
+						{ __(
+							'Saving or checking this Monitor does not enable recurring checks. Review the context below, then use Enable monitoring to opt in.',
+							'superdav-ai-agent'
+						) }
+					</p>
+				</div>
+			) }
+
+			<dl className="sd-ai-agent-monitor-details">
+				<div>
+					<dt>{ __( 'Cadence', 'superdav-ai-agent' ) }</dt>
+					<dd>{ monitor.schedule }</dd>
+				</div>
+				<div>
+					<dt>{ __( 'Owner', 'superdav-ai-agent' ) }</dt>
+					<dd>
+						{ monitor.owner_user_id
+							? `${ __( 'User', 'superdav-ai-agent' ) } #${
+									monitor.owner_user_id
+							  }`
+							: __( 'Needs configuration', 'superdav-ai-agent' ) }
+					</dd>
+				</div>
+				<div>
+					<dt>{ __( 'Tool profile', 'superdav-ai-agent' ) }</dt>
+					<dd>
+						{ monitor.tool_profile ||
+							__( 'Default tool policy', 'superdav-ai-agent' ) }
+					</dd>
+				</div>
+				<div>
+					<dt>
+						{ __( 'Notification policy', 'superdav-ai-agent' ) }
+					</dt>
+					<dd>
+						{ notificationCount
+							? `${ notificationCount } ${ __(
+									'attention channel(s)',
+									'superdav-ai-agent'
+							  ) }`
+							: __(
+									'No attention notifications',
+									'superdav-ai-agent'
+							  ) }
+					</dd>
+				</div>
+				<div>
+					<dt>{ __( 'Last check', 'superdav-ai-agent' ) }</dt>
+					<dd>
+						{ monitor.last_run_at ||
+							__( 'Not checked yet', 'superdav-ai-agent' ) }
+					</dd>
+				</div>
+				<div>
+					<dt>{ __( 'Next expected', 'superdav-ai-agent' ) }</dt>
+					<dd>
+						{ monitor.next_run_at ||
+							__( 'Not scheduled', 'superdav-ai-agent' ) }
+					</dd>
+				</div>
+				{ isRunning && monitor.lease_expires_at && (
+					<div>
+						<dt>
+							{ __( 'Execution lease', 'superdav-ai-agent' ) }
+						</dt>
+						<dd>{ monitor.lease_expires_at }</dd>
+					</div>
+				) }
+			</dl>
+
+			<p className="sd-ai-agent-monitor-timing">
+				{ getTimingMessage( monitor ) }
+			</p>
+			{ monitor.monitor_timing_help && (
+				<p className="sd-ai-agent-monitor-timing">
+					{ monitor.monitor_timing_help }
+				</p>
+			) }
+			<p className="sd-ai-agent-monitor-cost">
+				{ __( 'Cost context:', 'superdav-ai-agent' ) }{ ' ' }
+				{ `${ monitor.max_iterations || 10 } ${ __(
+					'AI iterations per check at most; actual provider cost depends on your configured model and budget.',
+					'superdav-ai-agent'
+				) }` }
+			</p>
+			{ monitor.last_monitor_summary && (
+				<p className="sd-ai-agent-monitor-summary">
+					<strong>
+						{ __( 'Latest result:', 'superdav-ai-agent' ) }
+					</strong>{ ' ' }
+					{ monitor.last_monitor_summary }
+				</p>
+			) }
+			{ monitor.last_run_error && (
+				<p className="sd-ai-agent-monitor-error">
+					<strong>
+						{ __( 'Latest error:', 'superdav-ai-agent' ) }
+					</strong>{ ' ' }
+					{ monitor.last_run_error }
+				</p>
+			) }
+
+			<div className="sd-ai-agent-monitor-actions">
+				{ monitor.enabled ? (
+					<Button
+						variant="secondary"
+						onClick={ () => onDisable( monitor ) }
+					>
+						{ __( 'Disable monitoring', 'superdav-ai-agent' ) }
+					</Button>
+				) : (
+					<>
+						<Button
+							variant="primary"
+							onClick={ () => onEnable( monitor ) }
+						>
+							{ __( 'Enable monitoring', 'superdav-ai-agent' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={ () => onCheckNow( monitor ) }
+							disabled={ running === monitor.id }
+						>
+							{ running === monitor.id ? <Spinner /> : null }
+							{ __( 'Check now', 'superdav-ai-agent' ) }
+						</Button>
+					</>
+				) }
+				<Button
+					variant="tertiary"
+					onClick={ () => onViewLogs( monitor.id ) }
+				>
+					{ viewLogsId === monitor.id
+						? __( 'Hide logs', 'superdav-ai-agent' )
+						: __( 'Inspect logs', 'superdav-ai-agent' ) }
+				</Button>
+				<Button
+					icon={ pencil }
+					label={ __( 'Edit Monitor', 'superdav-ai-agent' ) }
+					onClick={ () => onEdit( monitor ) }
+					size="small"
+				/>
+				<Button
+					icon={ trash }
+					label={ __( 'Delete Monitor', 'superdav-ai-agent' ) }
+					onClick={ () => onDelete( monitor ) }
+					isDestructive
+					size="small"
+				/>
+			</div>
+
+			{ viewLogsId === monitor.id && (
+				<div className="sd-ai-agent-monitor-logs">
+					{ logs.length === 0 ? (
+						<p className="description">
+							{ __(
+								'No durable logs have been recorded yet.',
+								'superdav-ai-agent'
+							) }
+						</p>
+					) : (
+						logs.map( ( log ) => (
+							<div
+								key={ log.id }
+								className="sd-ai-agent-monitor-log"
+							>
+								<strong>
+									{ log.monitor_outcome ||
+										log.lifecycle_status }
+								</strong>
+								<span>{ log.created_at }</span>
+								{ log.error_message && (
+									<p>{ log.error_message }</p>
+								) }
+							</div>
+						) )
+					) }
+				</div>
+			) }
+		</article>
+	);
+}
+
+/** Render the opt-in Monitor/Pulse manager separate from scheduled tasks. */
+export default function MonitorManager() {
+	const [ monitors, setMonitors ] = useState( [] );
+	const [ templates, setTemplates ] = useState( [] );
+	const [ loaded, setLoaded ] = useState( false );
+	const [ showForm, setShowForm ] = useState( false );
+	const [ editId, setEditId ] = useState( null );
+	const [ form, setForm ] = useState( emptyMonitorForm() );
+	const [ notice, setNotice ] = useState( null );
+	const [ saving, setSaving ] = useState( false );
+	const [ running, setRunning ] = useState( null );
+	const [ logs, setLogs ] = useState( [] );
+	const [ viewLogsId, setViewLogsId ] = useState( null );
+
+	const fetchAll = useCallback( async () => {
+		try {
+			const [ automationResult, templateResult ] = await Promise.all( [
+				apiFetch( { path: '/sd-ai-agent/v1/automations' } ),
+				apiFetch( { path: '/sd-ai-agent/v1/automation-templates' } ),
+			] );
+			setMonitors(
+				Array.isArray( automationResult )
+					? automationResult.filter( isMonitor )
+					: []
+			);
+			setTemplates(
+				Array.isArray( templateResult )
+					? templateResult.filter( isMonitor )
+					: []
+			);
+		} catch {
+			setMonitors( [] );
+			setTemplates( [] );
+		} finally {
+			setLoaded( true );
+		}
+	}, [] );
+
+	useEffect( () => {
+		fetchAll();
+	}, [ fetchAll ] );
+
+	const resetForm = useCallback( () => {
+		setShowForm( false );
+		setEditId( null );
+		setForm( emptyMonitorForm() );
+	}, [] );
+
+	const updateForm = useCallback( ( key, value ) => {
+		setForm( ( previous ) => ( { ...previous, [ key ]: value } ) );
+	}, [] );
+
+	const updateChannel = useCallback( ( index, key, value ) => {
+		setForm( ( previous ) => {
+			const channels = [ ...( previous.notification_channels || [] ) ];
+			channels[ index ] = { ...channels[ index ], [ key ]: value };
+			return { ...previous, notification_channels: channels };
+		} );
+	}, [] );
+
+	const addChannel = useCallback( () => {
+		setForm( ( previous ) => ( {
+			...previous,
+			notification_channels: [
+				...( previous.notification_channels || [] ),
+				emptyChannel(),
+			],
+		} ) );
+	}, [] );
+
+	const removeChannel = useCallback( ( index ) => {
+		setForm( ( previous ) => {
+			const channels = [ ...( previous.notification_channels || [] ) ];
+			channels.splice( index, 1 );
+			return { ...previous, notification_channels: channels };
+		} );
+	}, [] );
+
+	const handleSubmit = useCallback( async () => {
+		if ( ! form.name.trim() || ! form.prompt.trim() ) {
+			setNotice( {
+				status: 'error',
+				message: __(
+					'A Monitor name and check instructions are required.',
+					'superdav-ai-agent'
+				),
+			} );
+			return;
+		}
+
+		setSaving( true );
+		setNotice( null );
+		const payload = { ...form, mode: 'monitor', enabled: false };
+
+		try {
+			if ( editId ) {
+				const { enabled, ...updates } = payload;
+				await apiFetch( {
+					path: `/sd-ai-agent/v1/automations/${ editId }`,
+					method: 'PATCH',
+					data: updates,
+				} );
+			} else {
+				await apiFetch( {
+					path: '/sd-ai-agent/v1/automations',
+					method: 'POST',
+					data: payload,
+				} );
+			}
+
+			resetForm();
+			await fetchAll();
+			setNotice( {
+				status: 'success',
+				message: editId
+					? __(
+							'Monitor saved without changing its enabled state.',
+							'superdav-ai-agent'
+					  )
+					: __(
+							'Monitor saved as a disabled draft.',
+							'superdav-ai-agent'
+					  ),
+			} );
+		} catch ( error ) {
+			setNotice( {
+				status: 'error',
+				message:
+					error?.message ||
+					__( 'Failed to save the Monitor.', 'superdav-ai-agent' ),
+			} );
+		} finally {
+			setSaving( false );
+		}
+	}, [ editId, fetchAll, form, resetForm ] );
+
+	const handleEdit = useCallback( ( monitor ) => {
+		setEditId( monitor.id );
+		setForm( {
+			...emptyMonitorForm(),
+			name: monitor.name || '',
+			description: monitor.description || '',
+			prompt: monitor.prompt || '',
+			monitor_scratch: monitor.monitor_scratch || '',
+			schedule: monitor.schedule || 'daily',
+			tool_profile: monitor.tool_profile || '',
+			max_iterations: monitor.max_iterations || 10,
+			notification_channels: monitor.notification_channels || [],
+			enabled: false,
+		} );
+		setShowForm( true );
+	}, [] );
+
+	const handleUseTemplate = useCallback( ( template ) => {
+		setForm( {
+			...emptyMonitorForm(),
+			name: template.name || '',
+			description: template.description || '',
+			prompt: template.prompt || '',
+			monitor_scratch: template.monitor_scratch || '',
+			schedule: template.schedule || 'daily',
+			tool_profile: template.tool_profile || '',
+			max_iterations: template.max_iterations || 10,
+			enabled: false,
+		} );
+		setEditId( null );
+		setShowForm( true );
+	}, [] );
+
+	const updateEnabled = useCallback( async ( monitor, enabled ) => {
+		const previous = monitor;
+		setNotice( null );
+		setMonitors( ( current ) =>
+			current.map( ( item ) =>
+				item.id === monitor.id ? { ...item, enabled } : item
+			)
+		);
+
+		try {
+			const updated = await apiFetch( {
+				path: `/sd-ai-agent/v1/automations/${ monitor.id }`,
+				method: 'PATCH',
+				data: { enabled },
+			} );
+			setMonitors( ( current ) =>
+				current.map( ( item ) =>
+					item.id === monitor.id
+						? { ...item, ...( updated || {} ) }
+						: item
+				)
+			);
+			setNotice( {
+				status: 'success',
+				message: enabled
+					? __(
+							'Monitor enabled. Its first recurring check is scheduled by WP-Cron.',
+							'superdav-ai-agent'
+					  )
+					: __(
+							'Monitor disabled. Future recurring checks were removed.',
+							'superdav-ai-agent'
+					  ),
+			} );
+		} catch ( error ) {
+			setMonitors( ( current ) =>
+				current.map( ( item ) =>
+					item.id === monitor.id ? previous : item
+				)
+			);
+			setNotice( {
+				status: 'error',
+				message:
+					error?.message ||
+					__(
+						'The Monitor state could not be changed. Its previous state was restored.',
+						'superdav-ai-agent'
+					),
+			} );
+		}
+	}, [] );
+
+	const handleCheckNow = useCallback(
+		async ( monitor ) => {
+			setRunning( monitor.id );
+			setNotice( null );
+
+			try {
+				const result = await apiFetch( {
+					path: `/sd-ai-agent/v1/automations/${ monitor.id }/run`,
+					method: 'POST',
+					data: { manual_monitor_draft: true },
+				} );
+				await fetchAll();
+				setNotice( {
+					status:
+						result.lifecycle_status === 'blocked'
+							? 'warning'
+							: 'success',
+					message:
+						result.lifecycle_status === 'blocked'
+							? result.error_message ||
+							  __(
+									'The Monitor check was blocked.',
+									'superdav-ai-agent'
+							  )
+							: __(
+									'Monitor check completed without enabling recurring checks.',
+									'superdav-ai-agent'
+							  ),
+				} );
+			} catch ( error ) {
+				setNotice( {
+					status: 'error',
+					message:
+						error?.message ||
+						__(
+							'The Monitor check could not be started.',
+							'superdav-ai-agent'
+						),
+				} );
+			} finally {
+				setRunning( null );
+			}
+		},
+		[ fetchAll ]
+	);
+
+	const handleViewLogs = useCallback(
+		async ( monitorId ) => {
+			if ( viewLogsId === monitorId ) {
+				setViewLogsId( null );
+				setLogs( [] );
+				return;
+			}
+
+			try {
+				const result = await apiFetch( {
+					path: `/sd-ai-agent/v1/automations/${ monitorId }/logs`,
+				} );
+				setLogs( Array.isArray( result ) ? result : [] );
+				setViewLogsId( monitorId );
+			} catch ( error ) {
+				setNotice( {
+					status: 'error',
+					message:
+						error?.message ||
+						__(
+							'Monitor logs could not be loaded.',
+							'superdav-ai-agent'
+						),
+				} );
+			}
+		},
+		[ viewLogsId ]
+	);
+
+	const handleDelete = useCallback(
+		async ( monitor ) => {
+			// eslint-disable-next-line no-alert
+			const isConfirmed = window.confirm(
+				__( 'Delete this Monitor?', 'superdav-ai-agent' )
+			);
+			if ( ! isConfirmed ) {
+				return;
+			}
+
+			try {
+				await apiFetch( {
+					path: `/sd-ai-agent/v1/automations/${ monitor.id }`,
+					method: 'DELETE',
+				} );
+				await fetchAll();
+			} catch ( error ) {
+				setNotice( {
+					status: 'error',
+					message:
+						error?.message ||
+						__(
+							'The Monitor could not be deleted.',
+							'superdav-ai-agent'
+						),
+				} );
+			}
+		},
+		[ fetchAll ]
+	);
+
+	return (
+		<section
+			className="sd-ai-agent-monitor-manager"
+			aria-labelledby="sd-ai-agent-monitor-heading"
+		>
+			<div className="sd-ai-agent-monitor-header">
+				<div>
+					<h3 id="sd-ai-agent-monitor-heading">
+						{ __( 'Monitor/Pulse', 'superdav-ai-agent' ) }
+					</h3>
+					<p className="description">
+						{ __(
+							'Monitors assess a checklist on a cadence and stay quiet unless attention is needed. They are disabled until you explicitly enable them.',
+							'superdav-ai-agent'
+						) }
+					</p>
+				</div>
+				{ ! showForm && (
+					<Button
+						variant="secondary"
+						icon={ plus }
+						onClick={ () => {
+							resetForm();
+							setShowForm( true );
+						} }
+					>
+						{ __( 'Add Monitor', 'superdav-ai-agent' ) }
+					</Button>
+				) }
+			</div>
+
+			{ notice && (
+				<Notice
+					status={ notice.status }
+					isDismissible
+					onDismiss={ () => setNotice( null ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
+
+			{ ! loaded && (
+				<p className="description">
+					{ __(
+						'Loading Monitor/Pulse configuration…',
+						'superdav-ai-agent'
+					) }
+				</p>
+			) }
+
+			{ ! showForm && templates.length > 0 && (
+				<div className="sd-ai-agent-monitor-templates">
+					<h4>{ __( 'Monitor templates', 'superdav-ai-agent' ) }</h4>
+					{ templates.map( ( template ) => (
+						<div
+							key={ template.name }
+							className="sd-ai-agent-monitor-template"
+						>
+							<div>
+								<strong>{ template.name }</strong>
+								<p>{ template.description }</p>
+							</div>
+							<Button
+								variant="secondary"
+								onClick={ () => handleUseTemplate( template ) }
+							>
+								{ __(
+									'Use as disabled draft',
+									'superdav-ai-agent'
+								) }
+							</Button>
+						</div>
+					) ) }
+				</div>
+			) }
+
+			{ showForm && (
+				<MonitorForm
+					form={ form }
+					editId={ editId }
+					saving={ saving }
+					onChange={ updateForm }
+					onAddChannel={ addChannel }
+					onUpdateChannel={ updateChannel }
+					onRemoveChannel={ removeChannel }
+					onSubmit={ handleSubmit }
+					onCancel={ resetForm }
+				/>
+			) }
+
+			{ loaded && ! showForm && monitors.length === 0 && (
+				<p className="sd-ai-agent-monitor-empty">
+					{ __(
+						'No Monitor/Pulse drafts have been created. Scheduled Tasks stay separate and continue to run their own work on every schedule.',
+						'superdav-ai-agent'
+					) }
+				</p>
+			) }
+
+			{ monitors.length > 0 && (
+				<div className="sd-ai-agent-monitor-list">
+					{ monitors.map( ( monitor ) => (
+						<MonitorCard
+							key={ monitor.id }
+							monitor={ monitor }
+							running={ running }
+							logs={ logs }
+							viewLogsId={ viewLogsId }
+							onEnable={ ( item ) => updateEnabled( item, true ) }
+							onDisable={ ( item ) =>
+								updateEnabled( item, false )
+							}
+							onCheckNow={ handleCheckNow }
+							onViewLogs={ handleViewLogs }
+							onEdit={ handleEdit }
+							onDelete={ handleDelete }
+						/>
+					) ) }
+				</div>
+			) }
+		</section>
+	);
+}

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -981,6 +981,295 @@
 	border-radius: 3px;
 }
 
+/* Monitor/Pulse */
+.sd-ai-agent-monitor-manager {
+	margin-top: 32px;
+	padding-top: 24px;
+	border-top: 1px solid #dcdcde;
+}
+
+.sd-ai-agent-monitor-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 16px;
+}
+
+.sd-ai-agent-monitor-header h3 {
+	margin: 0 0 4px;
+	font-size: 14px;
+}
+
+.sd-ai-agent-monitor-header .description {
+	margin: 0;
+	max-width: 680px;
+}
+
+.sd-ai-agent-monitor-form {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	margin-bottom: 16px;
+	padding: 16px;
+	border: 1px solid #c3d1e0;
+	border-radius: 4px;
+	background: #f0f6fc;
+}
+
+.sd-ai-agent-monitor-form .components-notice {
+	margin: 0;
+}
+
+.sd-ai-agent-monitor-form-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.sd-ai-agent-monitor-channel {
+	display: grid;
+	grid-template-columns: minmax(120px, 0.75fr) minmax(0, 2fr) minmax(105px, 0.75fr) auto;
+	gap: 8px;
+	align-items: end;
+	padding: 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.sd-ai-agent-monitor-form-actions,
+.sd-ai-agent-monitor-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+}
+
+.sd-ai-agent-monitor-templates {
+	margin-bottom: 16px;
+}
+
+.sd-ai-agent-monitor-templates h4 {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-monitor-template {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.sd-ai-agent-monitor-template + .sd-ai-agent-monitor-template {
+	margin-top: 8px;
+}
+
+.sd-ai-agent-monitor-template p {
+	margin: 4px 0 0;
+	color: #646970;
+}
+
+.sd-ai-agent-monitor-list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.sd-ai-agent-monitor-card {
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.sd-ai-agent-monitor-card--disabled {
+	border-style: dashed;
+	background: #f6f7f7;
+}
+
+.sd-ai-agent-monitor-card-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 12px;
+}
+
+.sd-ai-agent-monitor-card-header h4 {
+	margin: 0 0 4px;
+}
+
+.sd-ai-agent-monitor-card-header .description {
+	margin: 0;
+}
+
+.sd-ai-agent-monitor-status {
+	flex: 0 0 auto;
+	padding: 3px 8px;
+	border-radius: 3px;
+	background: #f0f0f1;
+	color: #50575e;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.sd-ai-agent-monitor-status--quiet {
+	background: #edfaef;
+	color: #1e6129;
+}
+
+.sd-ai-agent-monitor-status--notify {
+	background: #fcf0c8;
+	color: #6b5d14;
+}
+
+.sd-ai-agent-monitor-status--blocked,
+.sd-ai-agent-monitor-status--error {
+	background: #fcf0f1;
+	color: #d63638;
+}
+
+.sd-ai-agent-monitor-status--claimed,
+.sd-ai-agent-monitor-status--running {
+	background: #f0f6fc;
+	color: var(--wp-admin-theme-color, #2271b1);
+}
+
+.sd-ai-agent-monitor-consent {
+	margin: 0 0 12px;
+	padding: 10px 12px;
+	border-left: 4px solid #dba617;
+	background: #fcf9e8;
+}
+
+.sd-ai-agent-monitor-consent p {
+	margin: 4px 0 0;
+}
+
+.sd-ai-agent-monitor-details {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 12px;
+	margin: 0 0 12px;
+}
+
+.sd-ai-agent-monitor-details div {
+	min-width: 0;
+}
+
+.sd-ai-agent-monitor-details dt {
+	color: #646970;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.sd-ai-agent-monitor-details dd {
+	margin: 2px 0 0;
+	overflow-wrap: anywhere;
+}
+
+.sd-ai-agent-monitor-timing,
+.sd-ai-agent-monitor-cost,
+.sd-ai-agent-monitor-summary,
+.sd-ai-agent-monitor-error {
+	margin: 8px 0;
+	padding: 8px 10px;
+	border-radius: 3px;
+	font-size: 13px;
+}
+
+.sd-ai-agent-monitor-timing {
+	background: #f0f6fc;
+	color: var(--wp-admin-theme-color, #2271b1);
+}
+
+.sd-ai-agent-monitor-cost {
+	background: #f6f7f7;
+	color: #50575e;
+}
+
+.sd-ai-agent-monitor-summary {
+	background: #edfaef;
+	color: #1e6129;
+}
+
+.sd-ai-agent-monitor-error {
+	background: #fcf0f1;
+	color: #d63638;
+}
+
+.sd-ai-agent-monitor-logs {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 12px;
+	padding-top: 12px;
+	border-top: 1px solid #dcdcde;
+}
+
+.sd-ai-agent-monitor-log {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 4px 12px;
+	padding: 10px 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 3px;
+	font-size: 12px;
+}
+
+.sd-ai-agent-monitor-log span {
+	color: #646970;
+}
+
+.sd-ai-agent-monitor-log p {
+	grid-column: 1 / -1;
+	margin: 0;
+	color: #d63638;
+}
+
+.sd-ai-agent-monitor-empty {
+	margin: 0;
+	padding: 12px;
+	border: 1px dashed #a7aaad;
+	border-radius: 4px;
+	color: #50575e;
+}
+
+@media screen and (max-width: 782px) {
+	.sd-ai-agent-monitor-form-grid,
+	.sd-ai-agent-monitor-details {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.sd-ai-agent-monitor-channel {
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	}
+}
+
+@media screen and (max-width: 600px) {
+	.sd-ai-agent-monitor-header,
+	.sd-ai-agent-monitor-card-header,
+	.sd-ai-agent-monitor-template {
+		flex-direction: column;
+	}
+
+	.sd-ai-agent-monitor-form-grid,
+	.sd-ai-agent-monitor-details,
+	.sd-ai-agent-monitor-channel {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.sd-ai-agent-monitor-template .components-button {
+		width: 100%;
+		justify-content: center;
+	}
+}
+
 /* ── Abilities Manager (t098) ────────────────────────────────────────────── */
 
 .sdaa-abilities-manager {

--- a/tests/SdAiAgent/Automations/AutomationRunnerTest.php
+++ b/tests/SdAiAgent/Automations/AutomationRunnerTest.php
@@ -184,6 +184,42 @@ class AutomationRunnerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An authorized Monitor draft check bypasses only the disabled guard while
+	 * preserving the stored disabled state and the absence of a cron schedule.
+	 */
+	public function test_manual_monitor_draft_run_preserves_disabled_state_and_schedule(): void {
+		$owner_id   = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$monitor_id = (int) Automations::create(
+			[
+				'name'            => 'Manual Monitor Draft',
+				'prompt'          => 'Assess the current site state.',
+				'mode'            => Automations::MONITOR_MODE,
+				'monitor_scratch' => '',
+				'owner_user_id'   => $owner_id,
+				'enabled'         => 0,
+			]
+		);
+
+		$this->assertGreaterThan( 0, $monitor_id );
+		$this->assertFalse( wp_next_scheduled( AutomationRunner::CRON_HOOK, [ $monitor_id ] ) );
+
+		$result  = AutomationRunner::run_manual_monitor_draft( $monitor_id );
+		$monitor = Automations::get( $monitor_id );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'succeeded', $result['lifecycle_status'] );
+		$this->assertSame( 'quiet', $result['monitor_outcome'] );
+		$this->assertNotNull( $monitor );
+		$this->assertFalse( $monitor['enabled'] );
+		$this->assertSame( 'quiet', $monitor['last_monitor_outcome'] );
+		$this->assertFalse( wp_next_scheduled( AutomationRunner::CRON_HOOK, [ $monitor_id ] ) );
+
+		$log = AutomationLogs::get_by_run_id( $result['run_id'] );
+		$this->assertNotNull( $log );
+		$this->assertSame( 'manual', $log['trigger_type'] );
+	}
+
+	/**
 	 * Legacy ownerless rows fail closed even when an old cron event is still
 	 * delivered after the schema upgrade.
 	 */

--- a/tests/SdAiAgent/REST/AutomationControllerTest.php
+++ b/tests/SdAiAgent/REST/AutomationControllerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * REST integration tests for the Monitor/Pulse draft check route.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Automations\AutomationRunner;
+use SdAiAgent\Automations\Automations;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+final class AutomationControllerTest extends WP_UnitTestCase {
+
+	/** @var WP_REST_Server REST server used to dispatch controller routes. */
+	private WP_REST_Server $server;
+
+	/** @var int Administrator permitted to invoke the protected route. */
+	private int $admin_id;
+
+	/** @var int Subscriber used to verify the permission callback. */
+	private int $subscriber_id;
+
+	/** Register REST routes and create users for each request-level test. */
+	public function set_up(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress REST test global.
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Standard WordPress REST hook.
+		do_action( 'rest_api_init' );
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+	}
+
+	/** Clear registered test state after each test. */
+	public function tear_down(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress REST test global.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/** Create a disabled Monitor whose empty checklist avoids provider work. */
+	private function create_disabled_monitor(): int {
+		$monitor_id = Automations::create(
+			[
+				'name'            => 'REST Monitor Draft',
+				'prompt'          => 'Assess the current site state.',
+				'mode'            => Automations::MONITOR_MODE,
+				'monitor_scratch' => '',
+				'owner_user_id'   => $this->admin_id,
+				'enabled'         => 0,
+			]
+		);
+
+		$this->assertIsInt( $monitor_id );
+		$this->assertGreaterThan( 0, $monitor_id );
+
+		return $monitor_id;
+	}
+
+	/** Dispatch a JSON REST request through the registered controller routes. */
+	private function dispatch( string $method, string $route, array $params = [] ): WP_REST_Response|WP_Error {
+		$request = new WP_REST_Request( $method, $route );
+		$request->set_body( (string) wp_json_encode( $params ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		return $this->server->dispatch( $request );
+	}
+
+	/** Assert a response or error uses the expected REST status. */
+	private function assert_status( int $expected, WP_REST_Response|WP_Error $response ): void {
+		if ( is_wp_error( $response ) ) {
+			$data   = $response->get_error_data();
+			$status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+		} else {
+			$status = $response->get_status();
+		}
+
+		$this->assertSame( $expected, $status );
+	}
+
+	/** A permitted Check now call runs one disabled Monitor draft without scheduling it. */
+	public function test_manual_monitor_draft_check_preserves_disabled_state_and_no_schedule(): void {
+		wp_set_current_user( $this->admin_id );
+		$monitor_id = $this->create_disabled_monitor();
+
+		$this->assertFalse( wp_next_scheduled( AutomationRunner::CRON_HOOK, [ $monitor_id ] ) );
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/automations/{$monitor_id}/run",
+			[ 'manual_monitor_draft' => true ]
+		);
+
+		$this->assert_status( 200, $response );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'succeeded', $response->get_data()['lifecycle_status'] );
+		$this->assertSame( 'quiet', $response->get_data()['monitor_outcome'] );
+
+		$monitor = Automations::get( $monitor_id );
+		$this->assertNotNull( $monitor );
+		$this->assertFalse( $monitor['enabled'] );
+		$this->assertSame( 'quiet', $monitor['last_monitor_outcome'] );
+		$this->assertFalse( wp_next_scheduled( AutomationRunner::CRON_HOOK, [ $monitor_id ] ) );
+	}
+
+	/** The protected route rejects a user without automation-management capability. */
+	public function test_manual_monitor_draft_check_requires_administrator(): void {
+		wp_set_current_user( $this->admin_id );
+		$monitor_id = $this->create_disabled_monitor();
+		wp_set_current_user( $this->subscriber_id );
+
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/automations/{$monitor_id}/run",
+			[ 'manual_monitor_draft' => true ]
+		);
+
+		$this->assert_status( 403, $response );
+		$this->assertFalse( wp_next_scheduled( AutomationRunner::CRON_HOOK, [ $monitor_id ] ) );
+		$this->assertFalse( Automations::get( $monitor_id )['enabled'] );
+	}
+
+	/** The manual flag cannot turn the existing scheduled-task path into a draft runner. */
+	public function test_manual_monitor_draft_check_rejects_scheduled_task(): void {
+		wp_set_current_user( $this->admin_id );
+		$task_id = Automations::create(
+			[
+				'name'          => 'Scheduled task',
+				'prompt'        => 'This must remain blocked.',
+				'owner_user_id' => $this->admin_id,
+				'enabled'       => 0,
+			]
+		);
+		$this->assertIsInt( $task_id );
+
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/automations/{$task_id}/run",
+			[ 'manual_monitor_draft' => true ]
+		);
+
+		$this->assert_status( 400, $response );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame(
+			'sd_ai_agent_automation_manual_draft_requires_disabled_monitor',
+			$response->get_data()['code'] ?? ''
+		);
+	}
+}

--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -2,7 +2,8 @@
  * E2E tests for the Superdav AI Agent automations system (t080/t081).
  *
  * Covers:
- *   - Scheduled automations: create, list, enable/disable toggle
+ *   - Scheduled tasks: create, list, enable/disable toggle
+ *   - Monitor/Pulse: disabled drafts, explicit enable, and one-off checks
  *   - Event-driven automations: create, list, enable/disable toggle
  *   - Proactive alert badge on the FAB
  *
@@ -31,11 +32,38 @@ const MOCK_AUTOMATION = {
 	schedule: 'daily',
 	tool_profile: '',
 	max_iterations: 10,
+	mode: 'task',
 	enabled: true,
 	notification_channels: [],
 	run_count: 3,
 	last_run_at: '2026-03-18 08:00:00',
 	next_run_at: null,
+	created_at: '2026-01-01 00:00:00',
+	updated_at: '2026-03-18 08:00:00',
+};
+
+/** A minimal disabled Monitor/Pulse definition returned by the REST API. */
+const MOCK_MONITOR = {
+	id: 2,
+	name: 'Test Site Availability Monitor',
+	description: 'Assess site availability and notify only when attention is needed.',
+	prompt: 'Assess the current site health.',
+	monitor_scratch: 'Check the home page and Site Health summary.',
+	schedule: 'daily',
+	tool_profile: 'site-health',
+	max_iterations: 10,
+	mode: 'monitor',
+	enabled: false,
+	notification_channels: [],
+	run_count: 1,
+	last_run_at: '2026-03-18 08:00:00',
+	next_run_at: null,
+	last_monitor_outcome: 'quiet',
+	last_monitor_summary: 'No attention is needed.',
+	last_run_error: '',
+	execution_status: 'idle',
+	owner_user_id: 1,
+	monitor_timing_help: 'WP-Cron can run late when site traffic is low.',
 	created_at: '2026-01-01 00:00:00',
 	updated_at: '2026-03-18 08:00:00',
 };
@@ -90,6 +118,15 @@ const MOCK_TEMPLATES = [
 		prompt: 'Check site health.',
 		schedule: 'daily',
 		tool_profile: 'site-health',
+	},
+	{
+		name: 'Availability Monitor Template',
+		description: 'Assess availability without notifying when the site is healthy.',
+		prompt: 'Assess the site health and report only attention-needed outcomes.',
+		monitor_scratch: 'Check the home page and Site Health summary.',
+		schedule: 'daily',
+		tool_profile: 'site-health',
+		mode: 'monitor',
 	},
 ];
 
@@ -415,6 +452,24 @@ async function goToAutomationsTab( page ) {
 }
 
 /**
+ * Navigate to the Monitor/Pulse manager inside the Automations tab.
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page.
+ * @return {Promise<import('@playwright/test').Locator>} Monitor manager.
+ */
+async function goToMonitorManager( page ) {
+	await goToAutomationsTab( page );
+	const manager = page.locator( '.sd-ai-agent-monitor-manager' );
+	await manager.waitFor( { state: 'visible', timeout: 15_000 } );
+	await manager
+		.getByText( 'Loading Monitor/Pulse configuration…' )
+		.waitFor( { state: 'hidden', timeout: 10_000 } )
+		.catch( () => {} ); // Already gone — that's fine.
+
+	return manager;
+}
+
+/**
  * Navigate to the Settings page and activate the Automations tab to reach the
  * EventsManager.
  *
@@ -463,7 +518,7 @@ test.describe( 'Scheduled Automations (t080)', () => {
 		await loginToWordPress( page );
 	} );
 
-	test( 'automations tab renders the manager heading', async ( { page } ) => {
+	test( 'automations tab renders the scheduled tasks heading', async ( { page } ) => {
 		await goToAutomationsTab( page );
 
 		const manager = page.locator( '.sdaa-automations-manager' );
@@ -471,7 +526,7 @@ test.describe( 'Scheduled Automations (t080)', () => {
 
 		// Heading text.
 		await expect(
-			page.getByRole( 'heading', { name: /scheduled automations/i } )
+			page.getByRole( 'heading', { name: /scheduled tasks/i } )
 		).toBeVisible();
 	} );
 
@@ -828,6 +883,370 @@ test.describe( 'Scheduled Automations (t080)', () => {
 
 		const nameInput = form.getByLabel( /^name/i );
 		await expect( nameInput ).toHaveValue( MOCK_TEMPLATES[ 0 ].name );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Monitor/Pulse
+// ---------------------------------------------------------------------------
+
+test.describe( 'Monitor/Pulse', () => {
+	test.beforeEach( async ( { page } ) => {
+		await mockAutomationRoutes( page );
+		await loginToWordPress( page );
+	} );
+
+	test( 'renders Monitor/Pulse separately from Scheduled Tasks', async ( {
+		page,
+	} ) => {
+		await mockAutomationRoutes( page, {
+			automations: [ MOCK_AUTOMATION, MOCK_MONITOR ],
+		} );
+
+		const manager = await goToMonitorManager( page );
+		const monitorCard = manager
+			.locator( '.sd-ai-agent-monitor-card' )
+			.filter( { hasText: MOCK_MONITOR.name } );
+
+		await expect(
+			manager.getByRole( 'heading', { name: 'Monitor/Pulse' } )
+		).toBeVisible();
+		await expect( monitorCard ).toBeVisible();
+		await expect( monitorCard ).toContainText( 'Disabled draft' );
+		await expect( monitorCard ).toContainText( 'Quiet' );
+		await expect( monitorCard ).toContainText(
+			'No attention notifications'
+		);
+		await expect(
+			monitorCard.getByRole( 'button', { name: 'Check now' } )
+		).toBeVisible();
+		await expect(
+			page
+				.locator( '.sdaa-skill-card' )
+				.filter( { hasText: MOCK_MONITOR.name } )
+		).toHaveCount( 0 );
+	} );
+
+	test( 'renders all API Monitor outcomes and delayed WP-Cron context', async ( {
+		page,
+	} ) => {
+		const monitors = [
+			{ ...MOCK_MONITOR, id: 3, name: 'Quiet Monitor' },
+			{
+				...MOCK_MONITOR,
+				id: 4,
+				name: 'Attention Monitor',
+				last_monitor_outcome: 'notify',
+				last_monitor_summary: 'An administrator should review this result.',
+			},
+			{
+				...MOCK_MONITOR,
+				id: 5,
+				name: 'Blocked Monitor',
+				last_monitor_outcome: 'blocked',
+				last_run_error: 'Approval is required before this check can continue.',
+			},
+			{
+				...MOCK_MONITOR,
+				id: 6,
+				name: 'Error Monitor',
+				last_monitor_outcome: 'error',
+				last_run_error: 'The provider returned an error.',
+			},
+			{
+				...MOCK_MONITOR,
+				id: 7,
+				name: 'Delayed Monitor',
+				enabled: true,
+				next_run_at: '2020-01-01 00:00:00',
+			},
+		];
+
+		await mockAutomationRoutes( page, { automations: monitors } );
+		const manager = await goToMonitorManager( page );
+
+		for ( const [ name, outcome ] of [
+			[ 'Quiet Monitor', 'Quiet' ],
+			[ 'Attention Monitor', 'Attention needed' ],
+			[ 'Blocked Monitor', 'Blocked' ],
+			[ 'Error Monitor', 'Error' ],
+		] ) {
+			const card = manager
+				.locator( '.sd-ai-agent-monitor-card' )
+				.filter( { hasText: name } );
+			await expect( card.getByText( outcome, { exact: true } ) ).toBeVisible();
+		}
+
+		await expect(
+			manager
+				.locator( '.sd-ai-agent-monitor-card' )
+				.filter( { hasText: 'Delayed Monitor' } )
+				.getByText( 'The next expected check time has passed, so WP-Cron may be delayed.' )
+		).toBeVisible();
+	} );
+
+	test( 'new Monitor form starts as a disabled draft', async ( { page } ) => {
+		const manager = await goToMonitorManager( page );
+
+		await manager.getByRole( 'button', { name: 'Add Monitor' } ).click();
+
+		const form = manager.locator( '.sd-ai-agent-monitor-form' );
+		const saveButton = form.getByRole( 'button', {
+			name: 'Save Monitor draft',
+		} );
+
+		await expect( form ).toContainText(
+			'New Monitors are saved as disabled drafts.'
+		);
+		await expect( saveButton ).toBeDisabled();
+		await form.getByLabel( 'Monitor name' ).fill( 'New Monitor' );
+		await form
+			.getByLabel( 'Check instructions' )
+			.fill( 'Assess the current site health.' );
+		await expect( saveButton ).toBeEnabled();
+	} );
+
+	test( 'template Monitor saves as a disabled draft', async ( { page } ) => {
+		let createdMonitor = null;
+		let postBody = null;
+
+		await page.route( '**', async ( route ) => {
+			const decodedUrl = decodeURIComponent( route.request().url() );
+			const isAutomationCollection =
+				decodedUrl.includes( 'sd-ai-agent/v1/automations' ) &&
+				! decodedUrl.includes( '/automation-templates' ) &&
+				! /sd-ai-agent\/v1\/automations\/\d/.test( decodedUrl );
+
+			if ( ! isAutomationCollection ) {
+				return route.fallback();
+			}
+
+			if ( route.request().method() === 'POST' ) {
+				postBody = JSON.parse( route.request().postData() || '{}' );
+				createdMonitor = {
+					...MOCK_MONITOR,
+					...postBody,
+					id: 99,
+				};
+				return route.fulfill( {
+					status: 201,
+					contentType: 'application/json',
+					body: JSON.stringify( createdMonitor ),
+				} );
+			}
+
+			if ( route.request().method() === 'GET' ) {
+				return route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(
+						createdMonitor ? [ createdMonitor ] : []
+					),
+				} );
+			}
+
+			return route.fallback();
+		} );
+
+		const manager = await goToMonitorManager( page );
+		await manager
+			.getByRole( 'button', { name: 'Use as disabled draft' } )
+			.click();
+
+		const form = manager.locator( '.sd-ai-agent-monitor-form' );
+		await form
+			.getByRole( 'button', { name: 'Save Monitor draft' } )
+			.click();
+
+		await expect.poll( () => postBody ).not.toBeNull();
+		expect( postBody ).toMatchObject( {
+			name: 'Availability Monitor Template',
+			mode: 'monitor',
+			enabled: false,
+		} );
+		await expect(
+			manager
+				.locator( '.components-notice' )
+				.filter( { hasText: 'Monitor saved as a disabled draft.' } )
+		).toBeVisible();
+		await expect(
+			manager
+				.locator( '.sd-ai-agent-monitor-card' )
+				.filter( { hasText: 'Availability Monitor Template' } )
+		).toHaveClass( /sd-ai-agent-monitor-card--disabled/ );
+	} );
+
+	test( 'Check now uses the manual draft contract without enabling monitoring', async ( {
+		page,
+	} ) => {
+		let checkBody = null;
+		let patchCalled = false;
+
+		await mockAutomationRoutes( page, { automations: [ MOCK_MONITOR ] } );
+		await page.route( '**', async ( route ) => {
+			const decodedUrl = decodeURIComponent( route.request().url() );
+			const method = route.request().method();
+			const override = route.request().headers()[
+				'x-http-method-override'
+			];
+			const effectiveMethod = override || method;
+
+			if (
+				/sd-ai-agent\/v1\/automations\/2\/run/.test( decodedUrl ) &&
+				effectiveMethod === 'POST'
+			) {
+				checkBody = JSON.parse( route.request().postData() || '{}' );
+				return route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						lifecycle_status: 'succeeded',
+						monitor_outcome: 'quiet',
+					} ),
+				} );
+			}
+
+			if (
+				/sd-ai-agent\/v1\/automations\/2\b/.test( decodedUrl ) &&
+				effectiveMethod === 'PATCH'
+			) {
+				patchCalled = true;
+			}
+
+			return route.fallback();
+		} );
+
+		const manager = await goToMonitorManager( page );
+		const card = manager.locator( '.sd-ai-agent-monitor-card' );
+
+		await card.getByRole( 'button', { name: 'Check now' } ).click();
+
+		await expect.poll( () => checkBody ).not.toBeNull();
+		expect( checkBody ).toEqual( { manual_monitor_draft: true } );
+		expect( patchCalled ).toBe( false );
+		await expect( card ).toHaveClass( /sd-ai-agent-monitor-card--disabled/ );
+		await expect( card ).toContainText( 'Not scheduled' );
+		await expect(
+			manager.getByText(
+				'Monitor check completed without enabling recurring checks.'
+			)
+		).toBeVisible();
+	} );
+
+	test( 'Enable monitoring is a separate affirmative action', async ( {
+		page,
+	} ) => {
+		let patchBody = null;
+
+		await mockAutomationRoutes( page, { automations: [ MOCK_MONITOR ] } );
+		await page.route( '**', async ( route ) => {
+			const decodedUrl = decodeURIComponent( route.request().url() );
+			const method = route.request().method();
+			const override = route.request().headers()[
+				'x-http-method-override'
+			];
+			const effectiveMethod = override || method;
+
+			if (
+				/sd-ai-agent\/v1\/automations\/2\b/.test( decodedUrl ) &&
+				effectiveMethod === 'PATCH'
+			) {
+				patchBody = JSON.parse( route.request().postData() || '{}' );
+				return route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						...MOCK_MONITOR,
+						enabled: true,
+						next_run_at: '2026-03-19 08:00:00',
+					} ),
+				} );
+			}
+
+			return route.fallback();
+		} );
+
+		const manager = await goToMonitorManager( page );
+		const card = manager.locator( '.sd-ai-agent-monitor-card' );
+
+		const enableButton = card.getByRole( 'button', {
+			name: 'Enable monitoring',
+		} );
+		await enableButton.focus();
+		await expect( enableButton ).toBeFocused();
+		await page.keyboard.press( 'Enter' );
+
+		await expect.poll( () => patchBody ).not.toBeNull();
+		expect( patchBody ).toEqual( { enabled: true } );
+		await expect( card ).not.toHaveClass(
+			/sd-ai-agent-monitor-card--disabled/
+		);
+		await expect(
+			card.getByRole( 'button', { name: 'Disable monitoring' } )
+		).toBeVisible();
+	} );
+
+	test( 'failed enable restores the disabled draft state', async ( { page } ) => {
+		await mockAutomationRoutes( page, { automations: [ MOCK_MONITOR ] } );
+		await page.route( '**', async ( route ) => {
+			const decodedUrl = decodeURIComponent( route.request().url() );
+			const method = route.request().method();
+			const override = route.request().headers()[
+				'x-http-method-override'
+			];
+			const effectiveMethod = override || method;
+
+			if (
+				/sd-ai-agent\/v1\/automations\/2\b/.test( decodedUrl ) &&
+				effectiveMethod === 'PATCH'
+			) {
+				return route.fulfill( {
+					status: 500,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						code: 'sd_ai_agent_monitor_enable_failed',
+						message: 'Enable failed for this test.',
+					} ),
+				} );
+			}
+
+			return route.fallback();
+		} );
+
+		const manager = await goToMonitorManager( page );
+		const card = manager.locator( '.sd-ai-agent-monitor-card' );
+		await card
+			.getByRole( 'button', { name: 'Enable monitoring' } )
+			.click();
+
+		await expect(
+			manager.getByText( 'Enable failed for this test.' )
+		).toBeVisible();
+		await expect( card ).toHaveClass( /sd-ai-agent-monitor-card--disabled/ );
+		await expect(
+			card.getByRole( 'button', { name: 'Enable monitoring' } )
+		).toBeVisible();
+	} );
+
+	test( 'keeps Monitor consent and form controls usable on a mobile viewport', async ( {
+		page,
+	} ) => {
+		await page.setViewportSize( { width: 600, height: 900 } );
+		await mockAutomationRoutes( page, { automations: [ MOCK_MONITOR ] } );
+
+		const manager = await goToMonitorManager( page );
+		const card = manager.locator( '.sd-ai-agent-monitor-card' );
+		await expect( card.getByText( 'Disabled draft' ) ).toBeVisible();
+		await expect(
+			card.getByRole( 'button', { name: 'Enable monitoring' } )
+		).toBeVisible();
+
+		await manager.getByRole( 'button', { name: 'Add Monitor' } ).click();
+		const form = manager.locator( '.sd-ai-agent-monitor-form' );
+		await expect( form.getByLabel( 'Monitor name' ) ).toBeVisible();
+		await expect(
+			form.getByRole( 'button', { name: 'Save Monitor draft' } )
+		).toBeVisible();
 	} );
 } );
 


### PR DESCRIPTION
## Summary

- Adds a dedicated Monitor/Pulse admin surface separate from Scheduled Tasks, with health, ownership, cadence, tool-profile, outcome, and delayed-WP-Cron context.
- Keeps new, template-derived, and edited Monitor configuration disabled until the dedicated **Enable monitoring** action is used.
- Adds the controller-authorized **Check now** path for one disabled Monitor draft run without enabling it or creating a recurring schedule.
- Preserves existing Scheduled Task creation, edit, toggle, log, and run behavior.

## Files Changed

- Monitor/Pulse UI and styles: `src/settings-page/monitor-manager.js`, `src/settings-page/automations-manager.js`, `src/settings-page/style.css`
- Manual-draft backend contract: `includes/Automations/AutomationRunner.php`, `includes/REST/AutomationController.php`
- Coverage and guidance: `tests/e2e/automations.spec.js`, `tests/SdAiAgent/Automations/AutomationRunnerTest.php`, `tests/SdAiAgent/REST/AutomationControllerTest.php`, `DESIGN.md`

## Worker self-verification

- PHPUnit: Tests: 4209, Assertions: 19264, Errors: 0, Failures: 0, Skipped: 136
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed
- E2E: 38/38 automation tests passed

## CI status

- The fresh-WordPress-trunk PHPUnit job fails 16 ability-registration assertions outside this change surface; one failed-job rerun reproduced the same result.
- The initial PR head had the same failure pattern. No merge was attempted while the required CI check remains failed.

Resolves #2566

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-terra spent 1h 39m and 1,211,676 tokens on this as a headless worker.