### PR TITLE
Fix oversized recoverable provider retries

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3228,6 +3228,8 @@ final class SessionController {
 			);
 		}
 
+		$paused_state = self::compact_oversized_provider_retry_state( $paused_state, $session_id );
+
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 		$job    = array(
@@ -3283,6 +3285,60 @@ final class SessionController {
 			),
 			202
 		);
+	}
+
+	/**
+	 * Ensure a manual provider retry makes payload progress instead of resending
+	 * the same oversized single-turn history that already exhausted all retries.
+	 *
+	 * @param array<string, mixed> $paused_state Recoverable loop state.
+	 * @param int                  $session_id   Owning session identifier.
+	 * @return array<string, mixed> State with bounded history when required.
+	 */
+	private static function compact_oversized_provider_retry_state( array $paused_state, int $session_id ): array {
+		if ( 'provider_retry_failed' !== ( $paused_state['exit_reason'] ?? '' ) ) {
+			return $paused_state;
+		}
+
+		$history = $paused_state['history'] ?? array();
+		if ( ! is_array( $history ) || empty( $history ) ) {
+			return $paused_state;
+		}
+
+		$encoded_history = wp_json_encode( $history );
+		$request_bytes   = is_string( $encoded_history ) ? strlen( $encoded_history ) : 0;
+		$request_tokens  = (int) ceil( $request_bytes / 4 );
+		if (
+			$request_bytes <= ConversationTrimmer::COMPACT_MAX_BYTES
+			&& $request_tokens <= ConversationTrimmer::COMPACT_MAX_TOKENS
+		) {
+			return $paused_state;
+		}
+
+		$compacted = ConversationTrimmer::compact_serialized_history( array_values( $history ) );
+		if ( empty( $compacted['messages'] ) ) {
+			return $paused_state;
+		}
+
+		$paused_state['history'] = $compacted['messages'];
+
+		AgentEventLog::log(
+			'recoverable_job_history_compacted',
+			AgentEventLog::SEVERITY_INFO,
+			array(
+				'session_id'              => $session_id,
+				'phase'                   => 'recoverable_job_resume',
+				'provider_id'             => (string) ( $paused_state['provider_id'] ?? '' ),
+				'model_id'                => (string) ( $paused_state['model_id'] ?? '' ),
+				'history_count'           => count( $history ),
+				'request_bytes_estimate'  => $request_bytes,
+				'request_tokens_estimate' => $request_tokens,
+				'payload_reduced'         => true,
+				'recovery_outcome'        => 'compact_provider_retry',
+			)
+		);
+
+		return $paused_state;
 	}
 
 	/**

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3308,14 +3308,24 @@ final class SessionController {
 		$encoded_history = wp_json_encode( $history );
 		$request_bytes   = is_string( $encoded_history ) ? strlen( $encoded_history ) : 0;
 		$request_tokens  = (int) ceil( $request_bytes / 4 );
+		$provider_id     = (string) ( $paused_state['provider_id'] ?? '' );
+		$model_id        = (string) ( $paused_state['model_id'] ?? '' );
+		$max_bytes       = min(
+			ConversationTrimmer::COMPACT_MAX_BYTES,
+			ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id )
+		);
+		$max_tokens      = min(
+			ConversationTrimmer::COMPACT_MAX_TOKENS,
+			ConversationTrimmer::get_request_token_budget( $provider_id, $model_id )
+		);
 		if (
-			$request_bytes <= ConversationTrimmer::COMPACT_MAX_BYTES
-			&& $request_tokens <= ConversationTrimmer::COMPACT_MAX_TOKENS
+			$request_bytes <= $max_bytes
+			&& $request_tokens <= $max_tokens
 		) {
 			return $paused_state;
 		}
 
-		$compacted = ConversationTrimmer::compact_serialized_history( array_values( $history ) );
+		$compacted = ConversationTrimmer::compact_serialized_history( array_values( $history ), $max_bytes, $max_tokens );
 		if ( empty( $compacted['messages'] ) ) {
 			return $paused_state;
 		}
@@ -3328,8 +3338,8 @@ final class SessionController {
 			array(
 				'session_id'              => $session_id,
 				'phase'                   => 'recoverable_job_resume',
-				'provider_id'             => (string) ( $paused_state['provider_id'] ?? '' ),
-				'model_id'                => (string) ( $paused_state['model_id'] ?? '' ),
+				'provider_id'             => $provider_id,
+				'model_id'                => $model_id,
 				'history_count'           => count( $history ),
 				'request_bytes_estimate'  => $request_bytes,
 				'request_tokens_estimate' => $request_tokens,

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1728,7 +1728,19 @@ class RestControllerTest extends WP_UnitTestCase {
 			]
 		);
 
-		$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/resume" );
+		$byte_budget   = static fn(): int => 20000;
+		$safety_margin = static fn(): int => 18000;
+		$token_budget  = static fn(): int => 500;
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10, 3 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10, 4 );
+		add_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10, 3 );
+		try {
+			$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/resume" );
+		} finally {
+			remove_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10 );
+			remove_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10 );
+			remove_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10 );
+		}
 
 		$this->assertStatus( 202, $response );
 		$data = $response->get_data();
@@ -1737,6 +1749,8 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $job['recovery_state']['history'] );
 		$compacted_json = (string) wp_json_encode( $job['recovery_state']['history'] );
 		$this->assertLessThan( strlen( (string) wp_json_encode( $history ) ), strlen( $compacted_json ) );
+		$this->assertLessThanOrEqual( 2000, strlen( $compacted_json ) );
+		$this->assertLessThanOrEqual( 500, (int) ceil( strlen( $compacted_json ) / 4 ) );
 		$this->assertStringContainsString( 'Home#17', $compacted_json );
 		$this->assertStringContainsString( 'Contact#13', $compacted_json );
 		$this->assertStringNotContainsString( 'SECRET_PAGE_CONTENT', $compacted_json );

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1666,6 +1666,84 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertNull( Database::load_and_clear_paused_state( $session_id ) );
 	}
 
+	/** Oversized exhausted-provider state is compacted before a manual retry. */
+	public function test_resume_recoverable_job_compacts_oversized_provider_retry_state(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Compact provider retry',
+		] );
+		$history    = [
+			[
+				'role'  => 'user',
+				'parts' => [ [ 'text' => str_repeat( 'Large onboarding context. ', 4000 ) ] ],
+			],
+			[
+				'role'  => 'model',
+				'parts' => [
+					[
+						'functionCall' => [
+							'name' => 'wpab__sd-ai-agent__batch-create-posts',
+							'args' => [
+								'posts' => [
+									[ 'title' => 'Home', 'content' => 'SECRET_PAGE_CONTENT' ],
+									[ 'title' => 'Contact', 'content' => 'SECRET_CONTACT_DETAILS' ],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'wpab__sd-ai-agent__batch-create-posts',
+							'response' => wp_json_encode(
+								[
+									'results'       => [
+										[ 'post_id' => 17, 'title' => 'Home', 'permalink' => 'https://private.example/home/' ],
+										[ 'post_id' => 13, 'title' => 'Contact', 'permalink' => 'https://private.example/contact/' ],
+									],
+									'created_count' => 2,
+								],
+							),
+						],
+					],
+				],
+			],
+		];
+		Database::save_paused_state(
+			$session_id,
+			[
+				'history'       => $history,
+				'tool_call_log' => [],
+				'message_log'   => [],
+				'token_usage'   => [ 'prompt' => 0, 'completion' => 0 ],
+				'provider_id'   => 'sd-ai-agent-cloud',
+				'model_id'      => 'superdav-chat-pro',
+				'exit_reason'   => 'provider_retry_failed',
+			]
+		);
+
+		$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/resume" );
+
+		$this->assertStatus( 202, $response );
+		$data = $response->get_data();
+		$job  = get_transient( RestController::JOB_PREFIX . $data['job_id'] );
+		$this->assertIsArray( $job );
+		$this->assertCount( 1, $job['recovery_state']['history'] );
+		$compacted_json = (string) wp_json_encode( $job['recovery_state']['history'] );
+		$this->assertLessThan( strlen( (string) wp_json_encode( $history ) ), strlen( $compacted_json ) );
+		$this->assertStringContainsString( 'Home#17', $compacted_json );
+		$this->assertStringContainsString( 'Contact#13', $compacted_json );
+		$this->assertStringNotContainsString( 'SECRET_PAGE_CONTENT', $compacted_json );
+		$this->assertStringNotContainsString( 'SECRET_CONTACT_DETAILS', $compacted_json );
+		$this->assertStringNotContainsString( 'private.example', $compacted_json );
+	}
+
 	/**
 	 * Test a resume action cannot start without durable recoverable state.
 	 */


### PR DESCRIPTION
## Summary

- compact oversized `provider_retry_failed` history before dispatching a manual retry
- reuse deterministic server-side compaction so page IDs/titles survive without raw page content, tool payloads, or URLs
- emit bounded retry-compaction telemetry

## Why

A retained Setup Assistant run accepted its browser-tool result, then repeatedly received HTTP 503 for a 317–323 KB provider envelope. `Retry failed step` atomically consumed the durable state but resent the same oversized single-turn history. This change guarantees payload progress while preserving mutation receipts that prevent duplicate pages.

## Worker self-verification

- PHPUnit: Tests: 4208, Assertions: 19177, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Focused verification

- `pnpm run test:php -- --filter="test_resume_recoverable_job"` — 3 tests, 17 assertions
- `vendor/bin/phpcs includes/REST/SessionController.php tests/SdAiAgent/REST/RestControllerTest.php`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of paused jobs that exceed conversation size limits.
  - Automatically compacts oversized retry history before resuming processing.
  - Preserves safe result identifiers while removing sensitive tool details.
  - Ensures successful background job creation after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->