### PR TITLE
Fix persisted provider retry recovery

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3296,7 +3296,8 @@ final class SessionController {
 	 * @return array<string, mixed> State with bounded history when required.
 	 */
 	private static function compact_oversized_provider_retry_state( array $paused_state, int $session_id ): array {
-		if ( 'provider_retry_failed' !== ( $paused_state['exit_reason'] ?? '' ) ) {
+		$exit_reason = (string) ( $paused_state['exit_reason'] ?? '' );
+		if ( ! in_array( $exit_reason, array( 'provider_retry_failed', 'sd_ai_agent_provider_retry_failed' ), true ) ) {
 			return $paused_state;
 		}
 

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1724,7 +1724,7 @@ class RestControllerTest extends WP_UnitTestCase {
 				'token_usage'   => [ 'prompt' => 0, 'completion' => 0 ],
 				'provider_id'   => 'sd-ai-agent-cloud',
 				'model_id'      => 'superdav-chat-pro',
-				'exit_reason'   => 'provider_retry_failed',
+				'exit_reason'   => 'sd_ai_agent_provider_retry_failed',
 			]
 		);
 


### PR DESCRIPTION
## Summary

- recognize the REST-persisted `sd_ai_agent_provider_retry_failed` exit reason during manual recovery
- retain support for the internal `provider_retry_failed` state written directly by the agent loop
- exercise the integration regression with the value stored by `persist_error_recovery_to_session()`

## Why

Follow-up validation of #2570 against retained Setup Assistant state found that the REST error-persistence path replaces the loop's internal exit reason with the `WP_Error` code. The compactor therefore did not activate for the actual 324 KB paused state even though its history met the size threshold.

## Worker self-verification

- PHPUnit: Tests: 4208, Assertions: 19186, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Focused verification

- `vendor/bin/phpunit --filter "test_resume_recoverable_job"` — 3 tests, 21 assertions
- `vendor/bin/phpcs includes/REST/SessionController.php tests/SdAiAgent/REST/RestControllerTest.php`
- `vendor/bin/phpstan analyse --no-progress includes/REST/SessionController.php`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol
