### PR TITLE
Fix automatic recovery for large provider retries

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2454,10 +2454,11 @@ PROMPT;
 			return $this->with_payload_recovery_metadata( $error, $before_bytes, $before_tokens, false, false );
 		}
 
-		$provider_recovery_history = null;
-		$result                    = $this->send_prompt( $provider_id, $model_id );
+		$provider_recovery_history      = null;
+		$provider_recovery_paused_state = null;
+		$result                         = $this->send_prompt( $provider_id, $model_id );
 		if ( is_wp_error( $result ) && 'sd_ai_agent_provider_retry_failed' === $result->get_error_code() ) {
-			$result        = $this->retry_large_provider_failure_with_compacted_history( $result, $provider_id, $model_id, $provider_recovery_history );
+			$result        = $this->retry_large_provider_failure_with_compacted_history( $result, $provider_id, $model_id, $provider_recovery_history, $provider_recovery_paused_state );
 			$before_bytes  = ConversationTrimmer::estimate_total_bytes( $this->history );
 			$before_tokens = ConversationTrimmer::estimate_total_tokens( $this->history );
 		}
@@ -2568,6 +2569,7 @@ PROMPT;
 			}
 
 			$this->restore_provider_recovery_history( $provider_recovery_history );
+			$this->restore_provider_recovery_paused_state( $provider_recovery_paused_state );
 			return $this->with_payload_recovery_metadata( $retry_result, $after_bytes, $after_tokens, true, true );
 		}
 		if ( $this->session_id > 0 ) {
@@ -2587,14 +2589,16 @@ PROMPT;
 	 * for a browser retry needlessly fails an otherwise completed setup run. Use the
 	 * compact copy for one transport attempt while retaining the full durable history.
 	 *
-	 * @param WP_Error            $error            Exhausted provider-retry error.
-	 * @param string              $provider_id      Runtime provider identifier.
-	 * @param string              $model_id         Runtime model identifier.
-	 * @param array<Message>|null $recovery_history Full history restored after the bounded fallback chain.
+	 * @param WP_Error                 $error                 Exhausted provider-retry error.
+	 * @param string                   $provider_id           Runtime provider identifier.
+	 * @param string                   $model_id              Runtime model identifier.
+	 * @param array<Message>|null      $recovery_history      Full history restored after the bounded fallback chain.
+	 * @param array<string,mixed>|null $recovery_paused_state Durable checkpoint restored after the bounded fallback chain fails.
 	 * @param-out array<Message>|null $recovery_history
+	 * @param-out array<string,mixed>|null $recovery_paused_state
 	 * @return GenerativeAiResult|WP_Error Compacted retry result, or the original error when ineligible.
 	 */
-	private function retry_large_provider_failure_with_compacted_history( WP_Error $error, string $provider_id, string $model_id, ?array &$recovery_history ): GenerativeAiResult|WP_Error {
+	private function retry_large_provider_failure_with_compacted_history( WP_Error $error, string $provider_id, string $model_id, ?array &$recovery_history, ?array &$recovery_paused_state ): GenerativeAiResult|WP_Error {
 		$serialized_history = $this->serialize_history();
 		$request_bytes      = ConversationTrimmer::estimate_total_bytes( $this->history );
 		$request_tokens     = ConversationTrimmer::estimate_total_tokens( $this->history );
@@ -2681,6 +2685,7 @@ PROMPT;
 				? $original_paused_state
 				: $compacted_paused_state;
 			if ( is_array( $restored_paused_state ) ) {
+				$recovery_paused_state = $restored_paused_state;
 				Database::save_paused_state( $this->session_id, $restored_paused_state );
 			}
 		}
@@ -2697,6 +2702,20 @@ PROMPT;
 		if ( is_array( $recovery_history ) ) {
 			$this->history = $recovery_history;
 		}
+	}
+
+	/**
+	 * Restore the durable checkpoint after the reduced payload fallback fails.
+	 *
+	 * @param array<string,mixed>|null $recovery_paused_state Checkpoint retained before compact retries.
+	 */
+	private function restore_provider_recovery_paused_state( ?array $recovery_paused_state ): void {
+		if ( $this->session_id <= 0 || ! is_array( $recovery_paused_state ) ) {
+			return;
+		}
+
+		Database::load_and_clear_paused_state( $this->session_id );
+		Database::save_paused_state( $this->session_id, $recovery_paused_state );
 	}
 
 	/** Whether an error represents a local or upstream HTTP 413. */

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2587,10 +2587,11 @@ PROMPT;
 	 * for a browser retry needlessly fails an otherwise completed setup run. Use the
 	 * compact copy for one transport attempt while retaining the full durable history.
 	 *
-	 * @param WP_Error                 $error            Exhausted provider-retry error.
-	 * @param string                   $provider_id      Runtime provider identifier.
-	 * @param string                   $model_id         Runtime model identifier.
-	 * @param array<int, Message>|null $recovery_history Full history restored after the bounded fallback chain.
+	 * @param WP_Error            $error            Exhausted provider-retry error.
+	 * @param string              $provider_id      Runtime provider identifier.
+	 * @param string              $model_id         Runtime model identifier.
+	 * @param array<Message>|null $recovery_history Full history restored after the bounded fallback chain.
+	 * @param-out array<Message>|null $recovery_history
 	 * @return GenerativeAiResult|WP_Error Compacted retry result, or the original error when ineligible.
 	 */
 	private function retry_large_provider_failure_with_compacted_history( WP_Error $error, string $provider_id, string $model_id, ?array &$recovery_history ): GenerativeAiResult|WP_Error {
@@ -2687,7 +2688,11 @@ PROMPT;
 		return $retry_result;
 	}
 
-	/** Restore full provider history after temporary compact retries finish. */
+	/**
+	 * Restore full provider history after temporary compact retries finish.
+	 *
+	 * @param array<Message>|null $recovery_history Full history retained before compaction.
+	 */
 	private function restore_provider_recovery_history( ?array $recovery_history ): void {
 		if ( is_array( $recovery_history ) ) {
 			$this->history = $recovery_history;

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2404,7 +2404,7 @@ PROMPT;
 	}
 
 	/**
-	 * Apply local input budgets and make at most one reduced 413 fallback.
+	 * Apply local input budgets and bounded provider-recovery fallbacks.
 	 *
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
@@ -2454,12 +2454,21 @@ PROMPT;
 			return $this->with_payload_recovery_metadata( $error, $before_bytes, $before_tokens, false, false );
 		}
 
-		$result = $this->send_prompt( $provider_id, $model_id );
+		$provider_recovery_history = null;
+		$result                    = $this->send_prompt( $provider_id, $model_id );
+		if ( is_wp_error( $result ) && 'sd_ai_agent_provider_retry_failed' === $result->get_error_code() ) {
+			$result        = $this->retry_large_provider_failure_with_compacted_history( $result, $provider_id, $model_id, $provider_recovery_history );
+			$before_bytes  = ConversationTrimmer::estimate_total_bytes( $this->history );
+			$before_tokens = ConversationTrimmer::estimate_total_tokens( $this->history );
+		}
+
 		if ( ! is_wp_error( $result ) || ! $this->is_payload_limit_error( $result ) ) {
+			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $result;
 		}
 
 		if ( $this->is_local_payload_limit_error( $result ) ) {
+			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
 		}
 		$source_data              = $result->get_error_data();
@@ -2486,6 +2495,7 @@ PROMPT;
 		// reduced retry is materially smaller. Do not retry 413s from SDK layers
 		// that did not reach the HTTP preflight hook.
 		if ( $complete_envelope_bytes <= 0 ) {
+			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
 		}
 
@@ -2494,8 +2504,24 @@ PROMPT;
 		$reduced       = ConversationTrimmer::trim_to_budget( $this->history, $target_bytes, $target_tokens );
 		$after_bytes   = ConversationTrimmer::estimate_total_bytes( $reduced );
 		$after_tokens  = ConversationTrimmer::estimate_total_tokens( $reduced );
+		if ( $after_bytes >= $before_bytes && is_array( $provider_recovery_history ) ) {
+			$compacted_reduction = ConversationTrimmer::compact_serialized_history(
+				$this->serialize_history(),
+				$target_bytes,
+				$target_tokens
+			);
+			try {
+				$reduced      = ConversationSerializer::deserialize( $compacted_reduction['messages'] );
+				$reduced      = ConversationTrimmer::validate_tool_pairs( $reduced );
+				$after_bytes  = ConversationTrimmer::estimate_total_bytes( $reduced );
+				$after_tokens = ConversationTrimmer::estimate_total_tokens( $reduced );
+			} catch ( \Throwable $exception ) {
+				$reduced = $this->history;
+			}
+		}
 
 		if ( $after_bytes >= $before_bytes ) {
+			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
 		}
 
@@ -2541,10 +2567,131 @@ PROMPT;
 				);
 			}
 
+			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $this->with_payload_recovery_metadata( $retry_result, $after_bytes, $after_tokens, true, true );
+		}
+		if ( $this->session_id > 0 ) {
+			Database::load_and_clear_paused_state( $this->session_id );
+		}
+		$this->restore_provider_recovery_history( $provider_recovery_history );
+
+		return $retry_result;
+	}
+
+	/**
+	 * Retry one exhausted large-context request with deterministic compact history.
+	 *
+	 * A long agentic turn can remain below the formal provider payload limit while
+	 * still being expensive enough for an upstream gateway to return repeated 5xx
+	 * responses. The existing manual recovery path compacts that state, but waiting
+	 * for a browser retry needlessly fails an otherwise completed setup run. Use the
+	 * compact copy for one transport attempt while retaining the full durable history.
+	 *
+	 * @param WP_Error                 $error            Exhausted provider-retry error.
+	 * @param string                   $provider_id      Runtime provider identifier.
+	 * @param string                   $model_id         Runtime model identifier.
+	 * @param array<int, Message>|null $recovery_history Full history restored after the bounded fallback chain.
+	 * @return GenerativeAiResult|WP_Error Compacted retry result, or the original error when ineligible.
+	 */
+	private function retry_large_provider_failure_with_compacted_history( WP_Error $error, string $provider_id, string $model_id, ?array &$recovery_history ): GenerativeAiResult|WP_Error {
+		$serialized_history = $this->serialize_history();
+		$request_bytes      = ConversationTrimmer::estimate_total_bytes( $this->history );
+		$request_tokens     = ConversationTrimmer::estimate_total_tokens( $this->history );
+		$max_bytes          = min(
+			ConversationTrimmer::COMPACT_MAX_BYTES,
+			ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id )
+		);
+		$max_tokens         = min(
+			ConversationTrimmer::COMPACT_MAX_TOKENS,
+			ConversationTrimmer::get_request_token_budget( $provider_id, $model_id )
+		);
+
+		if ( $request_bytes <= $max_bytes && $request_tokens <= $max_tokens ) {
+			return $error;
+		}
+
+		$compacted = ConversationTrimmer::compact_serialized_history( $serialized_history, $max_bytes, $max_tokens );
+		if ( empty( $compacted['messages'] ) ) {
+			return $error;
+		}
+
+		try {
+			$compacted_history = ConversationSerializer::deserialize( $compacted['messages'] );
+			$compacted_history = ConversationTrimmer::validate_tool_pairs( $compacted_history );
+		} catch ( \Throwable $exception ) {
+			return $error;
+		}
+
+		$compacted_bytes  = ConversationTrimmer::estimate_total_bytes( $compacted_history );
+		$compacted_tokens = ConversationTrimmer::estimate_total_tokens( $compacted_history );
+		if (
+			empty( $compacted_history )
+			|| $compacted_bytes >= $request_bytes
+			|| ! ConversationTrimmer::fits_budget( $compacted_history, $max_bytes, $max_tokens )
+		) {
+			return $error;
+		}
+
+		$recovery_history      = $this->history;
+		$original_paused_state = $this->session_id > 0
+			? Database::load_and_clear_paused_state( $this->session_id )
+			: null;
+		$this->history         = $compacted_history;
+		$this->message_log[]   = array(
+			'type'                   => 'provider_retry_compaction',
+			'message'                => __( 'The provider could not complete a large request. Retrying once with compacted conversation history.', 'superdav-ai-agent' ),
+			'request_size_class'     => ProviderTraceLogger::classify_request_size( $request_bytes ),
+			'request_bytes_estimate' => $request_bytes,
+			'compacted_bytes'        => $compacted_bytes,
+			'payload_reduced'        => true,
+			'fallback_attempted'     => true,
+			'sequence'               => $this->next_activity_sequence(),
+		);
+
+		AgentEventLog::log(
+			'provider_retry_history_compacted',
+			AgentEventLog::SEVERITY_INFO,
+			array(
+				'session_id'              => $this->session_id,
+				'phase'                   => $this->get_provider_trace_phase(),
+				'provider_id'             => $provider_id,
+				'model_id'                => $model_id,
+				'history_count'           => count( $serialized_history ),
+				'request_bytes_estimate'  => $request_bytes,
+				'request_tokens_estimate' => $request_tokens,
+				'payload_reduced'         => true,
+				'fallback_attempted'      => true,
+				'recovery_outcome'        => 'automatic_compact_provider_retry',
+			)
+		);
+		$this->fire_progress();
+
+		$original_max_attempts             = $this->provider_retry_max_attempts;
+		$this->provider_retry_max_attempts = 1;
+		try {
+			$retry_result = $this->send_prompt( $provider_id, $model_id );
+		} finally {
+			$this->provider_retry_max_attempts = $original_max_attempts;
+		}
+
+		if ( is_wp_error( $retry_result ) && $this->session_id > 0 ) {
+			$compacted_paused_state = Database::load_and_clear_paused_state( $this->session_id );
+			$restored_paused_state  = is_array( $original_paused_state )
+				? $original_paused_state
+				: $compacted_paused_state;
+			if ( is_array( $restored_paused_state ) ) {
+				Database::save_paused_state( $this->session_id, $restored_paused_state );
+			}
 		}
 
 		return $retry_result;
+	}
+
+	/** Restore full provider history after temporary compact retries finish. */
+	private function restore_provider_recovery_history( ?array $recovery_history ): void {
+		if ( is_array( $recovery_history ) ) {
+			$this->history = $recovery_history;
+		}
 	}
 
 	/** Whether an error represents a local or upstream HTTP 413. */

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1327,6 +1327,58 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertNull( Database::load_and_clear_paused_state( $session_id ) );
 	}
 
+	/** A failed reduced 413 retry restores the checkpoint from before compaction. */
+	public function test_compact_retry_413_reduction_failure_preserves_original_paused_state(): void {
+		$session_id = Database::create_session(
+			array(
+				'user_id' => 1,
+				'title'   => 'Failed compact and payload recovery',
+			)
+		);
+		$history    = array(
+			new UserMessage( array( new MessagePart( str_repeat( 'original tool evidence ', 5000 ) ) ) ),
+			new ModelMessage( array( new MessagePart( 'The completed work must remain resumable.' ) ) ),
+			new UserMessage( array( new MessagePart( 'Finish the current phase.' ) ) ),
+		);
+		$loop       = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'session_id'  => $session_id,
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			),
+			array(
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ),
+				new WP_Error(
+					'sd_ai_agent_provider_payload_too_large',
+					'Compacted request rejected.',
+					array(
+						'status_code'             => 413,
+						'request_size_source'     => 'complete_envelope',
+						'request_bytes'           => 131072,
+						'request_tokens_estimate' => 32768,
+					)
+				),
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Reduced request unavailable.' ),
+			)
+		);
+
+		$result = $loop->resume_from_checkpoint( 3 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
+		$this->assertCount( 3, $loop->requestSizes );
+		$this->assertSame( array( 6, 1, 6 ), $loop->requestAttemptLimits );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$this->assertLessThan( (int) floor( $loop->requestSizes[1] * 0.9 ), $loop->requestSizes[2] );
+		$paused_state = Database::load_and_clear_paused_state( $session_id );
+		$this->assertIsArray( $paused_state );
+		$this->assertStringContainsString( 'original tool evidence', (string) wp_json_encode( $paused_state['history'] ) );
+		$this->assertStringNotContainsString( 'Conversation compacted server-side', (string) wp_json_encode( $paused_state['history'] ) );
+	}
+
 	/**
 	 * Accepted screenshot results survive provider exhaustion and resume from
 	 * their post-results checkpoint without producing another browser-tool pause.

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -72,6 +72,10 @@ class ScriptedAgentLoop extends AgentLoop {
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
 	public array $requestSizes = array();
 
+	/** @var list<int> */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	public array $requestAttemptLimits = array();
+
 	/** @var list<array{ability_mode:bool,collection_mode:bool,knowledge_allowed:bool}> */
 	public array $policySnapshots = array();
 
@@ -94,6 +98,10 @@ class ScriptedAgentLoop extends AgentLoop {
 
 	/** Return the next scripted result while recording the outgoing history size. */
 	protected function send_prompt( string $provider_id, string $model_id ): GenerativeAiResult|WP_Error {
+		$attempts_property = new \ReflectionProperty( AgentLoop::class, 'provider_retry_max_attempts' );
+		$attempts_property->setAccessible( true );
+		$this->requestAttemptLimits[] = (int) $attempts_property->getValue( $this );
+
 		$this->policySnapshots[] = array(
 			'ability_mode'     => ToolDiscovery::is_anonymous_ability_mode(),
 			'collection_mode'  => KnowledgeAbilities::is_public_collection_mode(),
@@ -1129,6 +1137,194 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $data );
 		$retry_entries = array_filter( $data['messages'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
 		$this->assertCount( 2, $retry_entries );
+	}
+
+	/** A large exhausted request compacts and retries without browser recovery. */
+	public function test_large_provider_retry_exhaustion_compacts_and_recovers_automatically(): void {
+		$session_id = Database::create_session(
+			array(
+				'user_id' => 1,
+				'title'   => 'Automatic provider retry compaction',
+			)
+		);
+		$history    = array(
+			new UserMessage( array( new MessagePart( 'Build the complete onboarding site.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart(
+						new FunctionCall(
+							'call_large_result',
+							'wpab__sd-ai-agent__site-info',
+							array()
+						)
+					),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_large_result',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => str_repeat( 'large completed tool output ', 4000 ) )
+						)
+					),
+				)
+			),
+		);
+		$loop       = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'session_id'  => $session_id,
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			),
+			array(
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ),
+				$this->create_scripted_result( 'Recovered from compact context.' ),
+			)
+		);
+
+		$result = $loop->resume_from_checkpoint( 3 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered from compact context.', $result['reply'] );
+		$this->assertCount( 2, $loop->requestSizes );
+		$this->assertSame( array( 6, 1 ), $loop->requestAttemptLimits );
+		$this->assertGreaterThan( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[0] );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[1] );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$this->assertStringContainsString( 'large completed tool output', (string) wp_json_encode( $result['history'] ) );
+		$recovery_entries = array_filter( $result['messages'], static fn( $entry ) => 'provider_retry_compaction' === ( $entry['type'] ?? '' ) );
+		$this->assertCount( 1, $recovery_entries );
+		$this->assertNull( Database::load_and_clear_paused_state( $session_id ) );
+	}
+
+	/** A failed compact retry retains the full original recovery checkpoint. */
+	public function test_large_provider_compact_retry_failure_preserves_original_paused_state(): void {
+		$session_id = Database::create_session(
+			array(
+				'user_id' => 1,
+				'title'   => 'Preserved provider retry checkpoint',
+			)
+		);
+		$history    = array(
+			new UserMessage( array( new MessagePart( 'Finish the onboarding workflow.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'call_preserved', 'wpab__sd-ai-agent__site-info', array() ) ),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_preserved',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => str_repeat( 'original checkpoint evidence ', 4000 ) )
+						)
+					),
+				)
+			),
+		);
+		$loop       = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'session_id'  => $session_id,
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			),
+			array(
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ),
+				new WP_Error(
+					'sd_ai_agent_provider_payload_too_large',
+					'Compacted request rejected.',
+					array( 'status_code' => 413 )
+				),
+			)
+		);
+
+		$result = $loop->resume_from_checkpoint( 3 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_too_large', $result->get_error_code() );
+		$this->assertCount( 2, $loop->requestSizes );
+		$this->assertSame( array( 6, 1 ), $loop->requestAttemptLimits );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$paused_state = Database::load_and_clear_paused_state( $session_id );
+		$this->assertIsArray( $paused_state );
+		$this->assertStringContainsString( 'original checkpoint evidence', (string) wp_json_encode( $paused_state['history'] ) );
+		$this->assertStringNotContainsString( 'Conversation compacted server-side', (string) wp_json_encode( $paused_state['history'] ) );
+	}
+
+	/** A successful reduced 413 retry clears the checkpoint restored after compaction. */
+	public function test_compact_retry_413_reduction_success_clears_restored_paused_state(): void {
+		$session_id = Database::create_session(
+			array(
+				'user_id' => 1,
+				'title'   => 'Successful compact and payload recovery',
+			)
+		);
+		$history    = array(
+			new UserMessage( array( new MessagePart( str_repeat( 'older completed context ', 4000 ) ) ) ),
+			new ModelMessage( array( new MessagePart( 'The earlier phase is complete.' ) ) ),
+			new UserMessage( array( new MessagePart( 'Finish the current phase.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'call_current_phase', 'wpab__sd-ai-agent__site-info', array() ) ),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_current_phase',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => str_repeat( 'current phase evidence ', 1500 ) )
+						)
+					),
+				)
+			),
+		);
+		$loop       = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'session_id'  => $session_id,
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			),
+			array(
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ),
+				new WP_Error(
+					'sd_ai_agent_provider_payload_too_large',
+					'Compacted request rejected.',
+					array(
+						'status_code'             => 413,
+						'request_size_source'     => 'complete_envelope',
+						'request_bytes'           => 131072,
+						'request_tokens_estimate' => 32768,
+					)
+				),
+				$this->create_scripted_result( 'Recovered after compact and payload fallbacks.' ),
+			)
+		);
+
+		$result = $loop->resume_from_checkpoint( 3 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered after compact and payload fallbacks.', $result['reply'] );
+		$this->assertCount( 3, $loop->requestSizes );
+		$this->assertSame( array( 6, 1, 6 ), $loop->requestAttemptLimits );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[2] );
+		$this->assertLessThan( (int) floor( $loop->requestSizes[1] * 0.9 ), $loop->requestSizes[2] );
+		$this->assertNull( Database::load_and_clear_paused_state( $session_id ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- automatically retry one large provider-retry exhaustion with deterministic compact history
- retain the full conversation and original paused checkpoint when compact recovery fails
- clear stale paused state after successful compact or reduced-413 recovery
- keep compact context through the 413 fallback and require the next request to make measurable size progress

## Observed failure

A fresh Setup Assistant run completed 39 tool steps, including page, menu, template-part, and default-content mutations, then failed while requesting its final response. The managed provider returned HTTP 503 for a 327,636-byte request estimated at 81,909 tokens and exhausted six retries. Existing manual resume compaction could recover this state, but the otherwise-complete onboarding run still terminated and required browser intervention.

## Implementation

- `AgentLoop::send_prompt_with_payload_recovery()` now detects large `sd_ai_agent_provider_retry_failed` results and makes one compact-context transport attempt.
- The automatic compact attempt temporarily sets the provider retry limit to one.
- Full provider history is restored after the bounded fallback chain, avoiding durable transcript loss or mutation replay.
- The original paused state is preserved for terminal failures and cleared only after successful recovery.
- A compact request that receives a measured 413 is deterministically reduced again before the existing payload fallback, including the single-message compact-seed case.

## Worker self-verification

- PHPUnit: Tests: 4223, Assertions: 19308, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Command: `pnpm run verify`

Focused review-fix coverage: 3 tests, 25 assertions.

The verified review finding about failed reduced-413 retries overwriting the original paused checkpoint was fixed in `7acf8228`. The regression test covers timeout → compact measured 413 → timeout and confirms the original history remains resumable.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.21 with gpt-5.6-sol
