### PR TITLE
Fix bounded recovery for local request envelopes

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2468,10 +2468,7 @@ PROMPT;
 			return $result;
 		}
 
-		if ( $this->is_local_payload_limit_error( $result ) ) {
-			$this->restore_provider_recovery_history( $provider_recovery_history );
-			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
-		}
+		$local_payload_rejection  = $this->is_local_payload_limit_error( $result );
 		$source_data              = $result->get_error_data();
 		$complete_envelope_bytes  = is_array( $source_data ) && 'complete_envelope' === ( $source_data['request_size_source'] ?? '' )
 			? max( 0, (int) ( $source_data['request_bytes'] ?? 0 ) )
@@ -2486,15 +2483,17 @@ PROMPT;
 			$complete_envelope_bytes > 0 ? $complete_envelope_bytes : $before_bytes,
 			$complete_envelope_tokens > 0 ? $complete_envelope_tokens : $before_tokens,
 			$byte_budget,
-			false,
+			$local_payload_rejection,
 			false,
 			$complete_envelope_bytes <= 0,
 			'reduced_retry_attempted'
 		);
 
 		// Only a measured, complete request envelope can prove that the one
-		// reduced retry is materially smaller. Do not retry 413s from SDK layers
-		// that did not reach the HTTP preflight hook.
+		// reduced retry is materially smaller. This includes local transport
+		// preflight rejections: history can fit its standalone budget while the
+		// complete system-instruction and tool envelope still exceeds the limit.
+		// Do not retry 413s from SDK layers that did not measure the full request.
 		if ( $complete_envelope_bytes <= 0 ) {
 			$this->restore_provider_recovery_history( $provider_recovery_history );
 			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
@@ -2522,8 +2521,9 @@ PROMPT;
 		}
 
 		if ( $after_bytes >= $before_bytes ) {
+			$fallback_exhausted = $local_payload_rejection && is_array( $provider_recovery_history );
 			$this->restore_provider_recovery_history( $provider_recovery_history );
-			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, $fallback_exhausted );
 		}
 
 		$this->history       = $reduced;
@@ -2546,7 +2546,8 @@ PROMPT;
 			$this->provider_retry_baseline_envelope_bytes = 0;
 		}
 		if ( is_wp_error( $retry_result ) ) {
-			if ( $this->is_payload_limit_error( $retry_result ) && ! $this->is_local_payload_limit_error( $retry_result ) ) {
+			if ( $this->is_payload_limit_error( $retry_result ) ) {
+				$retry_local_rejection = $this->is_local_payload_limit_error( $retry_result );
 				$retry_error_data      = $retry_result->get_error_data();
 				$retry_envelope_bytes  = is_array( $retry_error_data ) && 'complete_envelope' === ( $retry_error_data['request_size_source'] ?? '' )
 					? max( 0, (int) ( $retry_error_data['request_bytes'] ?? 0 ) )
@@ -2561,7 +2562,7 @@ PROMPT;
 					$retry_envelope_bytes > 0 ? $retry_envelope_bytes : $after_bytes,
 					$retry_envelope_tokens > 0 ? $retry_envelope_tokens : $after_tokens,
 					$byte_budget,
-					false,
+					$retry_local_rejection,
 					true,
 					$retry_envelope_bytes <= 0,
 					'reduced_retry_exhausted'
@@ -2754,7 +2755,7 @@ PROMPT;
 		$data['request_tokens_estimate'] = $request_tokens;
 		$data['fallback_attempted']      = $fallback_attempted;
 		$data['payload_reduced']         = $reduced;
-		if ( $this->is_local_payload_limit_error( $error ) && $this->session_id > 0 ) {
+		if ( $this->is_local_payload_limit_error( $error ) && $this->session_id > 0 && ! $fallback_attempted ) {
 			$data['recovery'] = array(
 				'action'            => 'compact_session',
 				'source_session_id' => $this->session_id,

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1814,12 +1814,16 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( $current, (string) wp_json_encode( $data['history'] ) );
 	}
 
-	/** A local transport preflight rejection must not consume the one upstream-413 retry. */
-	public function test_local_transport_payload_rejection_skips_reduced_retry_and_offers_compaction(): void {
-		$loop = new ScriptedAgentLoop(
+	/** A measured local transport preflight rejection receives one reduced retry. */
+	public function test_local_transport_payload_rejection_retries_once_with_reduced_history(): void {
+		$history = array(
+			new UserMessage( array( new MessagePart( str_repeat( 'Completed tool evidence. ', 1200 ) ) ) ),
+			new ModelMessage( array( new MessagePart( 'The completed work remains available.' ) ) ),
+		);
+		$loop    = new ScriptedAgentLoop(
 			'Current request.',
 			array(),
-			array(),
+			$history,
 			array(
 				'provider_id' => 'scripted-provider',
 				'model_id'    => 'scripted-model',
@@ -1832,7 +1836,60 @@ class AgentLoopTest extends WP_UnitTestCase {
 					array(
 						'status_code'         => 413,
 						'local_rejection'     => true,
-						'request_bytes'       => 8192,
+						'request_bytes'       => 131072,
+						'request_size_source' => 'complete_envelope',
+					)
+				),
+				$this->create_scripted_result( 'Recovered after local envelope reduction.' ),
+			)
+		);
+
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered after local envelope reduction.', $result['reply'] );
+		$this->assertCount( 2, $loop->requestSizes );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$recoveries = array_filter(
+			$result['messages'],
+			static fn( array $entry ): bool => 'provider_payload_recovery' === ( $entry['type'] ?? '' )
+		);
+		$this->assertCount( 1, $recoveries );
+	}
+
+	/** A failed measured local retry must not request another compaction loop. */
+	public function test_repeated_local_transport_payload_rejection_stops_after_reduced_retry(): void {
+		$history = array(
+			new UserMessage( array( new MessagePart( str_repeat( 'Completed tool evidence. ', 1200 ) ) ) ),
+			new ModelMessage( array( new MessagePart( 'The completed work remains available.' ) ) ),
+		);
+		$loop    = new ScriptedAgentLoop(
+			'Current request.',
+			array(),
+			$history,
+			array(
+				'provider_id' => 'scripted-provider',
+				'model_id'    => 'scripted-model',
+				'session_id'  => 49,
+			),
+			array(
+				new WP_Error(
+					'sd_ai_agent_provider_payload_budget_exceeded',
+					'Complete request envelope exceeded the local budget.',
+					array(
+						'status_code'         => 413,
+						'local_rejection'     => true,
+						'request_bytes'       => 131072,
+						'request_size_source' => 'complete_envelope',
+					)
+				),
+				new WP_Error(
+					'sd_ai_agent_provider_payload_budget_exceeded',
+					'Reduced request still exceeded the local budget.',
+					array(
+						'status_code'         => 413,
+						'local_rejection'     => true,
+						'request_bytes'       => 78643,
 						'request_size_source' => 'complete_envelope',
 					)
 				),
@@ -1843,12 +1900,13 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_provider_payload_budget_exceeded', $result->get_error_code() );
-		$this->assertCount( 1, $loop->requestSizes );
+		$this->assertCount( 2, $loop->requestSizes );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
 		$data = $result->get_error_data();
 		$this->assertIsArray( $data );
-		$this->assertFalse( $data['fallback_attempted'] );
-		$this->assertSame( 'compact_session', $data['recovery']['action'] );
-		$this->assertSame( 48, $data['recovery']['source_session_id'] );
+		$this->assertTrue( $data['fallback_attempted'] );
+		$this->assertTrue( $data['payload_reduced'] );
+		$this->assertArrayNotHasKey( 'recovery', $data );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- retry one measured local complete-envelope 413 with materially reduced conversation history
- preserve the existing no-retry behavior when the SDK did not measure the complete envelope
- stop advertising another compact-session recovery after the bounded reduced retry is exhausted
- record local reduced-retry telemetry and cover successful and exhausted recovery paths

## Verification

- `pnpm run verify`
  - PHPCS and PHPStan passed
  - 4,224 tests passed with 19,315 assertions (137 skipped, 4 incomplete)
  - production build and bundle budgets passed
- `vendor/bin/phpunit --no-coverage tests/SdAiAgent/Core/AgentLoopTest.php`
  - 171 tests, 444 assertions (67 skipped)

## Context

Setup Assistant can fit the standalone history budget while the complete request envelope, including system instructions and tools, still exceeds the local transport limit. Previously that measured local rejection bypassed bounded history reduction and repeatedly offered compact-session recovery. This change reuses the existing one-shot demonstrably-smaller retry and terminates without another compaction action if that retry also fails.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 1d 22h and 13,652,579 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when requests exceed payload limits, including locally detected rejections.
  * Allows one reduced-history retry when the request size is known and complete.
  * Prevents repeated failures from triggering unnecessary additional recovery or compaction suggestions.
  * Preserves clearer provider diagnostics for payload-limit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->