### PR TITLE
Fix continued provider context compaction

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2409,6 +2409,30 @@ PROMPT;
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
 	private function send_prompt_with_payload_recovery(): GenerativeAiResult|WP_Error {
+		$durable_history           = $this->history;
+		$compacted_request_history = $this->continued_provider_compaction_history();
+		if ( is_array( $compacted_request_history ) ) {
+			$this->history = $compacted_request_history;
+		}
+
+		try {
+			return $this->send_prompt_with_payload_recovery_request();
+		} finally {
+			// Automatic retry compaction is provider context, not the durable chat
+			// transcript. Keep the full history for checkpoints, UI persistence,
+			// and recovery while subsequent provider calls reuse bounded context.
+			if ( is_array( $compacted_request_history ) ) {
+				$this->history = $durable_history;
+			}
+		}
+	}
+
+	/**
+	 * Send one provider request after any continued compact context is applied.
+	 *
+	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
+	 */
+	private function send_prompt_with_payload_recovery_request(): GenerativeAiResult|WP_Error {
 		$provider_id  = $this->resolve_provider_id();
 		$model_id     = $this->resolve_effective_model_id( $provider_id );
 		$byte_budget  = ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id );
@@ -2579,6 +2603,87 @@ PROMPT;
 		$this->restore_provider_recovery_history( $provider_recovery_history );
 
 		return $retry_result;
+	}
+
+	/**
+	 * Reuse deterministic compact context after an automatic retry needed it.
+	 *
+	 * Long setup runs commonly contain one genuine user turn followed by many
+	 * tool cycles. Ordinary turn-boundary trimming intentionally keeps that turn
+	 * intact, so restoring its full durable transcript after a successful compact
+	 * retry made every later provider call large again. The persisted message log
+	 * records that recovery across browser-tool resumes; use it to rebuild a safe
+	 * provider-only context while leaving the durable history untouched.
+	 *
+	 * @return array<Message>|null Compacted provider history, or null when inactive.
+	 */
+	private function continued_provider_compaction_history(): ?array {
+		$compaction_active = false;
+		foreach ( $this->message_log as $entry ) {
+			if ( 'provider_retry_compaction' === ( $entry['type'] ?? '' ) ) {
+				$compaction_active = true;
+				break;
+			}
+		}
+
+		if ( ! $compaction_active ) {
+			return null;
+		}
+
+		$request_bytes  = ConversationTrimmer::estimate_total_bytes( $this->history );
+		$request_tokens = ConversationTrimmer::estimate_total_tokens( $this->history );
+		if ( $request_bytes <= ConversationTrimmer::COMPACT_MAX_BYTES && $request_tokens <= ConversationTrimmer::COMPACT_MAX_TOKENS ) {
+			return null;
+		}
+
+		$compacted = ConversationTrimmer::compact_serialized_history(
+			$this->serialize_history(),
+			ConversationTrimmer::COMPACT_MAX_BYTES,
+			ConversationTrimmer::COMPACT_MAX_TOKENS
+		);
+		if ( empty( $compacted['messages'] ) ) {
+			return null;
+		}
+
+		try {
+			$compacted_history = ConversationSerializer::deserialize( $compacted['messages'] );
+			$compacted_history = ConversationTrimmer::validate_tool_pairs( $compacted_history );
+		} catch ( \Throwable $exception ) {
+			return null;
+		}
+
+		$compacted_bytes  = ConversationTrimmer::estimate_total_bytes( $compacted_history );
+		$compacted_tokens = ConversationTrimmer::estimate_total_tokens( $compacted_history );
+		if (
+			empty( $compacted_history )
+			|| $compacted_bytes >= $request_bytes
+			|| ! ConversationTrimmer::fits_budget(
+				$compacted_history,
+				ConversationTrimmer::COMPACT_MAX_BYTES,
+				ConversationTrimmer::COMPACT_MAX_TOKENS
+			)
+		) {
+			return null;
+		}
+
+		AgentEventLog::log(
+			'provider_retry_history_compacted',
+			AgentEventLog::SEVERITY_INFO,
+			array(
+				'session_id'              => $this->session_id,
+				'phase'                   => $this->get_provider_trace_phase(),
+				'provider_id'             => $this->resolve_provider_id(),
+				'model_id'                => $this->resolve_effective_model_id( $this->resolve_provider_id() ),
+				'history_count'           => count( $this->history ),
+				'request_bytes_estimate'  => $request_bytes,
+				'request_tokens_estimate' => $request_tokens,
+				'payload_reduced'         => true,
+				'fallback_attempted'      => false,
+				'recovery_outcome'        => 'continued_compact_provider_context',
+			)
+		);
+
+		return $compacted_history;
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -251,6 +251,10 @@ PROMPT;
 	/** @var int Full-envelope bytes from an upstream 413 eligible for one reduced retry. */
 	private int $provider_retry_baseline_envelope_bytes = 0;
 
+	/** @var list<Message>|null Full history retained while the provider receives compact context. */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	private ?array $providerPersistenceHistory = null;
+
 	/** @var string Last coarse loop phase for shutdown diagnostics. */
 	private string $last_loop_phase = 'initializing';
 
@@ -2409,10 +2413,12 @@ PROMPT;
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
 	private function send_prompt_with_payload_recovery(): GenerativeAiResult|WP_Error {
-		$durable_history           = $this->history;
-		$compacted_request_history = $this->continued_provider_compaction_history();
+		$durable_history                       = $this->history;
+		$previous_provider_persistence_history = $this->providerPersistenceHistory;
+		$compacted_request_history             = $this->continued_provider_compaction_history();
 		if ( is_array( $compacted_request_history ) ) {
-			$this->history = $compacted_request_history;
+			$this->history                    = $compacted_request_history;
+			$this->providerPersistenceHistory = $durable_history;
 		}
 
 		try {
@@ -2422,7 +2428,8 @@ PROMPT;
 			// transcript. Keep the full history for checkpoints, UI persistence,
 			// and recovery while subsequent provider calls reuse bounded context.
 			if ( is_array( $compacted_request_history ) ) {
-				$this->history = $durable_history;
+				$this->history                    = $durable_history;
+				$this->providerPersistenceHistory = $previous_provider_persistence_history;
 			}
 		}
 	}
@@ -3366,7 +3373,10 @@ PROMPT;
 	 * @param int                      $elapsed_seconds Total elapsed seconds.
 	 */
 	private function build_provider_retry_failed_error( $error, int $elapsed_seconds ): WP_Error {
-		$message = sprintf(
+		$serialized_history = is_array( $this->providerPersistenceHistory )
+			? ConversationSerializer::serialize( $this->providerPersistenceHistory )
+			: $this->serialize_history();
+		$message            = sprintf(
 			/* translators: 1: attempts, 2: elapsed seconds */
 			__( 'The AI service is temporarily unavailable after %1$d attempts over %2$ds. Please try again shortly.', 'superdav-ai-agent' ),
 			$this->provider_retry_max_attempts,
@@ -3380,7 +3390,7 @@ PROMPT;
 
 		if ( $this->session_id > 0 ) {
 			$paused_state = array(
-				'history'                 => $this->serialize_history(),
+				'history'                 => $serialized_history,
 				'tool_call_log'           => $this->tool_call_log,
 				'message_log'             => $this->message_log,
 				'token_usage'             => $this->token_usage,
@@ -3409,7 +3419,7 @@ PROMPT;
 					'token_usage'     => $this->token_usage,
 					'iterations_used' => $this->iterations_used,
 					'model_id'        => $this->model_id,
-					'history'         => $this->serialize_history(),
+					'history'         => $serialized_history,
 					'elapsed_seconds' => $elapsed_seconds,
 				]
 			)

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1202,6 +1202,102 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertNull( Database::load_and_clear_paused_state( $session_id ) );
 	}
 
+	/** A recovered agentic loop keeps later provider calls on compact context. */
+	public function test_large_provider_retry_compaction_stays_active_for_followup_provider_calls(): void {
+		$history = array(
+			new UserMessage( array( new MessagePart( 'Complete the remaining onboarding checks.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'call_large_followup', 'wpab__sd-ai-agent__site-info', array() ) ),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_large_followup',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => str_repeat( 'large completed tool output ', 4000 ) )
+						)
+					),
+				)
+			),
+		);
+		$loop    = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			),
+			array(
+				new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ),
+				$this->create_scripted_result( '' ),
+				$this->create_scripted_result( 'Completed after the compact-context follow-up.' ),
+			)
+		);
+
+		$result = $loop->resume_from_checkpoint( 4 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Completed after the compact-context follow-up.', $result['reply'] );
+		$this->assertCount( 3, $loop->requestSizes );
+		$this->assertSame( array( 6, 1, 6 ), $loop->requestAttemptLimits );
+		$this->assertGreaterThan( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[0] );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[1] );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[2] );
+		$this->assertStringContainsString( 'large completed tool output', (string) wp_json_encode( $result['history'] ) );
+	}
+
+	/** A persisted recovery marker bounds the first request after a browser resume. */
+	public function test_persisted_provider_retry_compaction_bounds_resumed_request(): void {
+		$large_evidence = str_repeat( 'persisted completed tool output ', 4000 );
+		$history        = array(
+			new UserMessage( array( new MessagePart( 'Resume the remaining onboarding checks.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'call_persisted_followup', 'wpab__sd-ai-agent__site-info', array() ) ),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_persisted_followup',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => $large_evidence )
+						)
+					),
+				)
+			),
+		);
+		$loop           = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+				'message_log' => array(
+					array(
+						'type'            => 'provider_retry_compaction',
+						'payload_reduced' => true,
+					),
+				),
+			),
+			array( $this->create_scripted_result( 'Resumed with compact provider context.' ) )
+		);
+
+		$result = $loop->resume_from_checkpoint( 2 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Resumed with compact provider context.', $result['reply'] );
+		$this->assertCount( 1, $loop->requestSizes );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[0] );
+		$this->assertStringContainsString( $large_evidence, (string) wp_json_encode( $result['history'] ) );
+	}
+
 	/** A failed compact retry retains the full original recovery checkpoint. */
 	public function test_large_provider_compact_retry_failure_preserves_original_paused_state(): void {
 		$session_id = Database::create_session(

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1298,6 +1298,66 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( $large_evidence, (string) wp_json_encode( $result['history'] ) );
 	}
 
+	/** A failed continued compact request persists the full durable history. */
+	public function test_persisted_provider_retry_compaction_failure_preserves_durable_history(): void {
+		$session_id    = Database::create_session(
+			array(
+				'user_id' => 1,
+				'title'   => 'Continued compact retry failure',
+			)
+		);
+		$large_evidence = str_repeat( 'durable completed tool evidence ', 4000 );
+		$history        = array(
+			new UserMessage( array( new MessagePart( 'Resume the remaining onboarding checks.' ) ) ),
+			new ModelMessage(
+				array(
+					new MessagePart( new FunctionCall( 'call_failed_followup', 'wpab__sd-ai-agent__site-info', array() ) ),
+				)
+			),
+			new UserMessage(
+				array(
+					new MessagePart(
+						new FunctionResponse(
+							'call_failed_followup',
+							'wpab__sd-ai-agent__site-info',
+							array( 'content' => $large_evidence )
+						)
+					),
+				)
+			),
+		);
+		$loop           = new ScriptedAgentLoop(
+			'',
+			array(),
+			$history,
+			array(
+				'session_id'  => $session_id,
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+				'message_log' => array(
+					array(
+						'type'            => 'provider_retry_compaction',
+						'payload_reduced' => true,
+					),
+				),
+			),
+			array( new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ) )
+		);
+
+		$result = $loop->resume_from_checkpoint( 2 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
+		$this->assertCount( 1, $loop->requestSizes );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $loop->requestSizes[0] );
+		$error_data = $result->get_error_data();
+		$this->assertIsArray( $error_data );
+		$this->assertStringContainsString( $large_evidence, (string) wp_json_encode( $error_data['history'] ?? array() ) );
+		$paused_state = Database::load_and_clear_paused_state( $session_id );
+		$this->assertIsArray( $paused_state );
+		$this->assertStringContainsString( $large_evidence, (string) wp_json_encode( $paused_state['history'] ) );
+	}
+
 	/** A failed compact retry retains the full original recovery checkpoint. */
 	public function test_large_provider_compact_retry_failure_preserves_original_paused_state(): void {
 		$session_id = Database::create_session(


### PR DESCRIPTION
## Summary

- reuse deterministic compact provider context after an automatic large-request retry
- preserve the full durable conversation for checkpoints, UI history, and recovery
- keep compact context active across follow-up calls and browser-tool resumes through the persisted recovery activity marker
- preserve full durable history in errors and paused state when a continued compact request fails

## Problem

A long Setup Assistant run recovered from provider retry exhaustion by making one compact request, but then restored the full tool-heavy history for every later provider call. Run 28 repeatedly rebounded from roughly 65 KiB compact context to more than 400 KiB of history until the local token budget rejected the request.

## Verification

- `pnpm run test:php -- --filter=AgentLoopTest`
  - Tests: 174, Assertions: 469, Skipped: 67
- focused provider recovery tests
  - Tests: 6, Assertions: 52
- `pnpm run verify`

## Worker self-verification
- PHPUnit: Tests: 4227, Assertions: 19343, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol
