### PR TITLE
Fix timed-out client tool resume recovery

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -974,6 +974,9 @@ PROMPT;
 		ProviderCredentialLoader::load();
 
 		AgentEventLog::set_session( $this->session_id );
+		if ( '' !== $this->active_job_id ) {
+			register_shutdown_function( array( $this, 'handle_active_job_shutdown' ) );
+		}
 
 		// Build a tool-response message from the client results.
 		$parts = array();

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -106,6 +106,33 @@ class ActiveJobRepository {
 	}
 
 	/**
+	 * Atomically claim a browser-tool pause for synchronous loop resumption.
+	 *
+	 * The processing status lets the shutdown handler convert a timed-out PHP
+	 * request into an interrupted job that the polling endpoint can auto-resume.
+	 * It also prevents a duplicate browser result POST from claiming the same
+	 * paused batch while the first request is still running.
+	 */
+	public static function claim_client_tool_resume( string $job_id, int $session_id, int $user_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional status transition is the browser-result worker claim.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'processing', pending_tools = '[]', updated_at = %s WHERE job_id = %s AND session_id = %d AND user_id = %d AND status = 'awaiting_client_tools'",
+				self::table_name(),
+				current_time( 'mysql', true ),
+				$job_id,
+				$session_id,
+				$user_id
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
 	 * Atomically return a durable confirmation pause to the queue for one new claim.
 	 *
 	 * A stale confirmation must never overwrite a worker that has already

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -466,6 +466,11 @@ Assistant: %s',
 		$paused_state = Database::load_and_clear_paused_state( $session_id );
 
 		if ( null === $paused_state ) {
+			$in_progress = self::client_tool_resume_in_progress_response( $job_id, $session_id );
+			if ( null !== $in_progress ) {
+				return $in_progress;
+			}
+
 			// Sync the job transient/DB row to a terminal state so the
 			// browser's poll loop stops re-issuing the same pending client
 			// tool call. Without this, a poll → execute → POST → 409 cycle
@@ -589,6 +594,23 @@ Assistant: %s',
 				'sd_ai_agent_invalid_client_tool_results',
 				__( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
 				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! self::start_client_tool_resume( $job_id, $session_id ) ) {
+			$in_progress = self::client_tool_resume_in_progress_response( $job_id, $session_id );
+			if ( null !== $in_progress ) {
+				return $in_progress;
+			}
+
+			// No worker owns this valid batch. Restore it so a subsequent request
+			// can retry instead of losing the only durable browser-tool result.
+			Database::save_paused_state( $session_id, $paused_state );
+
+			return new WP_Error(
+				'sd_ai_agent_job_not_resumable',
+				__( 'The browser-tool job is no longer available to resume.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
 			);
 		}
 
@@ -783,6 +805,66 @@ Assistant: %s',
 		}
 
 		return new WP_REST_Response( $response, 200 );
+	}
+
+	/** Claim a paused browser-tool job and make the in-flight state pollable. */
+	private static function start_client_tool_resume( string $job_id, int $session_id ): bool {
+		if ( '' === $job_id ) {
+			// Preserve compatibility with older clients that did not send job_id.
+			return true;
+		}
+
+		if ( ! ActiveJobRepository::claim_client_tool_resume( $job_id, $session_id, get_current_user_id() ) ) {
+			return false;
+		}
+
+		$transient_key = self::JOB_PREFIX . $job_id;
+		$job           = get_transient( $transient_key );
+		if ( is_array( $job ) ) {
+			unset( $job['token'], $job['pending_client_tool_calls'] );
+			$job['status'] = 'processing';
+			set_transient( $transient_key, $job, self::JOB_TTL );
+		}
+
+		return true;
+	}
+
+	/** Acknowledge a duplicate browser batch while its original resume is active. */
+	private static function client_tool_resume_in_progress_response( string $job_id, int $session_id ): ?WP_REST_Response {
+		if ( '' === $job_id ) {
+			return null;
+		}
+
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		if (
+			null === $row
+			|| 'processing' !== $row->status
+			|| $row->session_id !== $session_id
+			|| $row->user_id !== get_current_user_id()
+		) {
+			return null;
+		}
+
+		AgentEventLog::log(
+			'client_tools_duplicate_result_accepted',
+			AgentEventLog::SEVERITY_INFO,
+			array(
+				'session_id' => $session_id,
+				'job_id'     => $job_id,
+				'phase'      => 'tool_result_resume',
+				'reason'     => 'result_batch_resume_in_progress',
+			)
+		);
+
+		return new WP_REST_Response(
+			array(
+				'status'           => 'processing',
+				'results_accepted' => true,
+				'session_id'       => $session_id,
+				'job_id'           => $job_id,
+			),
+			202
+		);
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -3058,6 +3058,88 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'error', $db_row->status );
 	}
 
+	/** A duplicate result POST cannot fail a browser-tool resume still in flight. */
+	public function test_tool_result_retry_during_active_resume_is_acknowledged(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'In-flight client result resume',
+		] );
+		$job_id     = '55555555-6666-7777-8888-999999999999';
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[ 'status' => 'processing' ],
+			RestController::JOB_TTL
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			'job_id'       => $job_id,
+			'tool_results' => [
+				[
+					'id'     => 'call_screenshot_active',
+					'name'   => 'sd-ai-agent-js/screenshot-url',
+					'result' => [ 'success' => true ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertStatus( 202, $response );
+		$this->assertSame( 'processing', $response->get_data()['status'] );
+		$this->assertTrue( $response->get_data()['results_accepted'] );
+
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'processing', $db_row->status );
+		$this->assertSame( 'processing', get_transient( RestController::JOB_PREFIX . $job_id )['status'] );
+	}
+
+	/** Browser-tool resumes become recoverable interrupted jobs on PHP shutdown. */
+	public function test_client_tool_resume_claim_enables_interruption_recovery(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Recoverable client result resume',
+		] );
+		$job_id     = '66666666-7777-8888-9999-000000000000';
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_client_tools' );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'                    => 'awaiting_client_tools',
+				'pending_client_tool_calls' => [ [ 'id' => 'call_active' ] ],
+			],
+			RestController::JOB_TTL
+		);
+
+		$method = new \ReflectionMethod( RestController::class, 'start_client_tool_resume' );
+		$this->assertFalse( $method->invoke( null, $job_id, $session_id + 1 ) );
+		$unclaimed_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $unclaimed_row );
+		$this->assertSame( 'awaiting_client_tools', $unclaimed_row->status );
+		$this->assertTrue( $method->invoke( null, $job_id, $session_id ) );
+
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'processing', $db_row->status );
+		$this->assertSame( '[]', $db_row->pending_tools );
+		$job = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $job );
+		$this->assertSame( 'processing', $job['status'] );
+		$this->assertArrayNotHasKey( 'pending_client_tool_calls', $job );
+
+		$this->assertTrue( ActiveJobRepository::mark_interrupted( $job_id ) );
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'interrupted', $db_row->status );
+	}
+
 	/**
 	 * Test POST /chat/tool-result on a 'complete' transient does NOT
 	 * downgrade it to 'error'. A duplicate POST after the original already


### PR DESCRIPTION
## Summary
- claim validated browser-tool result batches as active processing jobs before resuming the agent loop
- acknowledge duplicate result POSTs while the original resume is still running instead of misclassifying them as expired approvals
- register the active-job shutdown handler for browser-tool resumes so PHP request timeouts become checkpoint-recoverable interruptions
- bind resume claims and duplicate acknowledgements to the owning session and user

## Root cause
A long Setup Assistant browser-tool resume exceeded PHP's 300-second request limit. The durable job row and transient still advertised `awaiting_client_tools`, while the session pause had already been consumed. The browser retried the same result batch, and the missing pause was incorrectly normalized as an expired approval, overwriting the recoverable in-flight job.

## Verification
- focused REST and AgentLoop tests: 300 tests, 940 assertions, 67 skipped
- regression tests cover duplicate in-flight POST acknowledgement, session-bound claiming, processing-state transition, and interruption recovery

## Worker self-verification
- PHPUnit: Tests: 4229, Assertions: 19336, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resuming jobs that require client-provided tool results.
  * Duplicate tool-result submissions are safely acknowledged while processing is already underway.
  * Jobs now recover correctly as interrupted if the process stops during a resumed operation.
  * Invalid or competing resume attempts return an appropriate conflict response.

* **Tests**
  * Added coverage for duplicate submissions, resume processing, and interruption recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->