### PR TITLE
GH#2588: Allow valid nested Gutenberg trees

### DIFF
--- a/src/abilities/__tests__/editor-mutations.test.js
+++ b/src/abilities/__tests__/editor-mutations.test.js
@@ -34,7 +34,7 @@ function setEditor() {
 		getBlockListSettings: () => ( {} ),
 		getBlockInsertionPoint: () => ( { rootClientId: '', index: 1 } ),
 		getSettings: () => ( { allowedBlockTypes: true } ),
-		canInsertBlockType: () => true,
+		canInsertBlockType: jest.fn( () => true ),
 		getBlocks: () => Object.values( state.blocks ),
 	};
 	const dispatcher = {
@@ -230,6 +230,126 @@ describe( 'editor markup mutations', () => {
 			applied: true,
 			clientIds: [ 'new' ],
 		} );
+	} );
+
+	test( 'allows valid nested trees but rejects invalid direct children', () => {
+		const { selector } = setEditor();
+		const { parseCanonicalMarkup } = loadModule();
+		const makeBlock = ( name, innerBlocks = [] ) => ( {
+			clientId: name,
+			name,
+			markup: name,
+			attributes: {},
+			innerBlocks,
+		} );
+		const nestedTrees = {
+			'core/list': () => [
+				makeBlock( 'core/list', [
+					makeBlock( 'core/list-item' ),
+					makeBlock( 'core/list-item' ),
+				] ),
+			],
+			'core/columns': () => [
+				makeBlock( 'core/columns', [
+					makeBlock( 'core/column' ),
+					makeBlock( 'core/column' ),
+				] ),
+			],
+			'core/buttons': () => [
+				makeBlock( 'core/buttons', [
+					makeBlock( 'core/button' ),
+					makeBlock( 'core/button' ),
+				] ),
+			],
+		};
+		const blockTypes = {
+			'core/list': {
+				name: 'core/list',
+				allowedBlocks: [ 'core/list-item' ],
+			},
+			'core/list-item': {
+				name: 'core/list-item',
+				parent: [ 'core/list' ],
+			},
+			'core/columns': {
+				name: 'core/columns',
+				allowedBlocks: [ 'core/column' ],
+			},
+			'core/column': {
+				name: 'core/column',
+				parent: [ 'core/columns' ],
+			},
+			'core/buttons': {
+				name: 'core/buttons',
+				allowedBlocks: [ 'core/button' ],
+			},
+			'core/button': {
+				name: 'core/button',
+				parent: [ 'core/buttons' ],
+			},
+		};
+		const originalSerialize =
+			global.wp.blocks.serialize.getMockImplementation();
+
+		global.wp.blocks.getBlockType.mockImplementation(
+			( name ) => blockTypes[ name ] || null
+		);
+		global.wp.blocks.parse.mockImplementation( ( markup ) => {
+			const name = markup
+				.replace( 'nested-', '' )
+				.replace( 'canonical-', '' );
+			return nestedTrees[ name ]
+				? nestedTrees[ name ]()
+				: [ makeBlock( name ) ];
+		} );
+		global.wp.blocks.serialize.mockImplementation( ( blocks ) => {
+			if ( nestedTrees[ blocks[ 0 ]?.name ] ) {
+				return `canonical-${ blocks[ 0 ].name }`;
+			}
+			return originalSerialize( blocks );
+		} );
+		selector.canInsertBlockType.mockImplementation(
+			( name, rootClientId ) =>
+				rootClientId !== 'group' ||
+				[ 'core/list', 'core/columns', 'core/buttons' ].includes( name )
+		);
+
+		for ( const name of Object.keys( nestedTrees ) ) {
+			expect(
+				parseCanonicalMarkup( `nested-${ name }`, selector, 'group' )
+			).toMatchObject( { blocks: [ { name } ] } );
+		}
+		for ( const name of [
+			'core/list-item',
+			'core/column',
+			'core/button',
+		] ) {
+			expect(
+				parseCanonicalMarkup( name, selector, 'group' )
+			).toMatchObject( {
+				reason: 'validation_failed',
+				errors: [ { code: 'disallowed_block', block: name } ],
+			} );
+		}
+	} );
+
+	test( 'rejects a template-locked insertion destination without writing', async () => {
+		const { selector, dispatcher } = setEditor();
+		const { insertBlockMarkup } = loadModule();
+
+		selector.getBlockListSettings = ( rootClientId ) =>
+			rootClientId === 'locked-group' ? { templateLock: 'all' } : {};
+		await expect(
+			insertBlockMarkup( {
+				markup: 'valid',
+				rootClientId: 'locked-group',
+				index: 1,
+			} )
+		).resolves.toMatchObject( {
+			applied: false,
+			reason: 'template_locked',
+		} );
+		expect( dispatcher.insertBlocks ).not.toHaveBeenCalled();
 	} );
 
 	test( 'runs one native history operation and reports whether it changed blocks', () => {

--- a/src/abilities/editor-mutations.js
+++ b/src/abilities/editor-mutations.js
@@ -71,6 +71,55 @@ function isAllowedBlock( editor, settings, name, rootClientId ) {
 }
 
 /**
+ * Determine whether a parsed child is permitted by its parsed parent.
+ *
+ * The editor selector can only validate a client ID already present in the
+ * editor. Parsed descendants have not been inserted yet, so validate their
+ * registered parent, ancestor, and allowed-block constraints directly.
+ *
+ * @param {Object}   settings      Editor settings.
+ * @param {Object}   blockType     Parsed child block type.
+ * @param {Object}   parentType    Parsed parent block type.
+ * @param {string[]} ancestorNames Parsed ancestor block names.
+ * @return {boolean} Whether the parsed child is allowed.
+ */
+function isAllowedNestedBlock(
+	settings,
+	blockType,
+	parentType,
+	ancestorNames
+) {
+	if (
+		Array.isArray( settings?.allowedBlockTypes ) &&
+		! settings.allowedBlockTypes.includes( blockType.name )
+	) {
+		return false;
+	}
+	if (
+		! Array.isArray( settings?.allowedBlockTypes ) &&
+		settings?.allowedBlockTypes !== true
+	) {
+		return false;
+	}
+	if (
+		Array.isArray( blockType.parent ) &&
+		! blockType.parent.includes( parentType?.name )
+	) {
+		return false;
+	}
+	if (
+		Array.isArray( blockType.ancestor ) &&
+		! blockType.ancestor.some( ( name ) => ancestorNames.includes( name ) )
+	) {
+		return false;
+	}
+	return ! (
+		Array.isArray( parentType?.allowedBlocks ) &&
+		! parentType.allowedBlocks.includes( blockType.name )
+	);
+}
+
+/**
  * Count and validate one parsed block tree.
  *
  * @param {Object}   api          Gutenberg blocks API.
@@ -83,7 +132,7 @@ function isAllowedBlock( editor, settings, name, rootClientId ) {
 function validateTree( api, editor, settings, blocks, rootClientId ) {
 	let count = 0;
 	const errors = [];
-	const walk = ( block, depth ) => {
+	const walk = ( block, depth, parentType = null, ancestorNames = [] ) => {
 		count++;
 		if ( depth > MAX_BLOCK_DEPTH ) {
 			errors.push( {
@@ -108,7 +157,10 @@ function validateTree( api, editor, settings, blocks, rootClientId ) {
 			errors.push( { code: 'unregistered_block', block: block.name } );
 			return;
 		}
-		if ( ! isAllowedBlock( editor, settings, block.name, rootClientId ) ) {
+		const isAllowed = parentType
+			? isAllowedNestedBlock( settings, type, parentType, ancestorNames )
+			: isAllowedBlock( editor, settings, block.name, rootClientId );
+		if ( ! isAllowed ) {
 			errors.push( { code: 'disallowed_block', block: block.name } );
 			return;
 		}
@@ -120,7 +172,7 @@ function validateTree( api, editor, settings, blocks, rootClientId ) {
 			errors.push( { code: 'invalid_block', block: block.name } );
 		}
 		for ( const child of block.innerBlocks || [] ) {
-			walk( child, depth + 1 );
+			walk( child, depth + 1, type, [ ...ancestorNames, block.name ] );
 		}
 	};
 	for ( const block of blocks ) {
@@ -220,6 +272,23 @@ function blockHasProtectedState( block ) {
 	}
 
 	return ( block?.innerBlocks || [] ).some( blockHasProtectedState );
+}
+
+/**
+ * Return true when the target insertion root is template locked.
+ *
+ * @param {Object} editor       Block editor selector.
+ * @param {string} rootClientId Target insertion root client ID.
+ * @return {boolean} Whether the insertion root is protected.
+ */
+function hasProtectedInsertionRoot( editor, rootClientId ) {
+	const rootBlock = rootClientId ? editor.getBlock?.( rootClientId ) : null;
+	if ( rootBlock?.attributes?.templateLock || rootBlock?.templateLock ) {
+		return true;
+	}
+	return Boolean(
+		editor.getBlockListSettings?.( rootClientId || '' )?.templateLock
+	);
 }
 
 /**
@@ -382,6 +451,9 @@ export async function insertBlockMarkup( args = {} ) {
 	const index = explicitIndex === undefined ? insertion.index : explicitIndex;
 	if ( ! Number.isInteger( index ) || index < 0 ) {
 		return rejected( 'insertion_point_unavailable' );
+	}
+	if ( hasProtectedInsertionRoot( editor, rootClientId ) ) {
+		return rejected( 'template_locked' );
 	}
 	const parsed = parseCanonicalMarkup( args.markup, editor, rootClientId );
 	if ( ! parsed.blocks ) {

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -506,6 +506,100 @@ test.describe( 'client-abilities — insert-block on editor screen', () => {
 	} );
 } );
 
+test.describe( 'client-abilities — nested block insertion', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginToWordPress( page );
+	} );
+
+	test( 'nested block insertion preserves the Group parent and index after reload', async ( {
+		page,
+	} ) => {
+		await createDraftAndOpenEditor( page );
+		await skipIfNoAbilitiesApi( page );
+		await waitForAbilitiesRegistered( page );
+
+		const inserted = await page.evaluate( async () => {
+			const blockEditor = wp.data.select( 'core/block-editor' );
+			const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+			const group = wp.blocks.createBlock( 'core/group', {}, [
+				wp.blocks.createBlock( 'core/paragraph', {
+					content: 'Existing Group child.',
+				} ),
+			] );
+			const list = wp.blocks.createBlock( 'core/list', {}, [
+				wp.blocks.createBlock( 'core/list-item', {
+					content: 'Nested first item.',
+				} ),
+				wp.blocks.createBlock( 'core/list-item', {
+					content: 'Nested second item.',
+				} ),
+			] );
+
+			blockDispatcher.resetBlocks( [ group ] );
+			const result = await wp.abilities.executeAbility(
+				'sd-ai-agent-js/insert-block-markup',
+				{
+					markup: wp.blocks.serialize( [ list ] ),
+					rootClientId: group.clientId,
+					index: 1,
+				}
+			);
+			const insertedGroup = blockEditor.getBlock( group.clientId );
+
+			return {
+				result,
+				children: insertedGroup.innerBlocks.map( ( block ) => ( {
+					name: block.name,
+					children: block.innerBlocks.map( ( child ) => child.name ),
+				} ) ),
+				markup: wp.blocks.serialize( blockEditor.getBlocks() ),
+			};
+		} );
+
+		expect( inserted.result ).toMatchObject( { applied: true } );
+		expect( inserted.children ).toEqual( [
+			{ name: 'core/paragraph', children: [] },
+			{
+				name: 'core/list',
+				children: [ 'core/list-item', 'core/list-item' ],
+			},
+		] );
+		expect( inserted.markup ).toContain( 'Nested first item.' );
+
+		await page.evaluate( async () => {
+			await wp.data.dispatch( 'core/editor' ).savePost();
+		} );
+		await page.reload();
+		await page.waitForLoadState( 'domcontentloaded' );
+		await page.waitForFunction(
+			() =>
+				typeof wp?.data?.select?.( 'core/block-editor' )?.getBlocks ===
+				'function',
+			null,
+			{ timeout: 60_000 }
+		);
+
+		const reloaded = await page.evaluate( () => {
+			const group = wp
+				.data.select( 'core/block-editor' )
+				.getBlocks()
+				.find( ( block ) => block.name === 'core/group' );
+			return {
+				children: group.innerBlocks.map( ( block ) => ( {
+					name: block.name,
+					children: block.innerBlocks.map( ( child ) => child.name ),
+				} ) ),
+				markup: wp.blocks.serialize(
+					wp.data.select( 'core/block-editor' ).getBlocks()
+				),
+			};
+		} );
+
+		expect( reloaded.children ).toEqual( inserted.children );
+		expect( reloaded.markup ).toContain( 'Nested second item.' );
+	} );
+} );
+
 // ---------------------------------------------------------------------------
 // Test suite 5: server-side post reflection in the block editor
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- validate parsed top-level blocks against the requested editor root only
- validate descendants against their registered parent, ancestor, and allowed-block constraints
- reject template-locked insertion roots before dispatching and cover nested-list persistence in Playwright

Resolves #2588

## Verification

- `pnpm run lint:js` passed
- `pnpm run test:js -- src/abilities/__tests__/editor-mutations.test.js` passed: 11 tests
- `composer phpstan` passed: 0 errors
- `pnpm run build` passed; `pnpm run check:bundle` passed
- `pnpm exec playwright test tests/e2e/client-abilities.spec.js --grep "nested block insertion" --project=chromium` could not start because the local Chromium executable is absent
- `pnpm run verify` reached PHPStan successfully, then stopped before PHP tests because the shared PHPUnit configuration cannot connect to MySQL as `root@localhost`; this occurs before plugin tests load

## Worker self-verification
- PHPUnit: blocked by local MySQL authentication (`root@localhost`, no password) before tests load
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for nested block insertions, including parent and ancestor restrictions.
  - Prevented insertions into template-locked areas.
  - Ensured invalid nested structures are rejected without applying changes.

- **Tests**
  - Added coverage for valid and invalid nested lists, columns, and buttons.
  - Added end-to-end verification that nested block structures persist after saving and reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->