### PR TITLE
Fix settled Gutenberg history results

### DIFF
--- a/src/abilities/__tests__/editor-mutations.test.js
+++ b/src/abilities/__tests__/editor-mutations.test.js
@@ -15,6 +15,9 @@ function setEditor() {
 	const state = {
 		selectedIds: [ 'old' ],
 		onSerialize: null,
+		canUndo: false,
+		canRedo: false,
+		subscribers: [],
 		blocks: {
 			old: {
 				clientId: 'old',
@@ -55,6 +58,15 @@ function setEditor() {
 		undo: jest.fn(),
 		redo: jest.fn(),
 	};
+	const historySelector = {
+		hasEditorUndo: () => state.canUndo,
+		hasEditorRedo: () => state.canRedo,
+	};
+	const notify = () => {
+		for ( const subscriber of state.subscribers ) {
+			subscriber();
+		}
+	};
 	const parse = jest.fn( ( markup ) => {
 		if (
 			markup === 'valid' ||
@@ -74,10 +86,20 @@ function setEditor() {
 	} );
 	global.wp = {
 		data: {
-			select: jest.fn( () => selector ),
+			select: jest.fn( ( storeName ) =>
+				storeName === 'core/editor' ? historySelector : selector
+			),
 			dispatch: jest.fn( ( storeName ) =>
 				storeName === 'core/editor' ? historyDispatcher : dispatcher
 			),
+			subscribe: jest.fn( ( callback ) => {
+				state.subscribers.push( callback );
+				return () => {
+					state.subscribers = state.subscribers.filter(
+						( subscriber ) => subscriber !== callback
+					);
+				};
+			} ),
 		},
 		blocks: {
 			parse,
@@ -91,7 +113,7 @@ function setEditor() {
 			validateBlock: jest.fn( () => [ true, [] ] ),
 		},
 	};
-	return { state, selector, dispatcher, historyDispatcher, parse };
+	return { state, selector, dispatcher, historyDispatcher, notify, parse };
 }
 
 describe( 'editor markup mutations', () => {
@@ -232,11 +254,13 @@ describe( 'editor markup mutations', () => {
 		} );
 	} );
 
-	test( 'runs one native history operation and reports whether it changed blocks', () => {
+	test( 'reports a no-history undo after one native dispatch', async () => {
 		const { historyDispatcher } = setEditor();
 		const { changeEditorHistory } = loadModule();
 
-		expect( changeEditorHistory( { direction: 'undo' } ) ).toEqual( {
+		await expect(
+			changeEditorHistory( { direction: 'undo' } )
+		).resolves.toEqual( {
 			applied: false,
 			direction: 'undo',
 		} );
@@ -245,8 +269,9 @@ describe( 'editor markup mutations', () => {
 		expect( global.wp.data.dispatch ).toHaveBeenCalledWith( 'core/editor' );
 	} );
 
-	test( 'reports a history change and rejects an invalid direction', () => {
+	test( 'reports a settled synchronous history change and rejects an invalid direction', async () => {
 		const { state, historyDispatcher } = setEditor();
+		state.canUndo = true;
 		historyDispatcher.undo.mockImplementation( () => {
 			state.blocks.changed = {
 				clientId: 'changed',
@@ -258,18 +283,79 @@ describe( 'editor markup mutations', () => {
 		} );
 		const { changeEditorHistory } = loadModule();
 
-		expect( changeEditorHistory( { direction: 'undo' } ) ).toEqual( {
+		await expect(
+			changeEditorHistory( { direction: 'undo' } )
+		).resolves.toEqual( {
 			applied: true,
 			direction: 'undo',
 		} );
-		expect(
+		await expect(
 			changeEditorHistory( { direction: 'sideways' } )
-		).toMatchObject( {
+		).resolves.toMatchObject( {
 			applied: false,
 			reason: 'invalid_history_direction',
 		} );
 		expect( historyDispatcher.undo ).toHaveBeenCalledTimes( 1 );
 		expect( historyDispatcher.redo ).not.toHaveBeenCalled();
+	} );
+
+	test( 'waits for delayed undo and redo store settlement before reporting success', async () => {
+		const { state, historyDispatcher, notify } = setEditor();
+		state.canUndo = true;
+		historyDispatcher.undo.mockImplementation( () => {
+			setTimeout( () => {
+				state.blocks = {
+					restored: {
+						clientId: 'restored',
+						name: 'core/paragraph',
+						markup: '<!-- wp:paragraph -->Restored<!-- /wp:paragraph -->',
+						attributes: {},
+						innerBlocks: [],
+					},
+				};
+				state.canUndo = false;
+				state.canRedo = true;
+				notify();
+			}, 0 );
+		} );
+		historyDispatcher.redo.mockImplementation( () => {
+			setTimeout( () => {
+				state.blocks = {
+					redone: {
+						clientId: 'redone',
+						name: 'core/paragraph',
+						markup: '<!-- wp:paragraph -->Redone<!-- /wp:paragraph -->',
+						attributes: {},
+						innerBlocks: [],
+					},
+				};
+				state.canUndo = true;
+				state.canRedo = false;
+				notify();
+			}, 0 );
+		} );
+		const { changeEditorHistory } = loadModule();
+
+		await expect(
+			changeEditorHistory( { direction: 'undo' } )
+		).resolves.toEqual( {
+			applied: true,
+			direction: 'undo',
+		} );
+		expect(
+			global.wp.blocks.serialize( Object.values( state.blocks ) )
+		).toBe( '<!-- wp:paragraph -->Restored<!-- /wp:paragraph -->' );
+		await expect(
+			changeEditorHistory( { direction: 'redo' } )
+		).resolves.toEqual( {
+			applied: true,
+			direction: 'redo',
+		} );
+		expect(
+			global.wp.blocks.serialize( Object.values( state.blocks ) )
+		).toBe( '<!-- wp:paragraph -->Redone<!-- /wp:paragraph -->' );
+		expect( historyDispatcher.undo ).toHaveBeenCalledTimes( 1 );
+		expect( historyDispatcher.redo ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'returns an uncertain result when an editor dispatch throws', async () => {
@@ -307,7 +393,9 @@ describe( 'editor markup mutations', () => {
 			applied: 'unknown',
 			reason: 'dispatch_failed',
 		} );
-		expect( changeEditorHistory( { direction: 'undo' } ) ).toMatchObject( {
+		await expect(
+			changeEditorHistory( { direction: 'undo' } )
+		).resolves.toMatchObject( {
 			applied: 'unknown',
 			direction: 'undo',
 			reason: 'dispatch_failed',

--- a/src/abilities/editor-mutations.js
+++ b/src/abilities/editor-mutations.js
@@ -17,6 +17,7 @@ export const MAX_MARKUP_BYTES = 64 * 1024;
 export const MAX_TOP_LEVEL_BLOCKS = 50;
 export const MAX_TOTAL_BLOCKS = 200;
 export const MAX_BLOCK_DEPTH = 20;
+const HISTORY_SETTLEMENT_TIMEOUT = 1_000;
 
 const UNSUPPORTED_BLOCKS = new Set( [ 'core/freeform', 'core/missing' ] );
 
@@ -45,6 +46,92 @@ function isValidBlock( result ) {
  */
 function rejected( reason, errors = [] ) {
 	return { applied: false, reason, errors: errors.slice( 0, 20 ) };
+}
+
+/**
+ * Serialize the current block-editor state without exposing editor internals.
+ *
+ * @param {Object} editor Block editor selector.
+ * @return {string} Current editor serialization.
+ */
+function getEditorSerialization( editor ) {
+	return wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
+}
+
+/**
+ * Wait for one block-editor store update that proves a history mutation changed content.
+ *
+ * @param {Object} editor Block editor selector.
+ * @param {string} before Serialized content before the history dispatch.
+ * @return {Promise<boolean>} Whether a settled store state differs from before.
+ */
+function waitForHistorySettlement( editor, before ) {
+	return new Promise( ( resolve ) => {
+		if ( typeof wp.data?.subscribe !== 'function' ) {
+			resolve( false );
+			return;
+		}
+
+		let complete = false;
+		let unsubscribe;
+		const finish = ( changed ) => {
+			if ( complete ) {
+				return;
+			}
+			complete = true;
+			if ( timeoutId ) {
+				clearTimeout( timeoutId );
+			}
+			if ( typeof unsubscribe === 'function' ) {
+				unsubscribe();
+			}
+			resolve( changed );
+		};
+		const check = () => {
+			if ( getEditorSerialization( editor ) !== before ) {
+				finish( true );
+			}
+		};
+
+		const timeoutId = setTimeout(
+			() => finish( false ),
+			HISTORY_SETTLEMENT_TIMEOUT
+		);
+		try {
+			unsubscribe = wp.data.subscribe( check, 'core/block-editor' );
+		} catch ( _error ) {
+			finish( false );
+			return;
+		}
+		if ( complete && typeof unsubscribe === 'function' ) {
+			unsubscribe();
+			return;
+		}
+		check();
+	} );
+}
+
+/**
+ * Capture pre-dispatch history state and request one native history action.
+ *
+ * @param {Object} editor     Block editor selector.
+ * @param {Object} dispatcher Editor history dispatcher.
+ * @param {string} direction  Requested history direction.
+ * @return {{before: string, hasHistory: boolean|undefined, dispatchFailed: boolean}} Dispatch evidence.
+ */
+function dispatchEditorHistory( editor, dispatcher, direction ) {
+	const history = wp.data.select( 'core/editor' );
+	const before = getEditorSerialization( editor );
+	const hasHistory =
+		direction === 'undo'
+			? history?.hasEditorUndo?.()
+			: history?.hasEditorRedo?.();
+	try {
+		dispatcher[ direction ]();
+		return { before, hasHistory, dispatchFailed: false };
+	} catch ( _error ) {
+		return { before, hasHistory, dispatchFailed: true };
+	}
 }
 
 /**
@@ -419,9 +506,9 @@ export async function insertBlockMarkup( args = {} ) {
  * Request precisely one native editor undo or redo action.
  *
  * @param {Object} args History arguments.
- * @return {Object} History mutation result.
+ * @return {Promise<Object>} History mutation result.
  */
-export function changeEditorHistory( args = {} ) {
+export async function changeEditorHistory( args = {} ) {
 	if (
 		typeof wp === 'undefined' ||
 		! wp.data?.select ||
@@ -438,18 +525,29 @@ export function changeEditorHistory( args = {} ) {
 	if ( ! editor || typeof dispatcher?.[ direction ] !== 'function' ) {
 		return rejected( 'history_unavailable' );
 	}
-	const before = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
-	try {
-		dispatcher[ direction ]();
-	} catch ( _error ) {
+	const historyResult = dispatchEditorHistory(
+		editor,
+		dispatcher,
+		direction
+	);
+	if ( historyResult.dispatchFailed ) {
 		return {
 			applied: 'unknown',
 			direction,
 			reason: 'dispatch_failed',
 		};
 	}
-	const after = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
-	return { applied: before !== after, direction };
+	if ( historyResult.hasHistory === false ) {
+		return { applied: false, direction };
+	}
+	if ( await waitForHistorySettlement( editor, historyResult.before ) ) {
+		return { applied: true, direction };
+	}
+	return {
+		applied: 'unknown',
+		direction,
+		reason: 'history_settlement_timeout',
+	};
 }
 
 /**

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -507,7 +507,79 @@ test.describe( 'client-abilities — insert-block on editor screen', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 5: server-side post reflection in the block editor
+// Test suite 5: editor history execution
+// ---------------------------------------------------------------------------
+
+test.describe( 'client-abilities — editor history', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginToWordPress( page );
+	} );
+
+	test( 'reports settled editor history undo and redo evidence', async ( {
+		page,
+	} ) => {
+		await createDraftAndOpenEditor( page );
+		await skipIfNoAbilitiesApi( page );
+		await waitForAbilitiesRegistered( page );
+
+		const result = await page.evaluate( async () => {
+			const blockEditor = wp.data.select( 'core/block-editor' );
+			const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+			const initialBlocks = blockEditor.getBlocks();
+			const selected = initialBlocks.find(
+				( block ) => block.name === 'core/paragraph'
+			);
+			if ( ! selected ) {
+				return { error: 'paragraph_unavailable' };
+			}
+
+			const original = wp.blocks.serialize( initialBlocks );
+			const replacement = wp.blocks.createBlock( 'core/paragraph', {
+				content: 'History replacement from Playwright.',
+			} );
+			blockDispatcher.selectBlock( selected.clientId );
+			blockDispatcher.replaceBlocks( [ selected.clientId ], replacement );
+			const replacementMarkup = wp.blocks.serialize(
+				blockEditor.getBlocks()
+			);
+			const undo = await wp.abilities.executeAbility(
+				'sd-ai-agent-js/change-editor-history',
+				{ direction: 'undo' }
+			);
+			const afterUndo = wp.blocks.serialize( blockEditor.getBlocks() );
+			const redo = await wp.abilities.executeAbility(
+				'sd-ai-agent-js/change-editor-history',
+				{ direction: 'redo' }
+			);
+			const afterRedo = wp.blocks.serialize( blockEditor.getBlocks() );
+
+			return {
+				original,
+				replacementMarkup,
+				undo,
+				afterUndo,
+				redo,
+				afterRedo,
+			};
+		} );
+
+		expect( result.error ).toBeUndefined();
+		expect( result.replacementMarkup ).not.toBe( result.original );
+		expect( result.undo ).toMatchObject( {
+			applied: true,
+			direction: 'undo',
+		} );
+		expect( result.afterUndo ).toBe( result.original );
+		expect( result.redo ).toMatchObject( {
+			applied: true,
+			direction: 'redo',
+		} );
+		expect( result.afterRedo ).toBe( result.replacementMarkup );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Test suite 6: server-side post reflection in the block editor
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — server post reflection', () => {
@@ -675,7 +747,7 @@ test.describe( 'client-abilities — server post reflection', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 6: insert-block no-op on non-editor screen
+// Test suite 7: insert-block no-op on non-editor screen
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — insert-block no-op on non-editor screen', () => {
@@ -719,7 +791,7 @@ test.describe( 'client-abilities — insert-block no-op on non-editor screen', (
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 7: snapshotDescriptors
+// Test suite 8: snapshotDescriptors
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — snapshotDescriptors', () => {
@@ -793,7 +865,7 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 8: No relevant console errors
+// Test suite 9: No relevant console errors
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — no relevant console errors', () => {


### PR DESCRIPTION
## Summary

- Wait for a bounded `core/block-editor` store settlement before reporting a Gutenberg undo or redo result.
- Distinguish verified history changes, known no-history actions, dispatch failures, and unverified settlement timeouts.
- Cover delayed unit-store updates and the real browser history path.

## Verification

- `pnpm run lint:js` — passed
- `pnpm run test:js -- src/abilities/__tests__/editor-mutations.test.js` — passed (12 tests)
- `composer phpstan` — passed (0 errors)
- `pnpm run build` — passed (existing webpack asset-size warnings only)
- `pnpm run check:bundle` — passed
- `pnpm run test:php` via `pnpm run verify` — blocked before test discovery: the local WordPress PHPUnit database rejected `root@localhost` with no password
- `pnpm exec playwright test tests/e2e/client-abilities.spec.js --grep "editor history" --project=chromium` — blocked: the local Playwright Chromium executable is absent

## Worker self-verification

- PHPUnit: blocked before running tests by the local WordPress test-database authentication failure
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

Resolves #2587

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra
