### PR TITLE
fix: omit empty client ability requirements (#2589)

### DIFF
--- a/src/abilities/__tests__/editor-capabilities.test.js
+++ b/src/abilities/__tests__/editor-capabilities.test.js
@@ -15,6 +15,23 @@ function loadModule() {
 }
 
 /**
+ * Load editor capabilities and its matching registry module instance.
+ *
+ * @return {{ capabilities: Object, registry: Object }} Isolated modules.
+ */
+function loadCapabilitiesAndRegistry() {
+	let capabilities;
+	let registry;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		capabilities = require( '../editor-capabilities' );
+		// eslint-disable-next-line global-require
+		registry = require( '../registry' );
+	} );
+	return { capabilities, registry };
+}
+
+/**
  * Set a minimal Gutenberg editor environment.
  *
  * @param {Object}   root0
@@ -135,5 +152,22 @@ describe( 'get-editor-capabilities', () => {
 			available: false,
 			unavailable_sources: [ 'block_registry', 'editor_settings' ],
 		} );
+	} );
+
+	test( 'registers an optional blockNames schema without required', async () => {
+		const { capabilities, registry } = loadCapabilitiesAndRegistry();
+		await capabilities.registerEditorCapabilitiesAbility();
+		const descriptor = ( await registry.snapshotDescriptors() ).find(
+			( candidate ) =>
+				candidate.name === 'sd-ai-agent-js/get-editor-capabilities'
+		);
+
+		expect( descriptor.input_schema ).toMatchObject( {
+			type: 'object',
+			properties: {
+				blockNames: { type: 'array' },
+			},
+		} );
+		expect( descriptor.input_schema ).not.toHaveProperty( 'required' );
 	} );
 } );

--- a/src/abilities/__tests__/editor.test.js
+++ b/src/abilities/__tests__/editor.test.js
@@ -123,6 +123,20 @@ describe( 'get-editor-selection', () => {
 		expect( descriptor.output_schema.properties ).toHaveProperty(
 			'fingerprint'
 		);
+		expect( descriptor.input_schema ).toMatchObject( {
+			type: 'object',
+			properties: {},
+		} );
+		expect( descriptor.input_schema ).not.toHaveProperty( 'required' );
+
+		const insertBlockDescriptor = (
+			await registry.snapshotDescriptors()
+		).find(
+			( candidate ) => candidate.name === 'sd-ai-agent-js/insert-block'
+		);
+		expect( insertBlockDescriptor.input_schema.required ).toEqual( [
+			'blockName',
+		] );
 	} );
 
 	test( 'returns a stable fingerprint for the same current selection', async () => {

--- a/src/abilities/__tests__/registry.test.js
+++ b/src/abilities/__tests__/registry.test.js
@@ -32,6 +32,23 @@ function loadRegistry() {
 	return mod;
 }
 
+/**
+ * Load refresh-page and its matching registry module instance.
+ *
+ * @return {{ refreshPage: Object, registry: Object }} Isolated modules.
+ */
+function loadRefreshPageAndRegistry() {
+	let refreshPage;
+	let registry;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		refreshPage = require( '../refresh-page' );
+		// eslint-disable-next-line global-require
+		registry = require( '../registry' );
+	} );
+	return { refreshPage, registry };
+}
+
 describe( 'registry — sd-ai-86a regression', () => {
 	let originalWp;
 
@@ -195,5 +212,20 @@ describe( 'registry — sd-ai-86a regression', () => {
 		// Local execution path still works alongside the WP store entry.
 		await executeClientAbility( 'sd-ai-agent-js/with-api', { x: 1 } );
 		expect( callback ).toHaveBeenCalledWith( { x: 1 } );
+	} );
+
+	test( 'registers refresh-page without an empty required array', async () => {
+		delete global.wp;
+		const { refreshPage, registry } = loadRefreshPageAndRegistry();
+		await refreshPage.registerRefreshPageAbility();
+		const descriptor = ( await registry.snapshotDescriptors() ).find(
+			( candidate ) => candidate.name === 'sd-ai-agent-js/refresh-page'
+		);
+
+		expect( descriptor.input_schema ).toMatchObject( {
+			type: 'object',
+			properties: {},
+		} );
+		expect( descriptor.input_schema ).not.toHaveProperty( 'required' );
 	} );
 } );

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -122,6 +122,13 @@ describe( 'full-page screenshot safety', () => {
 			expect( descriptor.output_schema.properties ).toHaveProperty(
 				'truncated'
 			);
+			if ( name === 'sd-ai-agent-js/capture-screenshot' ) {
+				expect( descriptor.input_schema ).not.toHaveProperty(
+					'required'
+				);
+			} else {
+				expect( descriptor.input_schema.required ).toEqual( [ 'url' ] );
+			}
 		}
 	} );
 } );

--- a/src/abilities/editor-capabilities.js
+++ b/src/abilities/editor-capabilities.js
@@ -447,7 +447,6 @@ export async function registerEditorCapabilitiesAbility() {
 					items: { type: 'string' },
 				},
 			},
-			required: [],
 		},
 		outputSchema: {
 			type: 'object',

--- a/src/abilities/editor.js
+++ b/src/abilities/editor.js
@@ -288,7 +288,6 @@ export async function registerEditorAbility() {
 		inputSchema: {
 			type: 'object',
 			properties: {},
-			required: [],
 		},
 		outputSchema: {
 			type: 'object',

--- a/src/abilities/refresh-page.js
+++ b/src/abilities/refresh-page.js
@@ -38,7 +38,6 @@ export async function registerRefreshPageAbility() {
 		inputSchema: {
 			type: 'object',
 			properties: {},
-			required: [],
 		},
 		outputSchema: {
 			type: 'object',

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -565,7 +565,6 @@ export async function registerCaptureScreenshotAbility() {
 					description: FULL_PAGE_CAPTURE_GUIDANCE,
 				},
 			},
-			required: [],
 		},
 		outputSchema: {
 			type: 'object',

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -303,7 +303,7 @@ test.describe( 'client-abilities — ability registration', () => {
 		await skipIfNoAbilitiesApi( page );
 	} );
 
-	test( 'navigate-to and insert-block appear in getAbilities()', async ( {
+	test( 'required client abilities expose valid schemas and readonly annotations', async ( {
 		page,
 	} ) => {
 		await waitForAbilitiesRegistered( page );
@@ -326,14 +326,23 @@ test.describe( 'client-abilities — ability registration', () => {
 			}
 		} );
 
-		const names = abilities.map( ( a ) => a.name );
-		expect( names ).toContain( 'sd-ai-agent-js/navigate-to' );
-		expect( names ).toContain( 'sd-ai-agent-js/insert-block' );
+		const byName = new Map(
+			abilities.map( ( ability ) => [ ability.name, ability ] )
+		);
+		for ( const name of [
+			'sd-ai-agent-js/navigate-to',
+			'sd-ai-agent-js/refresh-page',
+			'sd-ai-agent-js/get-editor-selection',
+			'sd-ai-agent-js/insert-block',
+			'sd-ai-agent-js/get-editor-capabilities',
+			'sd-ai-agent-js/capture-screenshot',
+			'sd-ai-agent-js/screenshot-url',
+		] ) {
+			expect( byName.has( name ) ).toBe( true );
+		}
 
 		// Verify expected schema shape for navigate-to.
-		const navigateTo = abilities.find(
-			( a ) => a.name === 'sd-ai-agent-js/navigate-to'
-		);
+		const navigateTo = byName.get( 'sd-ai-agent-js/navigate-to' );
 		expect( navigateTo ).toBeDefined();
 		expect( navigateTo ).toMatchObject( {
 			name: 'sd-ai-agent-js/navigate-to',
@@ -349,9 +358,7 @@ test.describe( 'client-abilities — ability registration', () => {
 		} );
 
 		// Verify expected schema shape for insert-block.
-		const insertBlock = abilities.find(
-			( a ) => a.name === 'sd-ai-agent-js/insert-block'
-		);
+		const insertBlock = byName.get( 'sd-ai-agent-js/insert-block' );
 		expect( insertBlock ).toBeDefined();
 		expect( insertBlock ).toMatchObject( {
 			name: 'sd-ai-agent-js/insert-block',
@@ -365,11 +372,68 @@ test.describe( 'client-abilities — ability registration', () => {
 				blockName: expect.objectContaining( { type: 'string' } ),
 			} ),
 		} );
+		expect( insertBlock.input_schema.required ).toEqual( [ 'blockName' ] );
+		expect( insertBlock.meta.annotations ).toMatchObject( {
+			readonly: false,
+		} );
+
+		for ( const name of [
+			'sd-ai-agent-js/refresh-page',
+			'sd-ai-agent-js/get-editor-selection',
+			'sd-ai-agent-js/get-editor-capabilities',
+			'sd-ai-agent-js/capture-screenshot',
+		] ) {
+			expect( byName.get( name ).input_schema ).not.toHaveProperty(
+				'required'
+			);
+			expect( byName.get( name ).meta.annotations ).toMatchObject( {
+				readonly: true,
+			} );
+		}
+		expect(
+			byName.get( 'sd-ai-agent-js/screenshot-url' ).input_schema.required
+		).toEqual( [ 'url' ] );
 	} );
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 3: navigate-to execution
+// Test suite 3: public schema validation
+// ---------------------------------------------------------------------------
+
+test.describe( 'client-abilities — public schema validation', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginToWordPress( page );
+		await goToDashboard( page );
+		await skipIfNoAbilitiesApi( page );
+	} );
+
+	test( 'executeAbility reaches get-editor-selection with empty input', async ( {
+		page,
+	} ) => {
+		await waitForAbilitiesRegistered( page );
+
+		const result = await page.evaluate( async () => {
+			try {
+				return await wp.abilities.executeAbility(
+					'sd-ai-agent-js/get-editor-selection',
+					{}
+				);
+			} catch ( err ) {
+				return { error: err.message };
+			}
+		} );
+
+		expect( result.error ).toBeUndefined();
+		expect( result ).toMatchObject( {
+			available: expect.any( Boolean ),
+			selected: expect.any( Boolean ),
+			count: expect.any( Number ),
+		} );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Test suite 4: navigate-to execution
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — navigate-to execution', () => {


### PR DESCRIPTION
## Summary

- Omit invalid empty `required` arrays from empty and optional client ability schemas.
- Preserve non-empty requirements for mutating abilities.
- Cover descriptor schemas and public `executeAbility()` validation without relying on a global descriptor count.

Resolves #2589

## Worker self-verification

- PHPUnit: blocked locally by the pre-existing `root@localhost` database authentication failure; the PR's remote PHPUnit check passed.
- JS unit tests: `pnpm run test:js -- src/abilities/__tests__` — 10 suites, 68 tests passed.
- Lint: PHP/JS/CSS all clean via `pnpm run verify` before the PHPUnit environment failure.
- PHPStan: 0 errors.
- Build: succeeded.
- Bundle: budgets passed.
- E2E: the specified Chromium run is blocked locally because the Playwright browser binary is absent; the system-Chrome fallback exits with SIGTRAP before the test starts. Remote E2E shards are in progress.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 16m and 171,541 tokens on this as a headless worker.