### PR TITLE
fix: bound page quality client validation

### DIFF
--- a/includes/Core/PageCompletionGate.php
+++ b/includes/Core/PageCompletionGate.php
@@ -104,6 +104,8 @@ final class PageCompletionGate {
 
 	private bool $visual_review_passed = false;
 
+	private bool $report_received = false;
+
 	/** @var bool True only for the canonical anonymous check immediately after preview publication. */
 	private bool $public_smoke_only = false;
 
@@ -295,7 +297,11 @@ final class PageCompletionGate {
 
 	/** Whether AgentLoop should dispatch the exact gate-owned browser call. */
 	public function should_dispatch_validation(): bool {
-		return $this->is_required() && ! $this->publish_failed && ! $this->deterministic_report_passed && $this->client_validator_available;
+		return $this->is_required()
+			&& ! $this->publish_failed
+			&& ! $this->deterministic_report_passed
+			&& ! $this->report_received
+			&& $this->client_validator_available;
 	}
 
 	/** Whether an approved private preview is ready for guarded publication. */
@@ -504,6 +510,7 @@ final class PageCompletionGate {
 			'viewports'                   => $inputs['viewports'],
 			'client_validator_present'    => $this->client_validator_available,
 			'deterministic_report_passed' => $this->deterministic_report_passed,
+			'report_received'             => $this->report_received,
 			'visual_review_required'      => $this->requires_visual_review(),
 			'visual_review_passed'        => $this->visual_review_passed,
 			'public_smoke_only'           => $this->public_smoke_only,
@@ -625,6 +632,7 @@ final class PageCompletionGate {
 	 */
 	private function record_quality_report( array $call_args, array $response ): void {
 		$this->last_report                 = $response;
+		$this->report_received             = true;
 		$this->passed                      = false;
 		$this->deterministic_report_passed = false;
 		$this->visual_review_passed        = false;
@@ -888,6 +896,7 @@ final class PageCompletionGate {
 		$this->passed                      = false;
 		$this->deterministic_report_passed = false;
 		$this->visual_review_passed        = false;
+		$this->report_received             = false;
 		$this->last_report                 = array();
 		$this->last_failure                = $reason;
 	}

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -906,6 +906,68 @@ describe( 'actions', () => {
 		}
 	} );
 
+	test( 'pollJob allows page-quality validation to exceed the generic client timeout', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		executeClientAbility.mockReset();
+		executeClientAbility.mockImplementation(
+			() =>
+				new Promise( ( resolve ) =>
+					setTimeout( () => resolve( { passed: true } ), 35000 )
+				)
+		);
+		apiFetch.mockImplementation( ( request ) => {
+			if ( request.path === '/sd-ai-agent/v1/job/page-quality-job' ) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'call-page-quality',
+							name: 'sd-ai-agent-js/validate-page-quality',
+							annotations: { readonly: true },
+							args: { profile: 'setup' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( {} );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'page-quality-job' ),
+		};
+
+		try {
+			actions.pollJob( 'page-quality-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 37000 );
+
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'page-quality-job',
+					tool_results: [
+						{
+							id: 'call-page-quality',
+							name: 'sd-ai-agent-js/validate-page-quality',
+							result: { passed: true },
+						},
+					],
+				},
+			} );
+		} finally {
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
 	test( 'resumeRecoverableJob starts and polls the replacement job', async () => {
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( { job_id: 'resumed-job' } );

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -647,6 +647,13 @@ export const actions = {
 
 						const toolResults = await Promise.all(
 							pendingCalls.map( async ( call ) => {
+								const abilityName =
+									call.client_name || call.name;
+								const timeoutMs =
+									abilityName ===
+									'sd-ai-agent-js/validate-page-quality'
+										? 120000
+										: 30000;
 								const isReadonly =
 									call.annotations?.readonly === true;
 								const isUserConfirmed =
@@ -668,15 +675,17 @@ export const actions = {
 								try {
 									const abilityResult = await Promise.race( [
 										executeClientAbility(
-											call.client_name || call.name,
+											abilityName,
 											call.args || {}
 										),
 										new Promise( ( _resolve, reject ) =>
 											setTimeout(
 												reject,
-												30000,
+												timeoutMs,
 												new Error(
-													'Client tool timed out after 30 seconds.'
+													`Client tool timed out after ${
+														timeoutMs / 1000
+													} seconds.`
 												)
 											)
 										),

--- a/tests/SdAiAgent/Core/PageCompletionGateTest.php
+++ b/tests/SdAiAgent/Core/PageCompletionGateTest.php
@@ -201,6 +201,24 @@ class PageCompletionGateTest extends WP_UnitTestCase {
 		$this->assertTrue( $gate->has_current_passing_report() );
 	}
 
+	/** A failed browser report must reach a repair turn instead of redispatching forever. */
+	public function test_failed_report_does_not_redispatch_until_a_mutation_invalidates_it(): void {
+		$gate = $this->gate( PageCompletionGate::PROFILE_INCREMENTAL );
+		$this->record_page( $gate, 41, self::PAGE_URL, 101 );
+		$inputs = $gate->get_expected_report_inputs();
+
+		$gate->record_tool_call( PageCompletionGate::CLIENT_ABILITY, $inputs );
+		$gate->record_tool_response( PageCompletionGate::CLIENT_ABILITY, array() );
+
+		$this->assertTrue( $gate->get_status()['report_received'] );
+		$this->assertFalse( $gate->should_dispatch_validation() );
+		$this->assertTrue( $gate->requires_repair() );
+
+		$this->record_page( $gate, 41, self::PAGE_URL, 102 );
+		$this->assertFalse( $gate->get_status()['report_received'] );
+		$this->assertTrue( $gate->should_dispatch_validation() );
+	}
+
 	/** Preview approval and public smoke validation never use a mixed render mode. */
 	public function test_preview_phase_defers_unrelated_public_targets_until_public_smoke(): void {
 		$gate = $this->gate( PageCompletionGate::PROFILE_SETUP );


### PR DESCRIPTION
## Summary

- give the server-directed page-quality browser validator a 120-second timeout while preserving the 30-second default for other client abilities
- record that a page-quality report was received even when it is empty or failed, so the completion gate enters a bounded repair turn instead of immediately redispatching the same validation
- reset the report latch only after a new governed mutation invalidates the prior evidence

## Observed failure

A Setup Assistant acceptance run repeatedly emitted the same five-page validation request with the same quality token. The client validator exceeded the generic 30-second timeout, and the gate immediately generated another identical request. More than ten call/response pairs accumulated without a repair turn or terminal result.

## Verification

- Focused PHP: 13 tests, 54 assertions, 0 failures
- JavaScript: 58 suites, 574 tests, 6 snapshots, 0 failures
- Lint: PHP, JavaScript, and CSS clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed
- Full PHP harness: 4,249 tests and 19,489 assertions; the changed page-gate suite passed. Four unrelated harness-specific failures were reproduced unchanged on `origin/main` in the same container (URL response shape, capability fallback state, and local screenshot-origin expectations).

## Worker self-verification

- PHPUnit: Focused changed suite — Tests: 13, Assertions: 54, Errors: 0, Failures: 0
- JavaScript: Tests: 574, Suites: 58, Failures: 0
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol
