### PR TITLE
fix: preserve compacted inspection evidence

### DIFF
--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -311,7 +311,8 @@ class ConversationTrimmer {
 		$header = array(
 			'Conversation compacted server-side to avoid provider payload limits.',
 			"Source messages: {$source_count}; retained excerpts: {$retained_count}; omitted messages: {$omitted_count}.",
-			'Use this compact context to continue from the user\'s next message. File attachments, inline image bytes, and raw tool payloads were omitted.',
+			'Use this compact context to continue the current task. File attachments, inline image bytes, and raw tool payloads were omitted.',
+			'Bounded inspection receipts are evidence of completed reads. Do not repeat an inspection solely because its raw result was omitted.',
 		);
 
 		return implode( "\n", $header ) . "\n\n" . implode( "\n\n", $lines );
@@ -381,6 +382,11 @@ class ConversationTrimmer {
 				return $mutation_receipt;
 			}
 
+			$inspection_receipt = self::compact_inspection_call_receipt( $function_call );
+			if ( '' !== $inspection_receipt ) {
+				return $inspection_receipt;
+			}
+
 			$name = self::compact_tool_name( $function_call['name'] ?? 'tool' );
 			return '[tool call: ' . $name . ']';
 		}
@@ -390,6 +396,11 @@ class ConversationTrimmer {
 			$mutation_receipt = self::compact_post_mutation_response_receipt( $function_response );
 			if ( '' !== $mutation_receipt ) {
 				return $mutation_receipt;
+			}
+
+			$inspection_receipt = self::compact_inspection_response_receipt( $function_response );
+			if ( '' !== $inspection_receipt ) {
+				return $inspection_receipt;
 			}
 
 			$name = self::compact_tool_name( $function_response['name'] ?? 'tool' );
@@ -484,6 +495,140 @@ class ConversationTrimmer {
 	private static function is_post_creation_tool( string $name ): bool {
 		return self::tool_name_has_suffix( $name, 'create-post' )
 			|| self::tool_name_has_suffix( $name, 'batch-create-posts' );
+	}
+
+	/**
+	 * Preserve bounded query parameters for read-only setup inspections.
+	 *
+	 * @param array<string,mixed> $function_call Serialized function call.
+	 */
+	private static function compact_inspection_call_receipt( array $function_call ): string {
+		$name = self::compact_tool_name( $function_call['name'] ?? 'tool' );
+		if ( ! self::is_compact_inspection_tool( $name ) ) {
+			return '';
+		}
+
+		$args    = self::compact_tool_payload_array( $function_call['args'] ?? array() );
+		$summary = self::compact_receipt_fields(
+			$args,
+			array( 'query', 'search', 'prefix', 'post_type', 'post_status', 'mime_type', 'limit', 'autoload', 'stylesheet', 'area' )
+		);
+
+		return '[inspection call: ' . $name . ' args=' . self::compact_receipt_json( $summary ) . ']';
+	}
+
+	/**
+	 * Preserve bounded, non-content evidence returned by read-only setup inspections.
+	 *
+	 * @param array<string,mixed> $function_response Serialized function response.
+	 */
+	private static function compact_inspection_response_receipt( array $function_response ): string {
+		$name = self::compact_tool_name( $function_response['name'] ?? 'tool' );
+		if ( ! self::is_compact_inspection_tool( $name ) ) {
+			return '';
+		}
+
+		$response = self::compact_tool_payload_array( $function_response['response'] ?? array() );
+		$summary  = self::compact_receipt_fields(
+			$response,
+			array( 'success', 'total', 'count', 'active', 'active_count', 'valid', 'passed', 'query', 'stylesheet', 'code', 'error' )
+		);
+
+		$collection_fields = array(
+			'results'   => array( 'id', 'label', 'name', 'title', 'status', 'post_id', 'success', 'error' ),
+			'posts'     => array( 'id', 'title', 'status', 'post_type' ),
+			'items'     => array( 'id', 'title', 'name', 'mime_type', 'status' ),
+			'themes'    => array( 'slug', 'name', 'active', 'status', 'version' ),
+			'plugins'   => array( 'name', 'active', 'status' ),
+			'menus'     => array( 'id', 'name', 'slug', 'count' ),
+			'options'   => array( 'option_name' ),
+			'templates' => array( 'slug', 'title' ),
+		);
+		foreach ( $collection_fields as $key => $fields ) {
+			if ( ! isset( $response[ $key ] ) || ! is_array( $response[ $key ] ) ) {
+				continue;
+			}
+
+			$entities = array();
+			foreach ( array_slice( $response[ $key ], 0, 10 ) as $entity ) {
+				if ( is_array( $entity ) ) {
+					$entities[] = self::compact_receipt_fields( $entity, $fields );
+				}
+			}
+			$summary[ $key ] = $entities;
+		}
+
+		return '[inspection result: ' . $name . ' summary=' . self::compact_receipt_json( $summary ) . ']';
+	}
+
+	/** Whether a tool is a read-only inspection whose bounded result aids continuation. */
+	private static function is_compact_inspection_tool( string $name ): bool {
+		foreach (
+			array(
+				'ability-search',
+				'get-plugins',
+				'get-themes',
+				'list-block-templates',
+				'list-media',
+				'list-menus',
+				'list-options',
+				'list-posts',
+			) as $suffix
+		) {
+			if ( self::tool_name_has_suffix( $name, $suffix ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Select and bound scalar or scalar-list receipt fields.
+	 *
+	 * @param array<string,mixed> $source         Source payload.
+	 * @param string[]            $allowed_fields Fields safe to retain.
+	 * @return array<string,mixed>
+	 */
+	private static function compact_receipt_fields( array $source, array $allowed_fields ): array {
+		$summary = array();
+		foreach ( $allowed_fields as $field ) {
+			if ( ! array_key_exists( $field, $source ) ) {
+				continue;
+			}
+
+			$value = $source[ $field ];
+			if ( is_scalar( $value ) || null === $value ) {
+				$summary[ $field ] = is_string( $value ) ? self::compact_receipt_value( $value ) : $value;
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$items = array();
+				foreach ( array_slice( $value, 0, 10 ) as $item ) {
+					if ( is_scalar( $item ) || null === $item ) {
+						$items[] = is_string( $item ) ? self::compact_receipt_value( $item ) : $item;
+					}
+				}
+				$summary[ $field ] = $items;
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Encode one bounded receipt summary.
+	 *
+	 * @param array<string,mixed> $summary Safe receipt fields.
+	 */
+	private static function compact_receipt_json( array $summary ): string {
+		$encoded = wp_json_encode( $summary );
+		if ( ! is_string( $encoded ) ) {
+			return '{}';
+		}
+
+		return strlen( $encoded ) > 1200 ? substr( $encoded, 0, 1199 ) . '…' : $encoded;
 	}
 
 	/** Match direct and dispatcher-safe function names by their ability suffix. */

--- a/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Focused tests for deterministic conversation compaction.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ConversationTrimmer;
+use WP_UnitTestCase;
+
+class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
+
+	/** Compacted setup reads retain bounded state without copying raw values. */
+	public function test_compact_serialized_history_preserves_inspection_receipts(): void {
+		$messages = [
+			[
+				'role'  => 'model',
+				'parts' => [
+					[
+						'functionCall' => [
+							'name' => 'wpab__sd-ai-agent__ability-search',
+							'args' => [ 'query' => 'scaffold block theme file write' ],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'wpab__sd-ai-agent__ability-search',
+							'response' => [
+								'query'   => 'scaffold block theme file write',
+								'total'   => 2,
+								'count'   => 2,
+								'results' => [
+									[ 'id' => 'sd-ai-agent/delete-post', 'label' => 'Delete Post', 'description' => 'SECRET_DESCRIPTION' ],
+									[ 'id' => 'sd-ai-agent/list-media', 'label' => 'List Media', 'input_schema' => 'SECRET_SCHEMA' ],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'wpab__sd-ai-agent__list-posts',
+							'response' => [
+								'total' => 2,
+								'posts' => [
+									[ 'id' => 2, 'title' => 'Sample Page', 'status' => 'publish', 'post_type' => 'page', 'permalink' => 'https://private.example/sample/' ],
+									[ 'id' => 1, 'title' => 'Hello world!', 'status' => 'publish', 'post_type' => 'post', 'content' => 'SECRET_CONTENT' ],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'wpab__sd-ai-agent__list-options',
+							'response' => [
+								'total'   => 1,
+								'options' => [
+									[ 'option_name' => 'provider_api_key', 'option_value' => 'SECRET_OPTION_VALUE' ],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = ConversationTrimmer::compact_serialized_history( $messages, 4096, 1024 );
+		$json   = (string) wp_json_encode( $result['messages'] );
+
+		$this->assertStringContainsString( 'Do not repeat an inspection solely', $json );
+		$this->assertStringContainsString( 'scaffold block theme file write', $json );
+		$this->assertStringContainsString( 'delete-post', $json );
+		$this->assertStringContainsString( 'Sample Page', $json );
+		$this->assertStringContainsString( 'provider_api_key', $json );
+		$this->assertStringNotContainsString( 'SECRET_DESCRIPTION', $json );
+		$this->assertStringNotContainsString( 'SECRET_SCHEMA', $json );
+		$this->assertStringNotContainsString( 'SECRET_CONTENT', $json );
+		$this->assertStringNotContainsString( 'SECRET_OPTION_VALUE', $json );
+		$this->assertStringNotContainsString( 'private.example', $json );
+	}
+}


### PR DESCRIPTION
## Summary

- preserve bounded query and result receipts for read-only setup inspections when provider history is compacted
- tell the model to continue the current task and not repeat completed inspections solely because raw payloads were omitted
- retain only allowlisted scalar metadata and entity identifiers; option values, content, URLs, schemas, and arbitrary payload fields remain omitted

## Problem

A fresh Setup Assistant onboarding run entered continued provider-context compaction after an automatic large-request retry. The compact context retained tool names but replaced every inspection result with `tool result omitted`. The model then repeated the same post, option, plugin, theme, menu, and media inspections for hundreds of history entries before eventually reaching a mutation.

## Implementation

- `includes/Core/ConversationTrimmer.php`: emit bounded receipts for ability search, post, option, plugin, theme, menu, media, and block-template inspections
- `tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php`: verify useful state survives while sensitive or bulky fields remain excluded

## Worker self-verification
- PHPUnit: Tests: 4250, Assertions: 19505, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol
