### PR TITLE
fix: preserve callable schemas after compaction

### DIFF
--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -635,7 +635,7 @@ class ConversationTrimmer {
 	private static function compact_schema_shape( array $schema, int $depth = 0 ): array {
 		$shape = self::compact_receipt_fields(
 			$schema,
-			array( 'type', 'format', 'required', 'enum', 'minimum', 'maximum', 'minItems', 'maxItems' )
+			array( 'type', 'format', 'enum', 'minimum', 'maximum', 'minItems', 'maxItems' )
 		);
 
 		if ( isset( $schema['additionalProperties'] ) && is_bool( $schema['additionalProperties'] ) ) {
@@ -648,15 +648,33 @@ class ConversationTrimmer {
 
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 			$properties = array();
+
+			$retained_property_names = array();
 			foreach ( array_slice( $schema['properties'], 0, 12, true ) as $property_name => $property_schema ) {
 				if ( ! is_string( $property_name ) || ! is_array( $property_schema ) ) {
 					continue;
 				}
 
-				$properties[ self::compact_receipt_value( $property_name ) ] = self::compact_schema_shape( $property_schema, $depth + 1 );
+				$compacted_property_name = self::compact_receipt_value( $property_name );
+
+				$properties[ $compacted_property_name ] = self::compact_schema_shape( $property_schema, $depth + 1 );
+
+				$retained_property_names[ $property_name ] = $compacted_property_name;
 			}
 			if ( ! empty( $properties ) ) {
 				$shape['properties'] = $properties;
+			}
+
+			if ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) {
+				$required = array();
+				foreach ( $schema['required'] as $required_property_name ) {
+					if ( is_string( $required_property_name ) && isset( $retained_property_names[ $required_property_name ] ) ) {
+						$required[] = $retained_property_names[ $required_property_name ];
+					}
+				}
+				if ( ! empty( $required ) ) {
+					$shape['required'] = $required;
+				}
 			}
 		}
 

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -43,6 +43,9 @@ class ConversationTrimmer {
 	/** Maximum characters copied from any single message into compact context. */
 	private const COMPACT_MAX_MESSAGE_CHARS = 2000;
 
+	/** Maximum JSON characters retained for callable ability-search schemas. */
+	private const COMPACT_MAX_ABILITY_SCHEMA_RECEIPT_CHARS = 1600;
+
 	/** Marker inserted when older turns are removed by a request-size budget. */
 	private const BUDGET_MARKER_TEXT = '[Earlier conversation turns were compacted to stay within the request safety budget.]';
 
@@ -313,6 +316,7 @@ class ConversationTrimmer {
 			"Source messages: {$source_count}; retained excerpts: {$retained_count}; omitted messages: {$omitted_count}.",
 			'Use this compact context to continue the current task. File attachments, inline image bytes, and raw tool payloads were omitted.',
 			'Bounded inspection receipts are evidence of completed reads. Do not repeat an inspection solely because its raw result was omitted.',
+			'Ability-search receipts retain callable input-schema shapes. Use ability-call directly with those schemas instead of searching for the same ability again.',
 		);
 
 		return implode( "\n", $header ) . "\n\n" . implode( "\n\n", $lines );
@@ -529,7 +533,11 @@ class ConversationTrimmer {
 		}
 
 		$response = self::compact_tool_payload_array( $function_response['response'] ?? array() );
-		$summary  = self::compact_receipt_fields(
+		if ( self::tool_name_has_suffix( $name, 'ability-search' ) ) {
+			return self::compact_ability_search_response_receipt( $name, $response );
+		}
+
+		$summary = self::compact_receipt_fields(
 			$response,
 			array( 'success', 'total', 'count', 'active', 'active_count', 'valid', 'passed', 'query', 'stylesheet', 'code', 'error' )
 		);
@@ -559,6 +567,104 @@ class ConversationTrimmer {
 		}
 
 		return '[inspection result: ' . $name . ' summary=' . self::compact_receipt_json( $summary ) . ']';
+	}
+
+	/**
+	 * Preserve enough of ability-search results to call selected abilities.
+	 *
+	 * Continued provider compaction runs before every later model call. Omitting
+	 * input schemas here means a newly fetched Tier-2 ability becomes unusable on
+	 * the very next turn, causing the model to search again or fall back to the
+	 * Tier-1 site-inspection tools. Retain only the schema's structural shape;
+	 * descriptions, defaults, examples, and output schemas remain omitted.
+	 *
+	 * @param string              $name     Compacted ability-search tool name.
+	 * @param array<string,mixed> $response Ability-search response payload.
+	 */
+	private static function compact_ability_search_response_receipt( string $name, array $response ): string {
+		$query   = isset( $response['query'] ) && is_scalar( $response['query'] )
+			? self::compact_receipt_value( (string) $response['query'] )
+			: '';
+		$results = isset( $response['results'] ) && is_array( $response['results'] )
+			? array_values( $response['results'] )
+			: array();
+		$kept    = array();
+
+		foreach ( array_slice( $results, 0, 10 ) as $result ) {
+			if ( ! is_array( $result ) ) {
+				continue;
+			}
+
+			$ability = self::compact_receipt_fields( $result, array( 'id', 'label' ) );
+			$schema  = self::compact_tool_payload_array( $result['input_schema'] ?? array() );
+			if ( ! empty( $schema ) ) {
+				$ability['input_schema'] = self::compact_schema_shape( $schema );
+			}
+
+			$candidate = array_merge( $kept, array( $ability ) );
+			$payload   = array(
+				'query'     => $query,
+				'abilities' => $candidate,
+				'omitted'   => max( 0, count( $results ) - count( $candidate ) ),
+			);
+			$encoded   = wp_json_encode( $payload );
+			if ( ! is_string( $encoded ) || strlen( $encoded ) > self::COMPACT_MAX_ABILITY_SCHEMA_RECEIPT_CHARS ) {
+				break;
+			}
+
+			$kept = $candidate;
+		}
+
+		$payload = array(
+			'query'     => $query,
+			'abilities' => $kept,
+			'omitted'   => max( 0, count( $results ) - count( $kept ) ),
+		);
+		$encoded = wp_json_encode( $payload );
+
+		return '[inspection result: ' . $name . ' callable_schemas=' . ( is_string( $encoded ) ? $encoded : '{}' ) . ']';
+	}
+
+	/**
+	 * Build a bounded schema shape without descriptions or example/default data.
+	 *
+	 * @param array<string,mixed> $schema Input schema.
+	 * @param int                 $depth  Current nested-schema depth.
+	 * @return array<string,mixed>
+	 */
+	private static function compact_schema_shape( array $schema, int $depth = 0 ): array {
+		$shape = self::compact_receipt_fields(
+			$schema,
+			array( 'type', 'format', 'required', 'enum', 'minimum', 'maximum', 'minItems', 'maxItems' )
+		);
+
+		if ( isset( $schema['additionalProperties'] ) && is_bool( $schema['additionalProperties'] ) ) {
+			$shape['additionalProperties'] = $schema['additionalProperties'];
+		}
+
+		if ( $depth >= 2 ) {
+			return $shape;
+		}
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			$properties = array();
+			foreach ( array_slice( $schema['properties'], 0, 12, true ) as $property_name => $property_schema ) {
+				if ( ! is_string( $property_name ) || ! is_array( $property_schema ) ) {
+					continue;
+				}
+
+				$properties[ self::compact_receipt_value( $property_name ) ] = self::compact_schema_shape( $property_schema, $depth + 1 );
+			}
+			if ( ! empty( $properties ) ) {
+				$shape['properties'] = $properties;
+			}
+		}
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$shape['items'] = self::compact_schema_shape( $schema['items'], $depth + 1 );
+		}
+
+		return $shape;
 	}
 
 	/** Whether a tool is a read-only inspection whose bounded result aids continuation. */

--- a/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
@@ -16,7 +16,7 @@ use WP_UnitTestCase;
 
 class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 
-	/** Compacted setup reads retain bounded state without copying raw values. */
+	/** Compacted setup reads retain bounded state and callable ability schemas. */
 	public function test_compact_serialized_history_preserves_inspection_receipts(): void {
 		$messages = [
 			[
@@ -41,7 +41,25 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 								'total'   => 2,
 								'count'   => 2,
 								'results' => [
-									[ 'id' => 'sd-ai-agent/delete-post', 'label' => 'Delete Post', 'description' => 'SECRET_DESCRIPTION' ],
+									[
+										'id'           => 'sd-ai-agent/delete-post',
+										'label'        => 'Delete Post',
+										'description'  => 'SECRET_DESCRIPTION',
+										'input_schema' => [
+											'type'       => 'object',
+											'required'   => [ 'post_id' ],
+											'properties' => [
+												'post_id' => [
+													'type'        => 'integer',
+													'description' => 'SECRET_SCHEMA_DESCRIPTION',
+												],
+												'force'   => [
+													'type'    => 'boolean',
+													'default' => 'SECRET_SCHEMA_DEFAULT',
+												],
+											],
+										],
+									],
 									[ 'id' => 'sd-ai-agent/list-media', 'label' => 'List Media', 'input_schema' => 'SECRET_SCHEMA' ],
 								],
 							],
@@ -88,12 +106,20 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 		$json   = (string) wp_json_encode( $result['messages'] );
 
 		$this->assertStringContainsString( 'Do not repeat an inspection solely', $json );
+		$this->assertStringContainsString( 'Use ability-call directly', $json );
 		$this->assertStringContainsString( 'scaffold block theme file write', $json );
 		$this->assertStringContainsString( 'delete-post', $json );
+		$this->assertStringContainsString( 'input_schema', $json );
+		$this->assertStringContainsString( 'post_id', $json );
+		$this->assertStringContainsString( 'integer', $json );
+		$this->assertStringContainsString( 'force', $json );
+		$this->assertStringContainsString( 'boolean', $json );
 		$this->assertStringContainsString( 'Sample Page', $json );
 		$this->assertStringContainsString( 'provider_api_key', $json );
 		$this->assertStringNotContainsString( 'SECRET_DESCRIPTION', $json );
 		$this->assertStringNotContainsString( 'SECRET_SCHEMA', $json );
+		$this->assertStringNotContainsString( 'SECRET_SCHEMA_DESCRIPTION', $json );
+		$this->assertStringNotContainsString( 'SECRET_SCHEMA_DEFAULT', $json );
 		$this->assertStringNotContainsString( 'SECRET_CONTENT', $json );
 		$this->assertStringNotContainsString( 'SECRET_OPTION_VALUE', $json );
 		$this->assertStringNotContainsString( 'private.example', $json );

--- a/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
@@ -18,6 +18,20 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 
 	/** Compacted setup reads retain bounded state and callable ability schemas. */
 	public function test_compact_serialized_history_preserves_inspection_receipts(): void {
+		$schema_properties = [
+			'post_id' => [
+				'type'        => 'integer',
+				'description' => 'SECRET_SCHEMA_DESCRIPTION',
+			],
+			'force'   => [
+				'type'    => 'boolean',
+				'default' => 'SECRET_SCHEMA_DEFAULT',
+			],
+		];
+		for ( $index = 1; $index <= 10; ++$index ) {
+			$schema_properties[ 'field_' . $index ] = [ 'type' => 'string' ];
+		}
+
 		$messages = [
 			[
 				'role'  => 'model',
@@ -47,17 +61,8 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 										'description'  => 'SECRET_DESCRIPTION',
 										'input_schema' => [
 											'type'       => 'object',
-											'required'   => [ 'post_id' ],
-											'properties' => [
-												'post_id' => [
-													'type'        => 'integer',
-													'description' => 'SECRET_SCHEMA_DESCRIPTION',
-												],
-												'force'   => [
-													'type'    => 'boolean',
-													'default' => 'SECRET_SCHEMA_DEFAULT',
-												],
-											],
+											'required'   => array_keys( $schema_properties ),
+											'properties' => $schema_properties,
 										],
 									],
 									[ 'id' => 'sd-ai-agent/list-media', 'label' => 'List Media', 'input_schema' => 'SECRET_SCHEMA' ],
@@ -104,6 +109,7 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 
 		$result = ConversationTrimmer::compact_serialized_history( $messages, 4096, 1024 );
 		$json   = (string) wp_json_encode( $result['messages'] );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
 
 		$this->assertStringContainsString( 'Do not repeat an inspection solely', $json );
 		$this->assertStringContainsString( 'Use ability-call directly', $json );
@@ -114,6 +120,7 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'integer', $json );
 		$this->assertStringContainsString( 'force', $json );
 		$this->assertStringContainsString( 'boolean', $json );
+		$this->assertStringContainsString( '"required":["post_id","force","field_1","field_2","field_3","field_4","field_5","field_6","field_7","field_8","field_9","field_10"]', $text );
 		$this->assertStringContainsString( 'Sample Page', $json );
 		$this->assertStringContainsString( 'provider_api_key', $json );
 		$this->assertStringNotContainsString( 'SECRET_DESCRIPTION', $json );


### PR DESCRIPTION
## Summary

- retain bounded structural `input_schema` shapes in compacted `ability-search` receipts
- direct the model to use preserved schemas with `ability-call` instead of repeating discovery
- omit descriptions, defaults, examples, output schemas, arbitrary content, and excess results

## Problem and evidence

Provider-context compaction already preserves bounded read receipts, but it reduced `ability-search` results to IDs and labels. The agent guidance requires reading a selected ability's `input_schema` before calling it, so the next compacted turn could reacquire the same schema or fall back to Tier-1 inspection tools.

The implementation is in `includes/Core/ConversationTrimmer.php`. Focused privacy and continuation assertions are in `tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php`.

## Verification

- `composer lint`
- `php bin/run-wp-phpunit.php` — 4,250 tests, 19,514 assertions, 137 skipped, 4 incomplete
- focused compaction regression — 1 test, 18 assertions

## Safety

The receipt has a 1,600-character JSON budget, retains at most ten ability results and twelve properties per schema level, and limits nested schema depth. Sensitive descriptions, defaults, examples, output schemas, and unrelated tool payloads are not copied.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compacted conversation context now retains bounded input-schema details for callable abilities.
  - Ability-search results include clearer queries, ability identifiers, labels, and safely limited schema structures.
  - Retained schemas can be used directly when making ability calls.

- **Bug Fixes**
  - Sensitive schema descriptions and default values continue to be redacted from compacted context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->