### PR TITLE
GH#2596: require client ability E2E coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,25 +28,26 @@ jobs:
     # limit was exceeded after the per-test timeout increased from 60 s to
     # 90 s in playwright.config.js — setup + test time could exceed 60 min.
     timeout-minutes: 90
-    # WP trunk may fail due to PSR namespace conflicts between our compat
-    # layer and core's native AI Client SDK.
-    continue-on-error: true
+    # This required WordPress 7.0 environment provides the browser Abilities
+    # API that client-abilities.spec.js must exercise. Do not allow failures to
+    # pass as advisory coverage.
+    continue-on-error: false
 
     strategy:
       fail-fast: false
       matrix:
-        # Plugin requires WP 7.0+; only trunk (pre-release 7.x) is relevant.
-        # WP 6.9 was removed — the plugin won't activate on it.
-        wp: ['trunk']
+        # Pin the required browser-ability coverage to WordPress 7.0. The
+        # moving trunk branch does not reliably load @wordpress/core-abilities.
+        wp: ['7.0']
         # 3 shards split 13 spec files into ~4-5 files each. With the 90-min
         # job timeout, each shard has ample headroom even with 2 retries.
         shard: [1, 2, 3]
         include:
-          - wp: 'trunk'
+          - wp: '7.0'
             wp_env_port: '8890'
-            wp_env_override: '{"core":"WordPress/WordPress#master"}'
+            wp_env_override: '{"core":"WordPress/WordPress#7.0"}'
             # 1 worker: shard 1 still showed login and SPA-render timeouts
-            # with 2 workers on GitHub-hosted runners under WP trunk load.
+            # with 2 workers on GitHub-hosted runners under WordPress 7.0 load.
             playwright_workers: '1'
 
     steps:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#7.0-branch",
+	"core": "WordPress/WordPress#7.0",
 	"phpVersion": "8.2",
 	"port": 8890,
 	"testsPort": 8893,

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -17,7 +17,7 @@
  *   3. executeAbility navigate-to actually navigates
  *   4. executeAbility insert-block inserts on editor screen
  *   5. insert-block no-ops on non-editor screen
- *   6. snapshotDescriptors returns the expected list
+ *   6. snapshotDescriptors includes the expected descriptors
  *   7. no relevant console errors on any screen
  *
  * Run: pnpm run test:e2e:playwright -- --grep client-abilities
@@ -71,10 +71,8 @@ async function goToDashboard( page ) {
  * false result reliably means the API is not available in this environment
  * — not that it hasn't loaded yet.
  *
- * Used by test.skip() to gracefully degrade when the CI environment runs a
- * WordPress version where @wordpress/core-abilities is not loaded (e.g.
- * the WP 7.0-branch build hasn't shipped the abilities script module yet,
- * or the module is registered but not enqueued by core).
+ * Required coverage uses WordPress 7.0, which loads @wordpress/core-abilities.
+ * Explicitly optional compatibility environments may opt into graceful skips.
  *
  * @param {import('@playwright/test').Page} page
  * @return {Promise<boolean>} True when all required wp.abilities methods exist.
@@ -92,20 +90,34 @@ async function isAbilitiesApiAvailable( page ) {
 }
 
 /**
- * Skip the current test if the abilities API is not available.
+ * Require the abilities API for the current test.
  *
- * Call this at the top of any test body that depends on wp.abilities.
+ * Call this at the top of any test body that depends on wp.abilities. The
+ * default E2E project is a required WordPress 7.0 coverage environment, so an
+ * unavailable API must fail with an actionable error instead of silently
+ * skipping the test. Compatibility jobs may opt into a graceful skip by
+ * setting PLAYWRIGHT_ALLOW_MISSING_ABILITIES_API=1 explicitly.
  * It must run AFTER goToDashboard() or equivalent page navigation so the
  * scripts have loaded.
  *
  * @param {import('@playwright/test').Page} page
  */
-async function skipIfNoAbilitiesApi( page ) {
+async function requireAbilitiesApi( page ) {
 	const available = await isAbilitiesApiAvailable( page );
-	test.skip(
-		! available,
-		'wp.abilities API not available — @wordpress/core-abilities script module not loaded in this WP build'
-	);
+	if (
+		! available &&
+		process.env.PLAYWRIGHT_ALLOW_MISSING_ABILITIES_API === '1'
+	) {
+		test.skip(
+			true,
+			'wp.abilities API not available in this explicitly optional compatibility environment'
+		);
+	}
+
+	expect(
+		available,
+		'wp.abilities API is required for client-ability E2E coverage. Use a WordPress 7.0 runtime that loads @wordpress/core-abilities, or set PLAYWRIGHT_ALLOW_MISSING_ABILITIES_API=1 only for an explicitly optional compatibility environment.'
+	).toBe( true );
 }
 
 /**
@@ -258,7 +270,7 @@ test.describe( 'client-abilities — category registration', () => {
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
 	test( 'registers on dashboard — category has expected label and description', async ( {
@@ -300,7 +312,7 @@ test.describe( 'client-abilities — ability registration', () => {
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
 	test( 'required client abilities expose valid schemas and readonly annotations', async ( {
@@ -404,7 +416,7 @@ test.describe( 'client-abilities — public schema validation', () => {
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
 	test( 'executeAbility reaches get-editor-selection with empty input', async ( {
@@ -440,7 +452,7 @@ test.describe( 'client-abilities — navigate-to execution', () => {
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
 	test( 'executeAbility navigate-to actually navigates to plugins.php', async ( {
@@ -516,7 +528,7 @@ test.describe( 'client-abilities — insert-block on editor screen', () => {
 		// Check abilities API BEFORE the slow editor wait. On CI the block
 		// editor can take 45-60 s to initialise — skipping early avoids a
 		// 60 s timeout when the abilities API isn't available at all.
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 
 		// Wait for the block editor to mount — the editor canvas is the signal.
 		// 60 s accommodates slow CI runners where the block editor can take
@@ -579,7 +591,7 @@ test.describe( 'client-abilities — nested block insertion', () => {
 		page,
 	} ) => {
 		await createDraftAndOpenEditor( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 		await waitForAbilitiesRegistered( page );
 
 		const inserted = await page.evaluate( async () => {
@@ -677,7 +689,7 @@ test.describe( 'client-abilities — editor history', () => {
 		page,
 	} ) => {
 		await createDraftAndOpenEditor( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 		await waitForAbilitiesRegistered( page );
 
 		const result = await page.evaluate( async () => {
@@ -912,7 +924,7 @@ test.describe( 'client-abilities — insert-block no-op on non-editor screen', (
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
 	test( 'insert-block returns inserted:false on dashboard without throwing', async ( {
@@ -956,10 +968,10 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 	test.beforeEach( async ( { page } ) => {
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 	} );
 
-	test( 'snapshotDescriptors returns 2 descriptors with expected shape', async ( {
+	test( 'snapshotDescriptors includes required descriptors with expected shape', async ( {
 		page,
 	} ) => {
 		await waitForAbilitiesRegistered( page );
@@ -997,8 +1009,25 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 			}
 		} );
 
-		// Must have exactly 2 descriptors.
-		expect( descriptors ).toHaveLength( 2 );
+		// Additional client abilities may be registered without breaking this
+		// coverage, but each expected editor ability must remain discoverable.
+		const names = descriptors.map( ( descriptor ) => descriptor.name );
+		for ( const name of [
+			'sd-ai-agent-js/navigate-to',
+			'sd-ai-agent-js/refresh-page',
+			'sd-ai-agent-js/get-editor-selection',
+			'sd-ai-agent-js/insert-block',
+			'sd-ai-agent-js/get-editor-capabilities',
+			'sd-ai-agent-js/capture-screenshot',
+			'sd-ai-agent-js/screenshot-url',
+			'sd-ai-agent-js/replace-editor-selection',
+			'sd-ai-agent-js/insert-block-markup',
+			'sd-ai-agent-js/change-editor-history',
+			'sd-ai-agent-js/get-canonical-block-examples',
+			'sd-ai-agent-js/validate-page-quality',
+		] ) {
+			expect( names ).toContain( name );
+		}
 
 		// Each descriptor must have the expected shape.
 		for ( const descriptor of descriptors ) {
@@ -1014,11 +1043,6 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 			expect( descriptor.label.length ).toBeGreaterThan( 0 );
 			expect( descriptor.description.length ).toBeGreaterThan( 0 );
 		}
-
-		// Verify the two expected ability names are present.
-		const names = descriptors.map( ( d ) => d.name );
-		expect( names ).toContain( 'sd-ai-agent-js/navigate-to' );
-		expect( names ).toContain( 'sd-ai-agent-js/insert-block' );
 	} );
 } );
 
@@ -1061,7 +1085,7 @@ test.describe( 'client-abilities — no relevant console errors', () => {
 
 		await loginToWordPress( page );
 		await goToDashboard( page );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 		await waitForAbilitiesRegistered( page );
 
 		assertNoForbiddenErrors(
@@ -1079,7 +1103,7 @@ test.describe( 'client-abilities — no relevant console errors', () => {
 		await page
 			.locator( '.sdaa-unified-admin' )
 			.waitFor( { state: 'visible', timeout: 45_000 } );
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 		await waitForAbilitiesRegistered( page );
 
 		assertNoForbiddenErrors(
@@ -1098,7 +1122,7 @@ test.describe( 'client-abilities — no relevant console errors', () => {
 		// Check abilities API BEFORE the slow editor wait. On CI the block
 		// editor can take 45-60 s to initialise — skipping early avoids a
 		// 60 s timeout when the abilities API isn't available at all.
-		await skipIfNoAbilitiesApi( page );
+		await requireAbilitiesApi( page );
 
 		// The block editor is notoriously slow to initialise on CI runners,
 		// especially on WP trunk where Gutenberg loads additional script


### PR DESCRIPTION
## Summary

Require browser Abilities API coverage on pinned WordPress 7.0 and replace stale descriptor count assertions.

## Files Changed

.github/workflows/e2e.yml, .wp-env.json, tests/e2e/client-abilities.spec.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Pending local Playwright verification against the pinned WordPress 7.0 environment.

Resolves #2596


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 6m and 105,523 tokens on this as a headless worker.