### PR TITLE
fix: make PHPUnit cache provisioning atomic (#2590)

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,178 +1,353 @@
 #!/usr/bin/env bash
 
-if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+if [ "$#" -lt 3 ]; then
+	printf 'usage: %s <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]\n' "$0" >&2
 	exit 1
 fi
 
-DB_NAME=$1
-DB_USER=$2
-DB_PASS=$3
-DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
-SKIP_DB_CREATE=${6-false}
+set -euo pipefail
 
-TMPDIR=${TMPDIR-/tmp}
-TMPDIR=$(echo "$TMPDIR" | sed -e "s/\/$//")
-WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+DB_NAME="$1"
+DB_USER="$2"
+DB_PASS="$3"
+DB_HOST="${4:-localhost}"
+WP_VERSION="${5:-latest}"
+SKIP_DB_CREATE="${6:-false}"
+
+TMPDIR="${TMPDIR:-/tmp}"
+TMPDIR="${TMPDIR%/}"
+TMPDIR="${TMPDIR:-/tmp}"
+WP_TESTS_DIR="${WP_TESTS_DIR:-$TMPDIR/wordpress-tests-lib}"
+WP_CORE_DIR="${WP_CORE_DIR:-$TMPDIR/wordpress}"
+CACHE_ROOT="${WP_PHPUNIT_CACHE_DIR:-$(dirname "$WP_CORE_DIR")}"
+VERSION_KEY="${WP_VERSION//[^[:alnum:]._-]/-}"
+VERSION_KEY="${VERSION_KEY:-trunk}"
+LOCK_DIR="$CACHE_ROOT/.wordpress-phpunit-${VERSION_KEY}.lock"
+LOCK_ACQUIRED=false
+WORK_DIR=''
+CORE_STAGING=''
+TESTS_STAGING=''
+WP_TESTS_TAG=''
+ARCHIVE_NAME=''
 
 download() {
-	if [ "$(which curl)" ]; then
-		curl -s "$1" >"$2"
-	elif [ "$(which wget)" ]; then
-		wget -nv -O "$2" "$1"
-	fi
-}
+	local url="$1"
+	local destination="$2"
 
-if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
-	WP_BRANCH=${WP_VERSION%\-*}
-	WP_TESTS_TAG="branches/$WP_BRANCH"
-
-elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
-	WP_TESTS_TAG="branches/$WP_VERSION"
-elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
-		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-		WP_TESTS_TAG="tags/${WP_VERSION%??}"
-	else
-		WP_TESTS_TAG="tags/$WP_VERSION"
-	fi
-elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-	WP_TESTS_TAG="trunk"
-else
-	# http serves a hierarchical list of all available tags
-	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//' | head -1)
-	if [[ -z "$LATEST_VERSION" ]]; then
-		echo "Latest WordPress version could not be found"
-		exit 1
-	fi
-	WP_TESTS_TAG="tags/$LATEST_VERSION"
-fi
-set -e
-
-install_wp() {
-
-	if [ -d "$WP_CORE_DIR" ]; then
-		return
-	fi
-
-	mkdir -p "$WP_CORE_DIR"
-
-	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p "$TMPDIR/wordpress-trunk"
-		rm -rf "$TMPDIR/wordpress-trunk/"*
-		svn export --quiet https://core.svn.wordpress.org/trunk "$TMPDIR/wordpress-trunk/wordpress"
-		mv "$TMPDIR/wordpress-trunk/wordpress/"* "$WP_CORE_DIR"
-	else
-		if [ "$WP_VERSION" == 'latest' ]; then
-			local ARCHIVE_NAME='latest'
-		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
-			# https serves a hierarchical list of all available tags
-			download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR/wp-latest.json"
-			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
-				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-				LATEST_VERSION=${WP_VERSION%??}
-			else
-				# otherwise, scan the releases and get the most up to date minor version of the major release
-				local VERSION_ESCAPED
-				VERSION_ESCAPED="${WP_VERSION//./'\\.'}"
-				LATEST_VERSION=$(grep -o '"version":"'"$VERSION_ESCAPED"'[^"]*' "$TMPDIR/wp-latest.json" | sed 's/"version":"//' | head -1)
-			fi
-			if [[ -z "$LATEST_VERSION" ]]; then
-				local ARCHIVE_NAME="wordpress-$WP_VERSION"
-			else
-				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
-			fi
-		else
-			local ARCHIVE_NAME="wordpress-$WP_VERSION"
-		fi
-		download "https://wordpress.org/${ARCHIVE_NAME}.tar.gz" "$TMPDIR/wordpress.tar.gz"
-		tar --strip-components=1 -zxmf "$TMPDIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
-	fi
-
-	download https://raw.githubusercontent.com/marber/wp-config-github-actions/main/wp-config-ci.php "$WP_CORE_DIR/wp-config.php"
-}
-
-install_test_suite() {
-	# portable in-place argument for both GNU sed and Mac OSX sed
-	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i.bak'
-	else
-		local ioption='-i'
-	fi
-
-	# set up testing suite if it doesn't yet exist
-	if [ ! -d "$WP_TESTS_DIR" ]; then
-		# set up testing suite
-		mkdir -p "$WP_TESTS_DIR"
-		rm -rf "$WP_TESTS_DIR/{includes,data}"
-		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
-		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/" "$WP_TESTS_DIR/data"
-	fi
-
-	if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]; then
-		download "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config.php"
-		# remove all trailing forward slashes
-		while [[ "$WP_CORE_DIR" == */ ]]; do WP_CORE_DIR="${WP_CORE_DIR%/}"; done
-		sed "$ioption" "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR/wp-tests-config.php"
-		sed "$ioption" "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR/wp-tests-config.php"
-		sed "$ioption" "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR/wp-tests-config.php"
-		sed "$ioption" "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR/wp-tests-config.php"
-		sed "$ioption" "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR/wp-tests-config.php"
-		sed "$ioption" "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR/wp-tests-config.php"
-	fi
-
-}
-
-recreate_db() {
-	shopt -s nocasematch
-	if [[ $1 =~ ^(y|yes)$ ]]; then
-		mysqladmin drop "$DB_NAME" -f --user="$DB_USER" --password="$DB_PASS""$EXTRA"
-		create_db
-		echo "Recreated the database ($DB_NAME)."
-	else
-		echo "Leaving the existing database ($DB_NAME) in place."
-	fi
-	shopt -u nocasematch
-}
-
-create_db() {
-	mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS""$EXTRA"
-}
-
-install_db() {
-
-	if [ "${SKIP_DB_CREATE}" = "true" ]; then
+	if command -v curl >/dev/null 2>&1; then
+		curl --fail --location --silent --show-error "$url" --output "$destination"
 		return 0
 	fi
 
-	# parse DB_HOST for port or socket references
-	local DB_HOSTNAME DB_SOCK_OR_PORT
-	IFS=':' read -r DB_HOSTNAME DB_SOCK_OR_PORT <<<"$DB_HOST"
-	local EXTRA=""
+	if command -v wget >/dev/null 2>&1; then
+		wget --quiet --output-document="$destination" "$url"
+		return 0
+	fi
 
-	if [ -n "$DB_HOSTNAME" ]; then
-		if echo "$DB_SOCK_OR_PORT" | grep -qe '^[0-9]\{1,\}$'; then
-			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif [ -n "$DB_SOCK_OR_PORT" ]; then
-			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif [ -n "$DB_HOSTNAME" ]; then
-			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+	printf 'Neither curl nor wget is available for downloading WordPress test files.\n' >&2
+	return 1
+}
+
+cleanup() {
+	local exit_code="$?"
+
+	if [ -n "$CORE_STAGING" ] && [ -d "$CORE_STAGING" ]; then
+		rm -rf "$CORE_STAGING"
+	fi
+
+	if [ -n "$TESTS_STAGING" ] && [ -d "$TESTS_STAGING" ]; then
+		rm -rf "$TESTS_STAGING"
+	fi
+
+	if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+		rm -rf "$WORK_DIR"
+	fi
+
+	if [ "$LOCK_ACQUIRED" = true ] && [ -d "$LOCK_DIR" ]; then
+		rm -rf "$LOCK_DIR"
+	fi
+
+	exit "$exit_code"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+acquire_lock() {
+	local owner_pid=''
+
+	while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+		if [ -f "$LOCK_DIR/pid" ]; then
+			read -r owner_pid <"$LOCK_DIR/pid" || owner_pid=''
+			if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+				printf 'Removing stale PHPUnit cache lock owned by process %s.\n' "$owner_pid"
+				rm -rf "$LOCK_DIR"
+				continue
+			fi
+		fi
+
+		printf 'Waiting for another process to provision WordPress PHPUnit cache %s.\n' "$VERSION_KEY"
+		sleep 1
+	done
+
+	printf '%s\n' "$$" >"$LOCK_DIR/pid"
+	LOCK_ACQUIRED=true
+	return 0
+}
+
+is_valid_core() {
+	local directory="$1"
+
+	[ -f "$directory/wp-settings.php" ]
+	return $?
+}
+
+is_valid_test_suite() {
+	local directory="$1"
+
+	[ -f "$directory/includes/functions.php" ]
+	return $?
+}
+
+create_staging_dir() {
+	local variable_name="$1"
+	local target_dir="$2"
+	local parent_dir=''
+	local base_name=''
+
+	parent_dir="$(dirname "$target_dir")"
+	base_name="$(basename "$target_dir")"
+	mkdir -p "$parent_dir"
+	printf -v "$variable_name" '%s' "$(mktemp -d "$parent_dir/.${base_name}.staging.XXXXXX")"
+	return 0
+}
+
+promote_staging_dir() {
+	local variable_name="$1"
+	local target_dir="$2"
+	local staging_dir="${!variable_name}"
+	local backup_dir="${target_dir}.previous.$$"
+
+	if [ -e "$target_dir" ]; then
+		rm -rf "$backup_dir"
+		mv "$target_dir" "$backup_dir"
+	fi
+
+	if ! mv "$staging_dir" "$target_dir"; then
+		if [ -e "$backup_dir" ]; then
+			mv "$backup_dir" "$target_dir"
+		fi
+		return 1
+	fi
+
+	printf -v "$variable_name" '%s' ''
+	rm -rf "$backup_dir"
+	return 0
+}
+
+set_wp_tests_tag() {
+	local latest_file="$WORK_DIR/wp-latest.json"
+	local latest_version=''
+
+	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+		WP_TESTS_TAG="branches/${WP_VERSION%-*}"
+		return 0
+	fi
+
+	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+		WP_TESTS_TAG="branches/$WP_VERSION"
+		return 0
+	fi
+
+	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+			WP_TESTS_TAG="tags/${WP_VERSION%??}"
+		else
+			WP_TESTS_TAG="tags/$WP_VERSION"
+		fi
+		return 0
+	fi
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		WP_TESTS_TAG='trunk'
+		return 0
+	fi
+
+	download 'https://api.wordpress.org/core/version-check/1.7/' "$latest_file"
+	latest_version="$(grep -o '"version":"[^"]*' "$latest_file" | sed 's/"version":"//' | head -1)"
+	if [ -z "$latest_version" ]; then
+		printf 'Latest WordPress version could not be found.\n' >&2
+		return 1
+	fi
+
+	WP_TESTS_TAG="tags/$latest_version"
+	return 0
+}
+
+resolve_archive_name() {
+	local latest_file="$WORK_DIR/wp-latest.json"
+	local latest_version=''
+	local version_escaped=''
+
+	if [ "$WP_VERSION" = 'latest' ]; then
+		ARCHIVE_NAME='latest'
+		return 0
+	fi
+
+	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+		download 'https://api.wordpress.org/core/version-check/1.7/' "$latest_file"
+		if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+			latest_version="${WP_VERSION%??}"
+		else
+			version_escaped="${WP_VERSION//./\\.}"
+			latest_version="$(grep -o '"version":"'"$version_escaped"'[^\"]*' "$latest_file" | sed 's/"version":"//' | head -1)"
+		fi
+
+		if [ -n "$latest_version" ]; then
+			ARCHIVE_NAME="wordpress-$latest_version"
+		else
+			ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		return 0
+	fi
+
+	ARCHIVE_NAME="wordpress-$WP_VERSION"
+	return 0
+}
+
+write_test_config() {
+	local tests_dir="$1"
+	local core_dir="$WP_CORE_DIR"
+	local ioption=''
+
+	if [ -f "$tests_dir/wp-tests-config.php" ]; then
+		return 0
+	fi
+
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		ioption='-i.bak'
+	else
+		ioption='-i'
+	fi
+
+	download "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php" "$tests_dir/wp-tests-config.php"
+	while [[ $core_dir == */ ]]; do
+		core_dir="${core_dir%/}"
+	done
+	sed "$ioption" "s:dirname( __FILE__ ) . '/src/':'$core_dir/':" "$tests_dir/wp-tests-config.php"
+	sed "$ioption" "s:__DIR__ . '/src/':'$core_dir/':" "$tests_dir/wp-tests-config.php"
+	sed "$ioption" "s/youremptytestdbnamehere/$DB_NAME/" "$tests_dir/wp-tests-config.php"
+	sed "$ioption" "s/yourusernamehere/$DB_USER/" "$tests_dir/wp-tests-config.php"
+	sed "$ioption" "s/yourpasswordhere/$DB_PASS/" "$tests_dir/wp-tests-config.php"
+	sed "$ioption" "s|localhost|${DB_HOST}|" "$tests_dir/wp-tests-config.php"
+	return 0
+}
+
+install_wp() {
+	local archive_file=''
+
+	if is_valid_core "$WP_CORE_DIR"; then
+		return 0
+	fi
+
+	printf 'Rebuilding incomplete WordPress core cache at %s.\n' "$WP_CORE_DIR"
+	create_staging_dir CORE_STAGING "$WP_CORE_DIR"
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		svn export --quiet https://core.svn.wordpress.org/trunk "$CORE_STAGING"
+	else
+		resolve_archive_name
+		archive_file="$CORE_STAGING/wordpress.tar.gz"
+		download "https://wordpress.org/${ARCHIVE_NAME}.tar.gz" "$archive_file"
+		tar --strip-components=1 -zxmf "$archive_file" -C "$CORE_STAGING"
+		rm -f "$archive_file"
+	fi
+
+	download 'https://raw.githubusercontent.com/marber/wp-config-github-actions/main/wp-config-ci.php' "$CORE_STAGING/wp-config.php"
+	if ! is_valid_core "$CORE_STAGING"; then
+		printf 'WordPress core staging directory is incomplete: %s/wp-settings.php is missing.\n' "$CORE_STAGING" >&2
+		return 1
+	fi
+
+	promote_staging_dir CORE_STAGING "$WP_CORE_DIR"
+	return 0
+}
+
+install_test_suite() {
+	if ! is_valid_test_suite "$WP_TESTS_DIR"; then
+		printf 'Rebuilding incomplete WordPress test-library cache at %s.\n' "$WP_TESTS_DIR"
+		create_staging_dir TESTS_STAGING "$WP_TESTS_DIR"
+		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/" "$TESTS_STAGING/includes"
+		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/" "$TESTS_STAGING/data"
+		write_test_config "$TESTS_STAGING"
+		if ! is_valid_test_suite "$TESTS_STAGING"; then
+			printf 'WordPress test-library staging directory is incomplete: %s/includes/functions.php is missing.\n' "$TESTS_STAGING" >&2
+			return 1
+		fi
+		promote_staging_dir TESTS_STAGING "$WP_TESTS_DIR"
+	fi
+
+	write_test_config "$WP_TESTS_DIR"
+	return 0
+}
+
+recreate_db() {
+	local -a extra=( "$@" )
+
+	mysqladmin drop "$DB_NAME" -f --user="$DB_USER" --password="$DB_PASS" "${extra[@]}"
+	create_db "${extra[@]}"
+	printf 'Recreated the database (%s).\n' "$DB_NAME"
+	return 0
+}
+
+create_db() {
+	local -a extra=( "$@" )
+
+	mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS" "${extra[@]}"
+	return 0
+}
+
+install_db() {
+	local db_hostname=''
+	local db_socket_or_port=''
+	local -a extra=()
+
+	if [ "$SKIP_DB_CREATE" = 'true' ]; then
+		return 0
+	fi
+
+	IFS=':' read -r db_hostname db_socket_or_port <<<"$DB_HOST"
+	if [ -n "$db_hostname" ]; then
+		if [[ $db_socket_or_port =~ ^[0-9]+$ ]]; then
+			extra=( "--host=$db_hostname" "--port=$db_socket_or_port" '--protocol=tcp' )
+		elif [ -n "$db_socket_or_port" ]; then
+			extra=( "--socket=$db_socket_or_port" )
+		else
+			extra=( "--host=$db_hostname" '--protocol=tcp' )
 		fi
 	fi
 
-	# create database
-	if mysql --user="$DB_USER" --password="$DB_PASS""$EXTRA" --execute='show databases;' | grep -q "^${DB_NAME}$"; then
-		echo "Reinitializing will delete the existing test database ($DB_NAME)"
-		recreate_db yes
+	if mysql --user="$DB_USER" --password="$DB_PASS" "${extra[@]}" --execute='show databases;' | grep -q "^${DB_NAME}$"; then
+		printf 'Reinitializing will delete the existing test database (%s).\n' "$DB_NAME"
+		recreate_db "${extra[@]}"
 	else
-		create_db
+		create_db "${extra[@]}"
 	fi
+	return 0
 }
 
+mkdir -p "$CACHE_ROOT"
+acquire_lock
+WORK_DIR="$(mktemp -d "$CACHE_ROOT/.wordpress-phpunit-${VERSION_KEY}.XXXXXX")"
+set_wp_tests_tag
 install_wp
 install_test_suite
+
+if ! is_valid_core "$WP_CORE_DIR" || ! is_valid_test_suite "$WP_TESTS_DIR"; then
+	printf 'WordPress PHPUnit cache validation failed after provisioning.\n' >&2
+	exit 1
+fi
+
 install_db

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -256,6 +256,7 @@ install_wp() {
 	create_staging_dir CORE_STAGING "$WP_CORE_DIR"
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		rmdir "$CORE_STAGING"
 		svn export --quiet https://core.svn.wordpress.org/trunk "$CORE_STAGING"
 	else
 		resolve_archive_name

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -265,7 +265,6 @@ install_wp() {
 		rm -f "$archive_file"
 	fi
 
-	download 'https://raw.githubusercontent.com/marber/wp-config-github-actions/main/wp-config-ci.php' "$CORE_STAGING/wp-config.php"
 	if ! is_valid_core "$CORE_STAGING"; then
 		printf 'WordPress core staging directory is incomplete: %s/wp-settings.php is missing.\n' "$CORE_STAGING" >&2
 		return 1

--- a/bin/run-wp-phpunit.php
+++ b/bin/run-wp-phpunit.php
@@ -112,6 +112,16 @@ if (is_dir($polyfills)) {
 	putenv('WP_TESTS_PHPUNIT_POLYFILLS_PATH=' . $polyfills);
 }
 
+if (! is_file($core_dir . '/wp-settings.php')) {
+	fwrite(
+		STDERR,
+		"WordPress core cache is incomplete at {$core_dir}/wp-settings.php." . PHP_EOL
+		. 'Run `pnpm run test:php:setup` to rebuild the shared cache.' . PHP_EOL
+		. 'Shared cache root: ' . $cache_root . PHP_EOL
+	);
+	exit(1);
+}
+
 if (! is_file($tests_dir . '/includes/functions.php')) {
 	fwrite(
 		STDERR,

--- a/bin/setup-wp-phpunit.php
+++ b/bin/setup-wp-phpunit.php
@@ -182,9 +182,9 @@ function sd_ai_agent_setup_database(string $db_name, string $db_user, string $db
 /**
  * Write a standard wp-config.php that WP-CLI can parse in the shared core tree.
  *
- * The legacy WordPress test installer downloads a CI-oriented config file that
- * does not directly load wp-settings.php. WP-CLI rejects that shape, which
- * breaks tests that exercise subprocess isolation through `wp eval-file`.
+ * The WordPress test installer only provisions core files. This setup command
+ * adds a config that directly loads wp-settings.php so WP-CLI can run tests
+ * that exercise subprocess isolation through `wp eval-file`.
  *
  * @param string $core_dir WordPress core directory.
  * @param string $db_name  Database name.

--- a/bin/setup-wp-phpunit.php
+++ b/bin/setup-wp-phpunit.php
@@ -217,6 +217,20 @@ PHP;
 	return false !== file_put_contents(rtrim($core_dir, '/') . '/wp-config.php', $config);
 }
 
+/**
+ * Confirm that the shared file cache contains the minimum WordPress PHPUnit
+ * contract before database setup begins.
+ *
+ * @param string $core_dir  WordPress core directory.
+ * @param string $tests_dir WordPress test library directory.
+ * @return bool
+ */
+function sd_ai_agent_setup_has_valid_file_cache(string $core_dir, string $tests_dir): bool
+{
+	return is_file(rtrim($core_dir, '/') . '/wp-settings.php')
+		&& is_file(rtrim($tests_dir, '/') . '/includes/functions.php');
+}
+
 $wp_version  = sd_ai_agent_setup_env('WP_VERSION') ?? 'trunk';
 $version_key = sd_ai_agent_setup_version_slug($wp_version);
 $cache_root  = sd_ai_agent_setup_cache_root();
@@ -242,8 +256,9 @@ if (! is_dir($cache_root) && ! mkdir($cache_root, 0777, true) && ! is_dir($cache
 }
 
 $env = array(
-	'WP_TESTS_DIR' => $tests_dir,
-	'WP_CORE_DIR'  => $core_dir,
+	'WP_PHPUNIT_CACHE_DIR' => $cache_root,
+	'WP_TESTS_DIR'         => $tests_dir,
+	'WP_CORE_DIR'          => $core_dir,
 );
 
 $command = sd_ai_agent_setup_env_prefix($env)
@@ -263,6 +278,14 @@ fwrite(STDOUT, '- Test database:  ' . $db_name . ' @ ' . $db_host . PHP_EOL);
 passthru($command, $exit_code);
 if (0 !== (int) $exit_code) {
 	exit((int) $exit_code);
+}
+
+if (! sd_ai_agent_setup_has_valid_file_cache($core_dir, $tests_dir)) {
+	fwrite(
+		STDERR,
+		'WordPress PHPUnit cache is incomplete after provisioning. Expected wp-settings.php and includes/functions.php; rerun `pnpm run test:php:setup` to rebuild it.' . PHP_EOL
+	);
+	exit(1);
 }
 
 if (! sd_ai_agent_setup_wp_config($core_dir, $db_name, $db_user, $db_pass, $db_host)) {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,6 +26,19 @@ Then run the suite from any checkout:
 pnpm run test:php
 ```
 
+### Shared-cache safety
+
+Setup serializes provisioning for each cache root and WordPress version. Each
+process extracts into its own staging directory, validates both
+`wp-settings.php` and `includes/functions.php`, then atomically publishes the
+complete core and test-library directories. A second worktree using the same
+cache waits for the active setup instead of reusing its staging files.
+
+If setup is interrupted, rerun the same setup command. An existing cache that
+lacks either sentinel is treated as incomplete and rebuilt. Database creation
+runs only after the file cache has been validated, so a database failure does
+not invalidate a completed shared cache.
+
 Useful overrides:
 
 ```bash


### PR DESCRIPTION
## Summary

- serialize PHPUnit cache provisioning per cache root and WordPress version
- stage and validate WordPress core and test-library trees before atomic promotion
- rebuild incomplete cache trees and diagnose a missing core sentinel before PHPUnit starts
- document safe shared-cache recovery across worktrees

Resolves #2590

## Files Scope

- `bin/install-wp-tests.sh`
- `bin/setup-wp-phpunit.php`
- `bin/run-wp-phpunit.php`
- `docs/testing.md`

## Verification

- `bash -n bin/install-wp-tests.sh` — passed
- `shellcheck bin/install-wp-tests.sh` — passed
- `php -l bin/setup-wp-phpunit.php` — passed
- `php -l bin/run-wp-phpunit.php` — passed
- `composer phpcs -- bin/setup-wp-phpunit.php bin/run-wp-phpunit.php` — passed
- two concurrent `WP_VERSION=7.0 WP_TESTS_SKIP_DB_CREATE=true pnpm run test:php:setup` processes against one empty cache — passed; both sentinels and the test config were present afterward
- `WP_VERSION=trunk WP_TESTS_SKIP_DB_CREATE=true pnpm run test:php:setup` — passed; both sentinels and the test config were present afterward
- database creation with local default credentials correctly failed separately while the completed 7.0 cache remained valid; the environment did not permit the requested WP 7.0 PHPUnit run
- `pnpm run verify` — passed: PHPUnit 4249 tests, 19498 assertions, 137 skipped, 4 incomplete; lint, PHPStan, build, and bundle checks passed

The initial CI run exposed an SVN staging-path failure. Commit `9f7b3a65` fixes it by removing the empty unique directory immediately before `svn export`, so SVN creates and owns that unique path.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
