### PR TITLE
fix: preserve receipts across repeated compaction

### DIFF
--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -46,6 +46,9 @@ class ConversationTrimmer {
 	/** Maximum JSON characters retained for callable ability-search schemas. */
 	private const COMPACT_MAX_ABILITY_SCHEMA_RECEIPT_CHARS = 1600;
 
+	/** Exact marker at the start of a deterministic compact-context message. */
+	private const COMPACT_CONTEXT_MARKER = 'Conversation compacted server-side to avoid provider payload limits.';
+
 	/** Marker inserted when older turns are removed by a request-size budget. */
 	private const BUDGET_MARKER_TEXT = '[Earlier conversation turns were compacted to stay within the request safety budget.]';
 
@@ -215,7 +218,7 @@ class ConversationTrimmer {
 			}
 		}
 
-		$source_count = count( $normalized );
+		$source_count = 0;
 		$max_bytes    = max( 1024, $max_bytes );
 		$max_tokens   = max( 256, $max_tokens );
 
@@ -224,12 +227,16 @@ class ConversationTrimmer {
 			min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) )
 		);
 
+		$available_lines = array();
+		foreach ( $normalized as $message ) {
+			$expanded        = self::serialized_message_to_compact_excerpts( $message, $per_message_chars );
+			$source_count   += $expanded['source_count'];
+			$available_lines = array_merge( $available_lines, $expanded['lines'] );
+		}
+
 		$lines = array();
-		for ( $i = $source_count - 1; $i >= 0; --$i ) {
-			$excerpt = self::serialized_message_to_compact_excerpt( $normalized[ $i ], $per_message_chars );
-			if ( '' === $excerpt ) {
-				continue;
-			}
+		for ( $i = count( $available_lines ) - 1; $i >= 0; --$i ) {
+			$excerpt = $available_lines[ $i ];
 
 			$candidate = $lines;
 			array_unshift( $candidate, $excerpt );
@@ -312,7 +319,7 @@ class ConversationTrimmer {
 		$omitted_count = max( 0, $source_count - $retained_count );
 
 		$header = array(
-			'Conversation compacted server-side to avoid provider payload limits.',
+			self::COMPACT_CONTEXT_MARKER,
 			"Source messages: {$source_count}; retained excerpts: {$retained_count}; omitted messages: {$omitted_count}.",
 			'Use this compact context to continue the current task. File attachments, inline image bytes, and raw tool payloads were omitted.',
 			'Bounded inspection receipts are evidence of completed reads. Do not repeat an inspection solely because its raw result was omitted.',
@@ -320,6 +327,88 @@ class ConversationTrimmer {
 		);
 
 		return implode( "\n", $header ) . "\n\n" . implode( "\n\n", $lines );
+	}
+
+	/**
+	 * Expand an existing deterministic compact seed instead of nesting it.
+	 *
+	 * Provider recovery can compact the same durable history repeatedly. Treating
+	 * an earlier seed as an ordinary user message collapses all of its structured
+	 * receipts into one 2,000-character excerpt, so later compaction loses the
+	 * evidence needed to continue. A strictly recognized seed contributes its
+	 * original excerpts and source count directly, making compaction idempotent.
+	 *
+	 * @param array<string, mixed> $message   Serialized message array.
+	 * @param int                  $max_chars Character limit for each excerpt body.
+	 * @return array{lines:list<string>,source_count:int}
+	 */
+	private static function serialized_message_to_compact_excerpts( array $message, int $max_chars ): array {
+		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? array_values( $message['parts'] ) : array();
+		if (
+			1 === count( $parts )
+			&& is_array( $parts[0] )
+			&& isset( $parts[0]['text'] )
+			&& is_string( $parts[0]['text'] )
+		) {
+			$expanded = self::parse_compact_context_text( $parts[0]['text'], $max_chars );
+			if ( null !== $expanded ) {
+				return $expanded;
+			}
+		}
+
+		$excerpt = self::serialized_message_to_compact_excerpt( $message, $max_chars );
+
+		return array(
+			'lines'        => '' === $excerpt ? array() : array( $excerpt ),
+			'source_count' => 1,
+		);
+	}
+
+	/**
+	 * Parse a compact seed produced by {@see build_compact_context_text()}.
+	 *
+	 * Recognition is deliberately strict so ordinary user prose that happens to
+	 * mention compaction is not reinterpreted as server-produced history.
+	 *
+	 * @param string $text      Candidate compact-context text.
+	 * @param int    $max_chars Character limit for each recovered excerpt.
+	 * @return array{lines:list<string>,source_count:int}|null
+	 */
+	private static function parse_compact_context_text( string $text, int $max_chars ): ?array {
+		$text  = str_replace( array( "\r\n", "\r" ), "\n", $text );
+		$lines = explode( "\n", $text );
+		if (
+			count( $lines ) < 7
+			|| self::COMPACT_CONTEXT_MARKER !== $lines[0]
+			|| ! preg_match( '/^Source messages: (\d+); retained excerpts: (\d+); omitted messages: (\d+)\.$/', $lines[1], $matches )
+			|| 'Use this compact context to continue the current task. File attachments, inline image bytes, and raw tool payloads were omitted.' !== $lines[2]
+			|| 'Bounded inspection receipts are evidence of completed reads. Do not repeat an inspection solely because its raw result was omitted.' !== $lines[3]
+			|| 'Ability-search receipts retain callable input-schema shapes. Use ability-call directly with those schemas instead of searching for the same ability again.' !== $lines[4]
+			|| '' !== $lines[5]
+		) {
+			return null;
+		}
+
+		$body      = implode( "\n", array_slice( $lines, 6 ) );
+		$excerpts  = preg_split( '/\n{2,}/', $body );
+		$excerpts  = is_array( $excerpts ) ? $excerpts : array();
+		$recovered = array();
+		foreach ( $excerpts as $excerpt ) {
+			$excerpt = trim( $excerpt );
+			if ( '' === $excerpt ) {
+				continue;
+			}
+
+			if ( strlen( $excerpt ) > $max_chars ) {
+				$excerpt = substr( $excerpt, 0, max( 0, $max_chars - 1 ) ) . '…';
+			}
+			$recovered[] = $excerpt;
+		}
+
+		return array(
+			'lines'        => $recovered,
+			'source_count' => max( count( $recovered ), (int) $matches[1] ),
+		);
 	}
 
 	/** Convert compact text into a single user-message seed. */

--- a/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php
@@ -131,4 +131,60 @@ class ConversationTrimmerCompactionTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'SECRET_OPTION_VALUE', $json );
 		$this->assertStringNotContainsString( 'private.example', $json );
 	}
+
+	/** Re-compacting a deterministic seed preserves its structured receipts. */
+	public function test_compact_serialized_history_expands_existing_compact_seed(): void {
+		$messages = [];
+		for ( $index = 0; $index < 6; ++$index ) {
+			$messages[] = [
+				'role'  => 'user',
+				'parts' => [ [ 'text' => str_repeat( 'Earlier bounded setup context. ', 18 ) ] ],
+			];
+		}
+		$messages[] = [
+			'role'  => 'user',
+			'parts' => [
+				[
+					'functionResponse' => [
+						'name'     => 'wpab__sd-ai-agent__ability-search',
+						'response' => [
+							'query'   => 'select:sd-ai-agent/delete-post',
+							'results' => [
+								[
+									'id'           => 'sd-ai-agent/delete-post',
+									'label'        => 'Delete Post',
+									'input_schema' => [
+										'type'       => 'object',
+										'properties' => [ 'post_id' => [ 'type' => 'integer' ] ],
+										'required'   => [ 'post_id' ],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$first = ConversationTrimmer::compact_serialized_history( $messages, 8192, 2048 );
+		$second_input = array_merge(
+			$first['messages'],
+			[
+				[
+					'role'  => 'model',
+					'parts' => [ [ 'text' => 'Continue from the retained callable schema.' ] ],
+				],
+			]
+		);
+		$second = ConversationTrimmer::compact_serialized_history( $second_input, 8192, 2048 );
+		$text   = (string) $second['messages'][0]['parts'][0]['text'];
+
+		$this->assertSame( 8, $second['meta']['source_message_count'] );
+		$this->assertSame( 1, substr_count( $text, 'Conversation compacted server-side to avoid provider payload limits.' ) );
+		$this->assertStringNotContainsString( 'User: Conversation compacted server-side', $text );
+		$this->assertStringContainsString( 'callable_schemas=', $text );
+		$this->assertStringContainsString( 'sd-ai-agent\/delete-post', $text );
+		$this->assertStringContainsString( '"required":["post_id"]', $text );
+		$this->assertStringContainsString( 'Continue from the retained callable schema.', $text );
+	}
 }


### PR DESCRIPTION
## Summary

- expand previously generated compact-context messages before applying a later compaction budget
- preserve the original source-message count and structured inspection/schema receipts
- add a regression that re-compacts a seed whose callable schema appears after the former per-message truncation boundary

## Root cause

Repeated recovery compaction treated an earlier compact seed as an ordinary user message. Its complete receipt ledger was normalized into one line and truncated to 2,000 characters, causing later provider turns to lose completed inspections and callable schemas and restart discovery.

## Verification

- `composer lint`
- `vendor/bin/phpunit tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php` (2 tests, 26 assertions)
- `vendor/bin/phpcs includes/Core/ConversationTrimmer.php tests/SdAiAgent/Core/ConversationTrimmerCompactionTest.php`
- `git diff --check`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeated conversation compaction to preserve recovered excerpts, metadata, source counts, callable schemas, receipts, and later model responses.
  * Prevented duplicate compaction markers during repeated processing.
  * Added validation and safe fallback handling for unrecognized compacted messages.

* **Tests**
  * Added regression coverage for preserving structured conversation data across repeated compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->