### PR TITLE
GH#2602: align bindings audit criterion

### DIFF
--- a/todo/tasks/t275-brief.md
+++ b/todo/tasks/t275-brief.md
@@ -80,7 +80,7 @@ No upstream — internal consistency task. Block-mcp's shape uses `bound_attribu
 
 ## Acceptance criteria
 
-1. Audit document exists in PR and is committed alongside the fixes.
+1. The bindings-field matrix is retained in the implementation PR history (PR #2581) as the durable audit reference; no committed audit document is required.
 2. Every read path that emits a parsed block dict includes both `bindings` and `bound_attributes` fields.
 3. When a block has zero bindings, `bindings: null` and `bound_attributes: []` (NOT absent, NOT missing).
 4. When a block has bindings, `bindings: { <attr_key>: { source, args } }` and `bound_attributes: [<attr_keys>]`.


### PR DESCRIPTION
## Summary

- Align the t275 audit acceptance criterion with the retained bindings-field matrix reference.
- Record PR #2581 as the durable implementation-history locator.

## Verification

- `git diff --check origin/main...HEAD` — passed.
- `composer phpstan` — passed with 0 errors.
- `pnpm run build` — passed (existing webpack bundle-size warnings only).
- `pnpm run verify` — lint passed, then the full PHPUnit suite hit shared test-database deadlocks/missing tables: 1 error and 6 failures in unrelated REST, ResourceExhaustion, and GlobalStyles tests. The scope diff contains only `todo/tasks/t275-brief.md`.
- `pnpm run check:bundle` — failed because ignored `build/floating-widget.js` is absent after the build; outside this documentation-only scope.

## Runtime Testing

- Self-assessed: documentation-only task brief correction; no runtime behavior changed.

Resolves #2602

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 2m and 49,399 tokens on this as a headless worker.
