### PR TITLE
test: isolate image provider registration precondition

### DIFF
--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -12,6 +12,7 @@ namespace SdAiAgent\Tests\Abilities;
 use SdAiAgent\Abilities\AiImageAbilities;
 use SdAiAgent\Abilities\ImageAbilities\GenerateImageAbility;
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Core\CredentialResolver;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
@@ -33,20 +34,50 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'WP 7.0+ Abilities API is unavailable.' );
 		}
 
-		if ( function_exists( 'wp_unregister_ability' ) ) {
-			wp_unregister_ability( 'sd-ai-agent/generate-image' );
+		$previous_settings    = get_option( Settings::OPTION_NAME, null );
+		$previous_credentials = get_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, null );
+		$previous_token       = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, null );
+
+		delete_option( Settings::OPTION_NAME );
+		delete_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION );
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+
+		try {
+			$method = new \ReflectionMethod( GenerateImageAbility::class, 'is_image_generation_supported' );
+			$method->setAccessible( true );
+			$this->assertFalse( $method->invoke( null ), 'Image generation must be unavailable without provider credentials.' );
+
+			if ( function_exists( 'wp_unregister_ability' ) ) {
+				wp_unregister_ability( 'sd-ai-agent/generate-image' );
+			}
+
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+			global $wp_current_filter;
+			$wp_current_filter[] = 'wp_abilities_api_init';
+			GenerateImageAbility::register();
+			array_pop( $wp_current_filter );
+
+			$ability = wp_get_ability( 'sd-ai-agent/generate-image' );
+
+			$this->assertNotNull( $ability );
+			$this->assertStringContainsString( 'Connectors settings page', $ability->get_description() );
+		} finally {
+			if ( null === $previous_settings ) {
+				delete_option( Settings::OPTION_NAME );
+			} else {
+				update_option( Settings::OPTION_NAME, $previous_settings );
+			}
+			if ( null === $previous_credentials ) {
+				delete_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION );
+			} else {
+				update_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, $previous_credentials );
+			}
+			if ( null === $previous_token ) {
+				delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+			} else {
+				update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $previous_token );
+			}
 		}
-
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_init';
-		GenerateImageAbility::register();
-		array_pop( $wp_current_filter );
-
-		$ability = wp_get_ability( 'sd-ai-agent/generate-image' );
-
-		$this->assertNotNull( $ability );
-		$this->assertStringContainsString( 'Connectors settings page', $ability->get_description() );
 	}
 
 	// ─── handle_generate ──────────────────────────────────────────

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -34,9 +34,9 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'WP 7.0+ Abilities API is unavailable.' );
 		}
 
-		$previous_settings    = get_option( Settings::OPTION_NAME, null );
-		$previous_credentials = get_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, null );
-		$previous_token       = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, null );
+		$previousSettings    = get_option( Settings::OPTION_NAME, null );
+		$previousCredentials = get_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, null );
+		$previousToken       = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, null );
 
 		delete_option( Settings::OPTION_NAME );
 		delete_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION );
@@ -62,20 +62,20 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 			$this->assertNotNull( $ability );
 			$this->assertStringContainsString( 'Connectors settings page', $ability->get_description() );
 		} finally {
-			if ( null === $previous_settings ) {
+			if ( null === $previousSettings ) {
 				delete_option( Settings::OPTION_NAME );
 			} else {
-				update_option( Settings::OPTION_NAME, $previous_settings );
+				update_option( Settings::OPTION_NAME, $previousSettings );
 			}
-			if ( null === $previous_credentials ) {
+			if ( null === $previousCredentials ) {
 				delete_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION );
 			} else {
-				update_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, $previous_credentials );
+				update_option( CredentialResolver::AI_EXPERIMENTS_CREDENTIALS_OPTION, $previousCredentials );
 			}
-			if ( null === $previous_token ) {
+			if ( null === $previousToken ) {
 				delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 			} else {
-				update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $previous_token );
+				update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $previousToken, false );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Make the generate-image registration test explicitly remove stored provider settings and credentials.
- Assert image generation is unavailable before proving the ability remains discoverable.
- Restore every altered option after the assertion.

Resolves #2603

## Worker self-verification

- Targeted PHPUnit: `AiImageAbilitiesTest` — 19 tests, 57 assertions, passed
- Targeted PHP lint: clean
- The prior PR's failed Playwright shard is independent of this test-only diff: its failing E2E files are unchanged from `origin/main` and fail because the CI runtime does not expose `wp.abilities`.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for image-generation behavior when required provider credentials are unavailable.
  * Added cleanup and restoration of configuration values to keep test execution isolated and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->