### PR TITLE
fix: renew client tool resume execution budget

### DIFF
--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -442,6 +442,11 @@ Assistant: %s',
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function handle_tool_result( WP_REST_Request $request ) {
+		// FrankenPHP workers can enter this follow-up request with most of the
+		// previous long-running turn's execution budget already consumed. Renew
+		// it before synchronously resuming the agent loop.
+		set_time_limit( 600 );
+
 		$session_id   = self::get_int_param( $request, 'session_id' );
 		$tool_results = $request->get_param( 'tool_results' );
 		$job_id       = (string) ( $request->get_param( 'job_id' ) ?? '' );


### PR DESCRIPTION
## Summary

- renew PHP's execution-time budget when `/chat/tool-result` begins a synchronous agent-loop resume
- prevent long Setup Assistant turns from inheriting an almost-exhausted timer in persistent FrankenPHP workers

## Runtime evidence

A fresh local multisite Setup Assistant run completed its browser-side `sd-ai-agent-js/screenshot-url` call and POSTed the result successfully. The resumed request then failed in the provider cURL transport with `Maximum execution time of 300 seconds exceeded`, and the durable job became `interrupted` with reason `worker_terminated`. The main background runner already grants long agent turns 600 seconds; this applies the same budget to the client-tool continuation endpoint.

## Worker self-verification

- PHPUnit: Tests: 4251, Assertions: 19539, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Focused PHPUnit: RestControllerTest — 126 tests, 474 assertions
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the execution time available when processing tool results and follow-up requests, reducing interruptions during long-running agent tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->