### PR TITLE
fix: bound read-only agent inspection loops

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1726,6 +1726,40 @@ PROMPT;
 	}
 
 	/**
+	 * Record whether a tool round made mutable progress and inject a correction
+	 * after repeated inspection-only rounds.
+	 *
+	 * @param Message $message         Assistant tool-call message.
+	 * @param int     $readonly_rounds Consecutive read-only rounds so far.
+	 * @return array{has_mutating_tools: bool, readonly_rounds: int}
+	 */
+	private function record_tool_progress( Message $message, int $readonly_rounds ): array {
+		$has_mutating_tools = ToolPermissionResolver::message_has_mutating_tools( $message );
+		if ( $has_mutating_tools ) {
+			return array(
+				'has_mutating_tools' => true,
+				'readonly_rounds'    => 0,
+			);
+		}
+
+		++$readonly_rounds;
+		if ( 0 === $readonly_rounds % self::READONLY_INSPECTION_NUDGE_ROUNDS ) {
+			$this->history[] = new UserMessage(
+				array(
+					new MessagePart(
+						__( 'You have spent several consecutive rounds on read-only inspections without making a change. Stop re-checking known state and perform the next concrete mutation required by the user now. If no safe mutation is possible, explain the exact blocker and finish instead of inspecting again.', 'superdav-ai-agent' )
+					),
+				)
+			);
+		}
+
+		return array(
+			'has_mutating_tools' => false,
+			'readonly_rounds'    => $readonly_rounds,
+		);
+	}
+
+	/**
 	 * Inner loop: send prompts, handle tool calls, repeat.
 	 *
 	 * @param int $iterations Max iterations remaining.
@@ -2213,21 +2247,9 @@ PROMPT;
 			$this->log_tool_responses( $truncated_message );
 			$this->readonly_tool_cache->record( $history_message, $truncated_message );
 
-			$has_mutating_tools = ToolPermissionResolver::message_has_mutating_tools( $assistant_message );
-			if ( $has_mutating_tools ) {
-				$readonly_rounds = 0;
-			} else {
-				++$readonly_rounds;
-				if ( 0 === $readonly_rounds % self::READONLY_INSPECTION_NUDGE_ROUNDS ) {
-					$this->history[] = new UserMessage(
-						array(
-							new MessagePart(
-								__( 'You have spent several consecutive rounds on read-only inspections without making a change. Stop re-checking known state and perform the next concrete mutation required by the user now. If no safe mutation is possible, explain the exact blocker and finish instead of inspecting again.', 'superdav-ai-agent' )
-							),
-						)
-					);
-				}
-			}
+			$tool_progress      = $this->record_tool_progress( $assistant_message, $readonly_rounds );
+			$has_mutating_tools = $tool_progress['has_mutating_tools'];
+			$readonly_rounds    = $tool_progress['readonly_rounds'];
 			if ( '' !== $media_budget['guidance'] ) {
 				$this->history[] = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
 			}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -58,6 +58,8 @@ class AgentLoop {
 	 * not killed — only truly stalled loops hit this limit.
 	 */
 	const LOOP_TIMEOUT_SECONDS = 300;
+	/** Consecutive inspection-only rounds before injecting a progress correction. */
+	const READONLY_INSPECTION_NUDGE_ROUNDS = 3;
 
 	/**
 	 * Consecutive no-progress rounds before forced exit.
@@ -1731,6 +1733,7 @@ PROMPT;
 	 */
 	private function run_loop( int $iterations ) {
 		$last_was_tool_call = false;
+		$readonly_rounds    = 0;
 
 		// Wall-clock deadline prevents runaway loops even when round count
 		// and token budget are within limits (e.g. cheap read-only tool
@@ -2209,6 +2212,22 @@ PROMPT;
 			$this->append_tool_response_to_history( $truncated_message );
 			$this->log_tool_responses( $truncated_message );
 			$this->readonly_tool_cache->record( $history_message, $truncated_message );
+
+			$has_mutating_tools = ToolPermissionResolver::message_has_mutating_tools( $assistant_message );
+			if ( $has_mutating_tools ) {
+				$readonly_rounds = 0;
+			} else {
+				++$readonly_rounds;
+				if ( 0 === $readonly_rounds % self::READONLY_INSPECTION_NUDGE_ROUNDS ) {
+					$this->history[] = new UserMessage(
+						array(
+							new MessagePart(
+								__( 'You have spent several consecutive rounds on read-only inspections without making a change. Stop re-checking known state and perform the next concrete mutation required by the user now. If no safe mutation is possible, explain the exact blocker and finish instead of inspecting again.', 'superdav-ai-agent' )
+							),
+						)
+					);
+				}
+			}
 			if ( '' !== $media_budget['guidance'] ) {
 				$this->history[] = new UserMessage( array( new MessagePart( $media_budget['guidance'] ) ) );
 			}
@@ -2236,11 +2255,11 @@ PROMPT;
 				);
 			}
 
-			// Reset the wall-clock deadline after each productive tool call.
-			// This allows genuinely long tasks (many sequential tool calls) to
-			// complete while still killing truly stalled loops that make no
-			// forward progress within a single LOOP_TIMEOUT_SECONDS window.
-			$deadline = microtime( true ) + self::LOOP_TIMEOUT_SECONDS;
+			// Only writes demonstrate forward progress. Repeated inspections must
+			// not renew the deadline indefinitely and outlive PHP's request limit.
+			if ( $has_mutating_tools ) {
+				$deadline = microtime( true ) + self::LOOP_TIMEOUT_SECONDS;
+			}
 
 			// Spin detection: delegate to SpinDetector which encapsulates
 			// the idle-round state (last_tool_signature + idle_rounds counter).

--- a/includes/Core/ToolPermissionResolver.php
+++ b/includes/Core/ToolPermissionResolver.php
@@ -156,6 +156,45 @@ class ToolPermissionResolver {
 	}
 
 	/**
+	 * Whether a tool-call message contains at least one non-read-only ability.
+	 *
+	 * Meta ability calls are classified by their nested target. Unknown registered
+	 * abilities are treated as mutations so an incomplete annotation cannot make a
+	 * potentially destructive call look like a harmless inspection.
+	 *
+	 * @param Message $message Assistant tool-call message.
+	 */
+	public static function message_has_mutating_tools( Message $message ): bool {
+		$all_abilities = function_exists( 'wp_get_abilities' ) ? wp_get_abilities() : array();
+
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call ) {
+				continue;
+			}
+
+			$function_name = (string) $call->getName();
+			if ( ! str_starts_with( $function_name, 'wpab__' ) ) {
+				continue;
+			}
+
+			$ability_name = $function_name;
+			if ( class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+				$ability_name = \WP_AI_Client_Ability_Function_Resolver::function_name_to_ability_name( $function_name );
+			}
+
+			$args        = self::normalize_function_call_args( $call->getArgs() );
+			$governed_id = self::get_confirmation_ability_id( $ability_name, $args, $all_abilities );
+			$ability     = $all_abilities[ $governed_id ] ?? null;
+			if ( ! $ability instanceof \WP_Ability || 'read' !== self::classify_ability( $ability ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Whether an ability should pause for user confirmation.
 	 *
 	 * @param string                   $ability_name     Ability ID.

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -4176,80 +4176,46 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertTrue( ToolPermissionResolver::message_has_mutating_tools( $mutation ) );
 	}
 
-	/** Alternating read-only inspections receive a salient progress correction. */
-	public function test_run_nudges_alternating_readonly_inspection_loop(): void {
-		$this->skip_if_sdk_unavailable();
+	/** Alternating inspections trigger a correction and mutation resets the counter. */
+	public function test_record_tool_progress_nudges_and_resets_without_provider(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! wp_has_ability( 'sd-ai-agent/list-posts' ) || ! wp_has_ability( 'sd-ai-agent/create-post' ) ) {
+			$this->markTestSkipped( 'Required read and write abilities are not registered.' );
+		}
 		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
 			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
 		}
 
-		$call_count    = 0;
-		$captured_body = '';
-		add_filter(
-			'pre_http_request',
-			static function ( $preempt, $args, $url ) use ( &$call_count, &$captured_body ) {
-				if ( false === strpos( $url, 'fake-ai-proxy.test' ) ) {
-					return $preempt;
-				}
-
-				++$call_count;
-				if ( $call_count <= AgentLoop::READONLY_INSPECTION_NUDGE_ROUNDS ) {
-					$body = wp_json_encode(
-						[
-							'id'      => 'chatcmpl-readonly-' . $call_count,
-							'object'  => 'chat.completion',
-							'choices' => [
-								[
-									'index'         => 0,
-									'message'       => [
-										'role'       => 'assistant',
-										'content'    => null,
-										'tool_calls' => [
-											[
-												'id'       => 'call_readonly_' . $call_count,
-												'type'     => 'function',
-												'function' => [
-													'name'      => 'wpab__sd-ai-agent__list-posts',
-													'arguments' => wp_json_encode( [ 'post_type' => 1 === $call_count ? 'page' : ( 2 === $call_count ? 'post' : [ 'page', 'post' ] ) ] ),
-												],
-											],
-										],
-									],
-									'finish_reason' => 'tool_calls',
-								],
-							],
-							'usage'   => [ 'prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10 ],
-						]
-					);
-				} else {
-					$captured_body = is_string( $args['body'] ?? null ) ? $args['body'] : (string) wp_json_encode( $args['body'] ?? [] );
-					$body          = wp_json_encode(
-						[
-							'id'      => 'chatcmpl-readonly-finished',
-							'object'  => 'chat.completion',
-							'choices' => [ [ 'index' => 0, 'message' => [ 'role' => 'assistant', 'content' => 'Finished after the progress correction.' ], 'finish_reason' => 'stop' ] ],
-							'usage'   => [ 'prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10 ],
-						]
-					);
-				}
-
-				return [
-					'headers'  => [ 'content-type' => 'application/json' ],
-					'body'     => $body,
-					'response' => [ 'code' => 200, 'message' => 'OK' ],
-					'cookies'  => [],
-					'filename' => '',
-				];
-			},
-			10,
-			3
+		$loop       = new AgentLoop( 'Complete the site without repeated inspections.' );
+		$method     = new \ReflectionMethod( AgentLoop::class, 'record_tool_progress' );
+		$inspection = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'call_inspect', 'wpab__sd-ai-agent__list-posts', array() ) ),
+			)
+		);
+		$mutation   = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'call_mutate', 'wpab__sd-ai-agent__create-post', array( 'title' => 'Progress marker' ) ) ),
+			)
 		);
 
-		$result = ( new AgentLoop( 'Complete the site without repeated inspections.', [], [], [ 'max_iterations' => 8 ] ) )->run();
+		$progress = array(
+			'has_mutating_tools' => false,
+			'readonly_rounds'    => 0,
+		);
+		for ( $round = 1; $round <= AgentLoop::READONLY_INSPECTION_NUDGE_ROUNDS; ++$round ) {
+			$progress = $method->invoke( $loop, $inspection, $progress['readonly_rounds'] );
+			$this->assertFalse( $progress['has_mutating_tools'] );
+			$this->assertSame( $round, $progress['readonly_rounds'] );
+		}
 
-		$this->assertIsArray( $result );
-		$this->assertSame( 'Finished after the progress correction.', $result['reply'] );
-		$this->assertStringContainsString( 'Stop re-checking known state', $captured_body );
+		$serialize = new \ReflectionMethod( AgentLoop::class, 'serialize_history' );
+		$history   = wp_json_encode( $serialize->invoke( $loop ) );
+		$this->assertIsString( $history );
+		$this->assertStringContainsString( 'Stop re-checking known state', $history );
+
+		$progress = $method->invoke( $loop, $mutation, $progress['readonly_rounds'] );
+		$this->assertTrue( $progress['has_mutating_tools'] );
+		$this->assertSame( 0, $progress['readonly_rounds'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -4107,6 +4107,151 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertLessThanOrEqual( AgentLoop::MAX_IDLE_ROUNDS + 1, $result['iterations_used'] );
 	}
 
+	/** Progress tracking distinguishes direct inspections from mutations. */
+	public function test_message_has_mutating_tools_classifies_direct_abilities(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! wp_has_ability( 'sd-ai-agent/list-posts' ) || ! wp_has_ability( 'sd-ai-agent/create-post' ) ) {
+			$this->markTestSkipped( 'Required read and write abilities are not registered.' );
+		}
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$inspection = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'call_inspect', 'wpab__sd-ai-agent__list-posts', array() ) ),
+			)
+		);
+		$mutation   = new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'call_mutate',
+						'wpab__sd-ai-agent__create-post',
+						array( 'title' => 'Progress marker' )
+					)
+				),
+			)
+		);
+
+		$this->assertFalse( ToolPermissionResolver::message_has_mutating_tools( $inspection ) );
+		$this->assertTrue( ToolPermissionResolver::message_has_mutating_tools( $mutation ) );
+	}
+
+	/** Progress tracking classifies a meta call by its governed target ability. */
+	public function test_message_has_mutating_tools_classifies_nested_target(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! wp_has_ability( 'sd-ai-agent/list-posts' ) || ! wp_has_ability( 'sd-ai-agent/create-post' ) ) {
+			$this->markTestSkipped( 'Required read and write abilities are not registered.' );
+		}
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$inspection = new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'call_nested_inspect',
+						'wpab__sd-ai-agent__ability-call',
+						array( 'ability' => 'sd-ai-agent/list-posts' )
+					)
+				),
+			)
+		);
+		$mutation   = new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'call_nested_mutate',
+						'wpab__sd-ai-agent__ability-call',
+						array(
+							'ability'   => 'sd-ai-agent/create-post',
+							'arguments' => array( 'title' => 'Progress marker' ),
+						)
+					)
+				),
+			)
+		);
+
+		$this->assertFalse( ToolPermissionResolver::message_has_mutating_tools( $inspection ) );
+		$this->assertTrue( ToolPermissionResolver::message_has_mutating_tools( $mutation ) );
+	}
+
+	/** Alternating read-only inspections receive a salient progress correction. */
+	public function test_run_nudges_alternating_readonly_inspection_loop(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count    = 0;
+		$captured_body = '';
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, &$captured_body ) {
+				if ( false === strpos( $url, 'fake-ai-proxy.test' ) ) {
+					return $preempt;
+				}
+
+				++$call_count;
+				if ( $call_count <= AgentLoop::READONLY_INSPECTION_NUDGE_ROUNDS ) {
+					$body = wp_json_encode(
+						[
+							'id'      => 'chatcmpl-readonly-' . $call_count,
+							'object'  => 'chat.completion',
+							'choices' => [
+								[
+									'index'         => 0,
+									'message'       => [
+										'role'       => 'assistant',
+										'content'    => null,
+										'tool_calls' => [
+											[
+												'id'       => 'call_readonly_' . $call_count,
+												'type'     => 'function',
+												'function' => [
+													'name'      => 'wpab__sd-ai-agent__list-posts',
+													'arguments' => wp_json_encode( [ 'post_type' => 1 === $call_count ? 'page' : ( 2 === $call_count ? 'post' : [ 'page', 'post' ] ) ] ),
+												],
+											],
+										],
+									],
+									'finish_reason' => 'tool_calls',
+								],
+							],
+							'usage'   => [ 'prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10 ],
+						]
+					);
+				} else {
+					$captured_body = is_string( $args['body'] ?? null ) ? $args['body'] : (string) wp_json_encode( $args['body'] ?? [] );
+					$body          = wp_json_encode(
+						[
+							'id'      => 'chatcmpl-readonly-finished',
+							'object'  => 'chat.completion',
+							'choices' => [ [ 'index' => 0, 'message' => [ 'role' => 'assistant', 'content' => 'Finished after the progress correction.' ], 'finish_reason' => 'stop' ] ],
+							'usage'   => [ 'prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10 ],
+						]
+					);
+				}
+
+				return [
+					'headers'  => [ 'content-type' => 'application/json' ],
+					'body'     => $body,
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+
+		$result = ( new AgentLoop( 'Complete the site without repeated inspections.', [], [], [ 'max_iterations' => 8 ] ) )->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Finished after the progress correction.', $result['reply'] );
+		$this->assertStringContainsString( 'Stop re-checking known state', $captured_body );
+	}
+
 	/**
 	 * Empty update-global-styles calls must be blocked before ability dispatch.
 	 */


### PR DESCRIPTION
## Summary

- classify direct and nested WordPress ability calls as read-only or mutating
- nudge the model after three consecutive inspection-only rounds
- renew the agent-loop deadline only after mutations, preventing alternating inspections from extending a request indefinitely

## Runtime evidence

A fresh local multisite Setup Assistant run created the requested pages, then alternated among post, menu, template, option, and media inspections without making further changes. The 600-second worker terminated and both automatic checkpoint recoveries repeated the same pattern before recovery was exhausted.

## Verification

- `pnpm verify`
- PHPUnit: 4254 tests, 19555 assertions, 0 errors/failures, 137 skipped, 4 incomplete
- `AgentLoopTest`: 177 tests, 483 assertions, 0 errors/failures, 67 skipped
- focused provider-independent progress coverage: 3 tests, 14 assertions
- PHPCS and PHPStan: clean
- build and bundle budgets: passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3d 14h and 22,622,731 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent task progression during repeated read-only inspections.
  * Added corrective guidance when inspections continue without making changes.
  * Prevented repeated read-only activity from extending the operation timeout.
  * Reset progress tracking after a mutating action is performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->