### PR TITLE
fix: execute XML text tool calls with JSON arguments

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3938,7 +3938,16 @@ PROMPT;
 				return null;
 			}
 
-			return $arguments;
+			$normalized_arguments = array();
+			foreach ( $arguments as $key => $value ) {
+				if ( ! is_string( $key ) ) {
+					return null;
+				}
+
+				$normalized_arguments[ $key ] = $value;
+			}
+
+			return $normalized_arguments;
 		}
 
 		return array();

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3799,6 +3799,11 @@ PROMPT;
 			return null;
 		}
 
+		$arguments = $this->extract_text_tool_call_arguments( $text );
+		if ( null === $arguments ) {
+			return __( 'The XML-like tool call contained malformed arguments. Call the tool through the structured tool channel with a valid JSON object instead of writing the call in assistant text.', 'superdav-ai-agent' );
+		}
+
 		$ability_name = $this->resolve_text_tool_call_ability_name( $raw_tool_name );
 		if ( null === $ability_name ) {
 			return sprintf(
@@ -3812,11 +3817,11 @@ PROMPT;
 			array(
 				new MessagePart(
 					new FunctionCall(
-						'text_tool_call_' . substr( md5( $raw_tool_name ), 0, 12 ),
+						'text_tool_call_' . substr( md5( $raw_tool_name . (string) wp_json_encode( $arguments ) ), 0, 12 ),
 						'wpab__sd-ai-agent__ability-call',
 						array(
 							'ability'   => $ability_name,
-							'arguments' => array(),
+							'arguments' => $arguments,
 						)
 					)
 				),
@@ -3882,8 +3887,8 @@ PROMPT;
 	 */
 	private function extract_text_tool_call_name( string $text ): ?string {
 		$patterns = array(
-			'/<tool_call>\s*([^\s<>]+)\s*<\/tool_call>/i',
-			'/<tool>\s*([^\s<>]+)\s*<\/tool>/i',
+			'/<tool_call>\s*([^\s<>(]+)(?:\s*\(.*\))?\s*<\/tool_call>/is',
+			'/<tool>\s*([^\s<>(]+)(?:\s*\(.*\))?\s*<\/tool>/is',
 			'/<function_call\s+name=["\']([^"\'<>]+)["\']\s*\/?\s*>/i',
 		);
 
@@ -3895,6 +3900,48 @@ PROMPT;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Extract JSON arguments from an XML-ish text tool call.
+	 *
+	 * Calls that only contain a tool name retain the legacy empty-arguments
+	 * behaviour. A call that opens an argument list must contain one valid JSON
+	 * object; malformed arguments are rejected rather than executing the ability
+	 * with an empty payload.
+	 *
+	 * @param string $text Assistant text.
+	 * @return array<string,mixed>|null Parsed arguments, or null when malformed.
+	 */
+	private function extract_text_tool_call_arguments( string $text ): ?array {
+		$opening_patterns  = array(
+			'/<tool_call>\s*[^\s<>(]+\s*\(/i',
+			'/<tool>\s*[^\s<>(]+\s*\(/i',
+		);
+		$argument_patterns = array(
+			'/<tool_call>\s*[^\s<>(]+\s*\(\s*(\{.*\})\s*\)\s*<\/tool_call>/is',
+			'/<tool>\s*[^\s<>(]+\s*\(\s*(\{.*\})\s*\)\s*<\/tool>/is',
+		);
+
+		foreach ( $opening_patterns as $index => $opening_pattern ) {
+			if ( ! preg_match( $opening_pattern, $text ) ) {
+				continue;
+			}
+
+			$matches = array();
+			if ( ! preg_match( $argument_patterns[ $index ], $text, $matches ) ) {
+				return null;
+			}
+
+			$arguments = json_decode( (string) $matches[1], true );
+			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $arguments ) || array_is_list( $arguments ) ) {
+				return null;
+			}
+
+			return $arguments;
+		}
+
+		return array();
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -376,6 +376,75 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * XML-ish text calls with JSON arguments should preserve the payload.
+	 */
+	public function test_intercepts_xml_tool_call_text_with_json_arguments(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		if ( ! function_exists( 'wp_has_ability' ) || ! wp_has_ability( 'sd-ai-agent/update-template-part' ) ) {
+			$this->markTestSkipped( 'sd-ai-agent/update-template-part ability is not registered.' );
+		}
+
+		$arguments = array(
+			'id'                    => 'twentytwentyfive//header',
+			'expected_content_hash' => 'abc123',
+			'content'               => '<!-- wp:group {"layout":{"type":"flex"}} /-->',
+		);
+		$loop      = new AgentLoop( 'Repair the header.' );
+		$message   = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					'<tool_call>wpab__sd-ai-agent__update-template-part(' . wp_json_encode( $arguments ) . ')</tool_call> Tool call emitted as text.'
+				),
+			)
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'intercept_text_tool_call' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertInstanceOf( \WordPress\AiClient\Messages\DTO\Message::class, $result );
+		$call = $result->getParts()[0]->getFunctionCall();
+		$this->assertInstanceOf( \WordPress\AiClient\Tools\DTO\FunctionCall::class, $call );
+		$this->assertSame( 'wpab__sd-ai-agent__ability-call', $call->getName() );
+		$this->assertSame(
+			array(
+				'ability'   => 'sd-ai-agent/update-template-part',
+				'arguments' => $arguments,
+			),
+			$call->getArgs()
+		);
+	}
+
+	/**
+	 * Malformed XML-ish text call arguments should request a structured retry.
+	 */
+	public function test_rejects_malformed_xml_tool_call_text_arguments(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop    = new AgentLoop( 'Repair the header.' );
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					'<tool_call>wpab__sd-ai-agent__update-template-part({"id":})</tool_call>'
+				),
+			)
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'intercept_text_tool_call' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'malformed arguments', $result );
+		$this->assertStringContainsString( 'structured tool channel', $result );
+	}
+
+	/**
 	 * Unknown XML-ish tool-call text should produce corrective guidance for another loop turn.
 	 */
 	public function test_unknown_xml_tool_call_text_gets_corrective_prompt(): void {


### PR DESCRIPTION
## Summary

- recognize XML-style assistant tool calls that include a JSON argument object
- route recovered calls through `sd-ai-agent/ability-call` with the original arguments
- reject malformed or list-shaped argument payloads with corrective guidance instead of executing an empty call

## Context

A live Setup Assistant acceptance run emitted `update-template-part({...})` inside `<tool_call>` text. The existing interception only recognized name-only XML calls, so the markup became a user-visible final response and the required navigation repair never executed.

## Verification

- `pnpm verify`
- 4,256 PHPUnit tests, 19,563 assertions, 0 failures/errors, 137 skipped, 4 incomplete
- focused XML text-tool-call coverage: 4 tests, 15 assertions
