### PR TITLE
fix: load WordPress autosave dependencies

### DIFF
--- a/includes/Core/PagePreviewWorkspace.php
+++ b/includes/Core/PagePreviewWorkspace.php
@@ -267,6 +267,11 @@ final class PagePreviewWorkspace {
 			);
 		}
 
+		$dependencies = self::ensure_autosave_dependencies();
+		if ( is_wp_error( $dependencies ) ) {
+			return $dependencies;
+		}
+
 		$scope = self::claim_context_scope( $post_id );
 		if ( is_wp_error( $scope ) ) {
 			return $scope;
@@ -330,6 +335,26 @@ final class PagePreviewWorkspace {
 		update_metadata( 'post', (int) $autosave_id, self::META_KEY, $metadata );
 
 		return self::build_descriptor( $parent, (int) $autosave_id, $metadata );
+	}
+
+	/** Load the admin-only callback registered by core for REST autosaves. */
+	private static function ensure_autosave_dependencies(): true|WP_Error {
+		if ( function_exists( 'wp_autosave_post_revisioned_meta_fields' ) ) {
+			return true;
+		}
+
+		$admin_post_file = ABSPATH . 'wp-admin/includes/post.php';
+		if ( ! is_readable( $admin_post_file ) ) {
+			return new WP_Error(
+				'sd_ai_agent_preview_autosave_dependency_missing',
+				__( 'WordPress could not load the autosave support required for the private page preview.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		require_once $admin_post_file;
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- load WordPress's admin-only autosave callback before the REST autosave controller runs on frontend agent requests
- fail with a bounded preview dependency error if the core support file is unavailable
- preserve the published page and preview scope until the dependency is ready

## Evidence

On WordPress 7.1, frontend Setup Assistant repairs reached `wp_creating_autosave` while `wp_autosave_post_revisioned_meta_fields()` was not loaded. This stopped the private preview before validation and left the public page unchanged.

## Worker self-verification
- PHPUnit: Tests: 4256, Assertions: 19564, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Manual verification

- `vendor/bin/phpcs includes/Core/PagePreviewWorkspace.php`
- focused `PagePreviewWorkspaceTest`: 9 tests, 44 assertions
- `pnpm run verify`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page preview autosave reliability when required WordPress functionality has not yet been loaded.
  * Prevented autosave creation failures by loading the necessary components automatically.
  * Added clearer error handling when the required WordPress file is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->