### PR TITLE
fix: deliver queued job interrupts

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3159,8 +3159,8 @@ final class SessionController {
 	/**
 	 * Handle POST /job/{id}/interrupt — inject a user message into a running job.
 	 *
-	 * Sets a flag on the job transient that the agent loop's progress callback
-	 * will pick up on the next poll cycle. The interrupt message is appended to
+	 * Queues a message on the job transient that the agent loop's interrupt
+	 * checker will consume on the next iteration. The interrupt message is appended to
 	 * the session in the database so it persists. The running agent loop will
 	 * see the interrupt on its next iteration and can incorporate the new context.
 	 *
@@ -3204,6 +3204,35 @@ final class SessionController {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Build the callback that consumes queued user interrupts.
+	 *
+	 * @param string $job_id Active job UUID.
+	 * @return \Closure(): ?array
+	 */
+	private static function build_job_interrupt_checker( string $job_id ): \Closure {
+		return static function () use ( $job_id ): ?array {
+			$transient_key = RestController::JOB_PREFIX . $job_id;
+			$job           = get_transient( $transient_key );
+
+			if ( ! is_array( $job ) || 'processing' !== ( $job['status'] ?? '' ) ) {
+				return null;
+			}
+
+			$current_interrupts = $job['interrupts'] ?? array();
+			$interrupts         = is_array( $current_interrupts ) ? array_values( $current_interrupts ) : array();
+			if ( empty( $interrupts ) ) {
+				return null;
+			}
+
+			$interrupt         = array_shift( $interrupts );
+			$job['interrupts'] = $interrupts;
+			set_transient( $transient_key, $job, RestController::JOB_TTL + 60 );
+
+			return is_array( $interrupt ) ? $interrupt : null;
+		};
 	}
 
 	/**
@@ -3699,7 +3728,8 @@ final class SessionController {
 		 * (b) register a shutdown handler that marks the row as 'interrupted'
 		 *     when the PHP process terminates before loop completion.
 		 */
-		$options['active_job_id'] = $job_id;
+		$options['active_job_id']     = $job_id;
+		$options['interrupt_checker'] = self::build_job_interrupt_checker( $job_id );
 
 		// Progress callback: write live tool-call activity and channel messages
 		// to the job transient so the polling frontend can display them incrementally.

--- a/tests/SdAiAgent/REST/SessionControllerTest.php
+++ b/tests/SdAiAgent/REST/SessionControllerTest.php
@@ -93,6 +93,44 @@ class SessionControllerTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'model_id', $annotated[2] );
 	}
 
+	/** Queued user steering reaches AgentLoop once and in FIFO order. */
+	public function test_job_interrupt_checker_consumes_queued_messages_in_order(): void {
+		$job_id = '00000000-0000-4000-8000-000000000199';
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'     => 'processing',
+				'user_id'    => $this->admin_id,
+				'interrupts' => [
+					[ 'message' => 'Stop inspecting and mutate.', 'timestamp' => 1 ],
+					[ 'message' => 'Then validate the preview.', 'timestamp' => 2 ],
+				],
+			],
+			RestController::JOB_TTL
+		);
+
+		$method = new \ReflectionMethod(
+			\SdAiAgent\REST\SessionController::class,
+			'build_job_interrupt_checker'
+		);
+		$method->setAccessible( true );
+		/** @var \Closure(): ?array $checker */
+		$checker = $method->invoke( null, $job_id );
+
+		$first = $checker();
+		$this->assertIsArray( $first );
+		$this->assertSame( 'Stop inspecting and mutate.', $first['message'] );
+		$second = $checker();
+		$this->assertIsArray( $second );
+		$this->assertSame( 'Then validate the preview.', $second['message'] );
+		$this->assertNull( $checker() );
+
+		$job = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $job );
+		$this->assertSame( [], $job['interrupts'] );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+	}
+
 	/** Durable-plan routes remain private session endpoints. */
 	public function test_durable_plan_routes_are_registered(): void {
 		$routes = $this->server->get_routes();


### PR DESCRIPTION
## Summary

- wire each processing job's queued interrupt transient into `AgentLoop` through `interrupt_checker`
- consume queued messages once in FIFO order while preserving the live job transient
- add focused regression coverage for ordered, one-time consumption

## Verification

- `vendor/bin/phpcs includes/REST/SessionController.php tests/SdAiAgent/REST/SessionControllerTest.php`
- `php bin/run-wp-phpunit.php tests/SdAiAgent/REST/SessionControllerTest.php` (13 tests, 124 assertions)
- `php -d memory_limit=2G vendor/bin/phpstan analyse includes/REST/SessionController.php --memory-limit=2G`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of messages sent while background jobs are running.
  - Queued messages are now processed in the order received, one at a time during job execution.

- **Bug Fixes**
  - Prevented queued interruptions from being skipped or processed out of order.

- **Tests**
  - Added coverage verifying ordered message processing and proper queue cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->