### PR TITLE
GH#2616: assert queued navigation origin

### DIFF
--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -516,9 +516,14 @@ test.describe( 'client-abilities — navigate-to execution', () => {
 			path: 'plugins.php',
 		} );
 		// The queued URL must be the validated same-origin admin destination.
-		expect( result.pendingNavigation ).toMatch(
-			/\/wp-admin\/plugins\.php$/
+		const pendingNavigationUrl = new URL(
+			result.pendingNavigation,
+			page.url()
 		);
+		expect( pendingNavigationUrl.origin ).toBe(
+			new URL( page.url() ).origin
+		);
+		expect( pendingNavigationUrl.pathname ).toBe( '/wp-admin/plugins.php' );
 	} );
 } );
 


### PR DESCRIPTION
## Summary

Resolves the review finding by resolving queued navigation against the active page and asserting its origin and plugins endpoint.

## Files Changed

tests/e2e/client-abilities.spec.js

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Manual diff review and targeted ESLint attempted; the lint command is blocked by the pre-existing missing @wordpress/eslint-plugin dependency.

Resolves #2616


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 2m and 50,758 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for queued navigation.
  * Added explicit verification that navigation stays on the same origin and reaches the expected plugins administration page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->