### PR TITLE
GH#2618: strengthen setup completion contract coverage

### DIFF
--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -293,6 +293,7 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 
 		foreach ( [
 			'anonymous rendered header and footer',
+			'remove or replace every visible default-theme link group in both regions',
 			'every visible default-theme link group',
 			'default footer navigation',
 			'`sd-ai-agent/list-template-parts` with `area: footer`',
@@ -303,6 +304,22 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 		] as $required ) {
 			$this->assertStringContainsString( $required, $agent->system_prompt );
 		}
+
+		$navigation_position   = strpos( $agent->system_prompt, 'Inspect the anonymous rendered header and footer' );
+		$page_quality_position = strpos( $agent->system_prompt, 'AgentLoop can dispatch `sd-ai-agent-js/validate-page-quality`' );
+		$visual_review_position = strpos( $agent->system_prompt, 'then call `sd-ai-agent/submit-page-visual-review` only with evidence-backed passing scores' );
+		$memory_position       = strpos( $agent->system_prompt, 'Save the final site brief and chosen design direction' );
+		$success_position      = strpos( $agent->system_prompt, 'Reply with a short success message including the live homepage URL' );
+
+		$this->assertNotFalse( $navigation_position );
+		$this->assertNotFalse( $page_quality_position );
+		$this->assertNotFalse( $visual_review_position );
+		$this->assertNotFalse( $memory_position );
+		$this->assertNotFalse( $success_position );
+		$this->assertLessThan( $page_quality_position, $navigation_position );
+		$this->assertLessThan( $visual_review_position, $page_quality_position );
+		$this->assertLessThan( $memory_position, $visual_review_position );
+		$this->assertLessThan( $success_position, $memory_position );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Require the Setup Assistant's explicit default-navigation replacement action.
- Assert the completion gates remain ordered from navigation inspection through final success reporting.

## Worker self-verification

- PHPUnit: Tests: 4257, Assertions: 19583, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

## Runtime Testing

- Self-assessed: test-only change with no runtime behavior change.

Resolves #2618

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 11m and 72,943 tokens on this as a headless worker.
