### PR TITLE
fix: discover third-party form abilities (#2622)

### DIFF
--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -334,6 +334,8 @@ class SystemInstructionBuilder {
 			. 'Active first-party direct tools this turn: ' . $direct_list . ".\n"
 			. 'If any prompt, memory, or manifest text mentions another `sd-ai-agent/<ability>` name, do not emit its direct `wpab__...` tool call. '
 			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`. '
+			. 'Before saying a requested capability is unavailable because it is not a direct tool, run a keyword `sd-ai-agent/ability-search` using the user\'s task words (for example, `create form`). '
+			. 'This can discover visible third-party abilities; after search returns a matching schema, invoke that ability through `sd-ai-agent/ability-call`. '
 			. 'For any ability listed in the catalog below, you MUST call `sd-ai-agent/ability-call` with `{"ability":"<name>","arguments":{...}}`; never write `<tool_call>wpab__...` or the ability name as text in the reply.';
 	}
 

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -284,6 +284,18 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 			'then invoke it through `sd-ai-agent/ability-call`',
 			$instruction
 		);
+		$this->assertStringContainsString(
+			'Before saying a requested capability is unavailable',
+			$instruction
+		);
+		$this->assertStringContainsString(
+			'`create form`',
+			$instruction
+		);
+		$this->assertStringContainsString(
+			'visible third-party abilities',
+			$instruction
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Require keyword capability discovery before the agent refuses a request whose tool is not directly loaded.
- Direct the agent to invoke matching visible third-party abilities through the existing schema-mediated ability-call path.
- Cover the prompt-routing regression for `create form` requests.

Resolves #2622

## Worker self-verification
- PHPUnit: Tests: 4257, Assertions: 19587, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved capability discovery so supported abilities can be found through keyword search.
  - Enables matching discovered abilities to be invoked instead of incorrectly reporting them as unavailable.

- **Bug Fixes**
  - Prevents supported third-party capabilities, such as form creation, from being incorrectly treated as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->