### PR TITLE
GH#2624: share client ability registry

### DIFF
--- a/src/abilities/__tests__/registry.test.js
+++ b/src/abilities/__tests__/registry.test.js
@@ -18,10 +18,9 @@
  */
 
 /**
- * Each test loads a fresh registry module via jest.isolateModules so the
- * module-scoped `registeredAbilityNames` and `clientCallbacks` Maps start
- * empty. This avoids cross-test bleed while still exercising the real
- * registry code (not a mock).
+ * Each test loads a fresh registry module via jest.isolateModules. The
+ * page-global registry is cleared in beforeEach so tests avoid cross-test
+ * bleed while still exercising the real registry code (not a mock).
  */
 function loadRegistry() {
 	let mod;
@@ -31,6 +30,8 @@ function loadRegistry() {
 	} );
 	return mod;
 }
+
+const WIN_REGISTRY_KEY = '__sdAiAgentClientAbilityRegistry';
 
 /**
  * Load refresh-page and its matching registry module instance.
@@ -54,10 +55,70 @@ describe( 'registry — sd-ai-86a regression', () => {
 
 	beforeEach( () => {
 		originalWp = global.wp;
+		delete window[ WIN_REGISTRY_KEY ];
 	} );
 
 	afterEach( () => {
 		global.wp = originalWp;
+		delete window[ WIN_REGISTRY_KEY ];
+	} );
+
+	test( 'shares callbacks and descriptors between webpack module instances without the WP API', async () => {
+		delete global.wp;
+		const firstBundle = loadRegistry();
+		const secondBundle = loadRegistry();
+		const callback = jest.fn().mockResolvedValue( { shared: true } );
+
+		await firstBundle.registerClientAbility( {
+			name: 'sd-ai-agent-js/cross-bundle',
+			label: 'Cross Bundle',
+			description: 'Registered by another bundle',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback,
+		} );
+
+		await expect(
+			secondBundle.executeClientAbility( 'sd-ai-agent-js/cross-bundle', {
+				from: 'second-bundle',
+			} )
+		).resolves.toEqual( { shared: true } );
+		expect( callback ).toHaveBeenCalledWith( { from: 'second-bundle' } );
+		await expect( secondBundle.snapshotDescriptors() ).resolves.toEqual( [
+			expect.objectContaining( {
+				name: 'sd-ai-agent-js/cross-bundle',
+				annotations: { readonly: true },
+			} ),
+		] );
+	} );
+
+	test( 'deduplicates WP ability registration between webpack module instances', async () => {
+		const registerAbility = jest.fn().mockResolvedValue( undefined );
+		global.wp = {
+			abilities: {
+				registerAbility,
+				registerAbilityCategory: jest
+					.fn()
+					.mockResolvedValue( undefined ),
+			},
+		};
+		const firstBundle = loadRegistry();
+		const secondBundle = loadRegistry();
+		const definition = {
+			name: 'sd-ai-agent-js/deduplicated',
+			label: 'Deduplicated',
+			description: 'Shared registration state',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback: jest.fn(),
+		};
+
+		await firstBundle.registerClientAbility( definition );
+		await secondBundle.registerClientAbility( definition );
+
+		expect( registerAbility ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'registerClientAbility stores callback locally even when wp.abilities is undefined', async () => {

--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -89,6 +89,9 @@ export function ensureRegistered() {
 	// Promise so we don't call wp.abilities.registerAbilityCategory() a
 	// second time (each call can trigger a REST fetch in WP 7.0-RC2).
 	if ( window[ WIN_REGISTRATION_KEY ] ) {
+		// The registry module keeps callback execution state page-global, so a
+		// bundle that reuses this Promise can execute abilities registered by
+		// the bundle that created it even without wp.abilities.executeAbility().
 		registrationPromise = window[ WIN_REGISTRATION_KEY ];
 		return registrationPromise;
 	}

--- a/src/abilities/registry.js
+++ b/src/abilities/registry.js
@@ -47,46 +47,47 @@ const CATEGORY_DESCRIPTION = __(
 );
 
 /**
- * Single category-registration Promise shared across all callers in the
- * same module instance, so concurrent ensureRegistered() calls await the
- * same in-flight registration instead of racing.
+ * Window-global key used to share client-ability state between webpack module
+ * instances. Each entry-point bundle has its own module scope, but they all
+ * execute in the same browser page.
+ *
+ * @type {string}
+ */
+const WIN_REGISTRY_KEY = '__sdAiAgentClientAbilityRegistry';
+
+/**
+ * Single category-registration Promise for this module instance. Cross-bundle
+ * category registration is already coordinated by index.js.
  *
  * @type {Promise<void>|null}
  */
 let categoryRegistrationPromise = null;
 
 /**
- * Per-ability deduplication set so the same ability isn't registered
- * twice from a second bundle on the same page (each entry-point bundle
- * has its own module instance).
+ * Return the page-lifetime client-ability registry.
  *
- * @type {Set<string>}
+ * The registration coordinator in index.js is already page-global. Its
+ * callback and descriptor state must be page-global too: otherwise a second
+ * bundle can await the first bundle's registration Promise but still be
+ * unable to execute the ability from its own module-local Map.
+ *
+ * @return {{n: Set<string>, c: Map<string, Function>, d: Map<string, Object>}} Shared browser-page state.
  */
-const registeredAbilityNames = new Set();
+function getPageRegistry() {
+	const page = window;
 
-/**
- * Callback map — name → async function(args) → result.
- *
- * Maintained in parallel to the WP 7.0 registry so jobSlice can invoke
- * abilities by name without relying on wp.abilities.executeAbility() (which
- * may not be available or may not surface the raw return value we need).
- *
- * @type {Map<string, Function>}
- */
-const clientCallbacks = new Map();
+	if ( page[ WIN_REGISTRY_KEY ] ) {
+		return page[ WIN_REGISTRY_KEY ];
+	}
 
-/**
- * Descriptor map — name → serializable descriptor.
- *
- * This mirrors the locally registered callback set so snapshotDescriptors()
- * can still post client abilities to /chat on pages where the WP abilities
- * global/store is unavailable. Without this fallback the server only exposes
- * sd-ai-agent-js/* via ability-search/ability-call stubs, and calling those
- * stubs cannot execute browser actions such as refresh-page.
- *
- * @type {Map<string, Object>}
- */
-const localDescriptors = new Map();
+	page[ WIN_REGISTRY_KEY ] = {
+		n: new Set(),
+		c: new Map(),
+		d: new Map(),
+	};
+
+	return page[ WIN_REGISTRY_KEY ];
+}
 
 /**
  * Detect whether the WP 7.0 abilities API is available on this page.
@@ -165,6 +166,9 @@ export async function registerCategory() {
 
 		if ( ! abilitiesApiAvailable() ) {
 			// API never became available (e.g. not a WP 7.0+ site). Skip silently.
+			// Clear the module value so a later call can retry after the core
+			// script module becomes available.
+			categoryRegistrationPromise = null;
 			return;
 		}
 
@@ -207,10 +211,12 @@ export async function registerClientAbility( def ) {
 	if ( ! def || typeof def.name !== 'string' || def.name === '' ) {
 		return;
 	}
-	if ( registeredAbilityNames.has( def.name ) ) {
+
+	const registry = getPageRegistry();
+	if ( registry.n.has( def.name ) ) {
 		return;
 	}
-	registeredAbilityNames.add( def.name );
+	registry.n.add( def.name );
 
 	// Store the callback so executeClientAbility() can invoke it by name
 	// without going through the WP abilities API (which may not expose the
@@ -227,9 +233,9 @@ export async function registerClientAbility( def ) {
 	// 'Client ability "..." is not registered on this page' even though
 	// the callback function is present in the bundle.
 	if ( typeof def.callback === 'function' ) {
-		clientCallbacks.set( def.name, def.callback );
+		registry.c.set( def.name, def.callback );
 	}
-	localDescriptors.set( def.name, {
+	registry.d.set( def.name, {
 		name: def.name,
 		label: def.label || def.name,
 		description: def.description || '',
@@ -303,12 +309,14 @@ export async function registerClientAbility( def ) {
  * @return {Promise<Array<{name: string, label: string, description: string, input_schema: Object, output_schema: Object, annotations: Object}>>} Promise of client ability descriptors.
  */
 export async function snapshotDescriptors() {
+	const registry = getPageRegistry();
+
 	if (
 		typeof wp === 'undefined' ||
 		! wp.abilities ||
 		typeof wp.abilities.getAbilities !== 'function'
 	) {
-		return Array.from( localDescriptors.values() );
+		return Array.from( registry.d.values() );
 	}
 
 	try {
@@ -332,9 +340,9 @@ export async function snapshotDescriptors() {
 
 		return descriptors.length
 			? descriptors
-			: Array.from( localDescriptors.values() );
+			: Array.from( registry.d.values() );
 	} catch ( _err ) {
-		return Array.from( localDescriptors.values() );
+		return Array.from( registry.d.values() );
 	}
 }
 
@@ -351,7 +359,7 @@ export async function snapshotDescriptors() {
  * @throws {Error} When the ability is not registered in the current page.
  */
 export async function executeClientAbility( name, args ) {
-	const callback = clientCallbacks.get( name );
+	const callback = getPageRegistry().c.get( name );
 	if ( callback ) {
 		return callback( args );
 	}


### PR DESCRIPTION
## Summary

Shared client ability callbacks, descriptors, and registration state across webpack bundle instances.

## Files Changed

src/abilities/__tests__/registry.test.js, src/abilities/index.js, src/abilities/registry.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:js -- src/abilities/__tests__/registry.test.js --runInBand; pnpm run lint:js

Resolves #2624


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 5m and 82,447 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ability registration across multiple app bundles on the same page.
  * Prevented duplicate registrations when shared functionality is initialized more than once.
  * Ensured callbacks and ability details remain available consistently across bundle instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->