### PR TITLE
GH#2625: fix: gate restored jobs on client ability readiness

### DIFF
--- a/src/components/chat-widget/widget-launcher.css
+++ b/src/components/chat-widget/widget-launcher.css
@@ -34,7 +34,7 @@
 		ui-monospace, sfmono-regular, "SF Mono", Menlo, Consolas, monospace;
 }
 
-.sdaa-w-launcher {
+.sd-ai-agent-w-launcher {
 	position: fixed;
 	right: 36px;
 	bottom: 28px;
@@ -55,25 +55,25 @@
 	transition: transform var(--sdaa-w-duration), background var(--sdaa-w-duration);
 }
 
-.sdaa-w-launcher:hover {
+.sd-ai-agent-w-launcher:hover {
 	background: var(--sdaa-w-primary-dark);
 	transform: translateY(-1px);
 }
 
-.sdaa-w-launcher svg {
+.sd-ai-agent-w-launcher svg {
 	width: 24px;
 	height: 24px;
 	fill: currentcolor;
 }
 
-.sdaa-w-launcher-logo {
+.sd-ai-agent-w-launcher-logo {
 	width: 26px;
 	height: 26px;
 	border-radius: 3px;
 	object-fit: contain;
 }
 
-.sdaa-w-launcher-pulse {
+.sd-ai-agent-w-launcher-pulse {
 	position: absolute;
 	top: -2px;
 	right: -2px;
@@ -85,7 +85,7 @@
 	animation: sdaa-w-pulse 1.5s ease-in-out infinite;
 }
 
-.sdaa-w-launcher-badge {
+.sd-ai-agent-w-launcher-badge {
 	position: absolute;
 	top: -4px;
 	right: -4px;
@@ -118,14 +118,14 @@
 }
 
 @media (max-width: 500px) {
-	.sdaa-w-launcher {
+	.sd-ai-agent-w-launcher {
 		right: 16px;
 		bottom: 16px;
 		width: 44px;
 		height: 44px;
 	}
 
-	.sdaa-w-launcher svg {
+	.sd-ai-agent-w-launcher svg {
 		width: 20px;
 		height: 20px;
 	}

--- a/src/components/chat-widget/widget-launcher.js
+++ b/src/components/chat-widget/widget-launcher.js
@@ -16,6 +16,7 @@ import { AiIcon } from '../chat-redesign/icons';
 import useDrag from './use-drag';
 
 const LAUNCHER_POSITION_STORAGE_KEY = 'aiAgentWidgetLauncherPosition';
+const LAUNCHER_CLASS_NAME = 'sd-ai-agent-w-launcher';
 
 /**
  * @param {Object}   root0              Component props.
@@ -78,7 +79,7 @@ export default function WidgetLauncher( { onActivate, label: labelOverride } ) {
 	return (
 		<button
 			type="button"
-			className="sdaa-w-launcher"
+			className={ LAUNCHER_CLASS_NAME }
 			data-drag-target="true"
 			style={ positionStyle }
 			onMouseDown={ handleMouseDown }
@@ -90,16 +91,18 @@ export default function WidgetLauncher( { onActivate, label: labelOverride } ) {
 				<img
 					src={ branding.logoUrl }
 					alt=""
-					className="sdaa-w-launcher-logo"
+					className={ `${ LAUNCHER_CLASS_NAME }-logo` }
 					aria-hidden="true"
 				/>
 			) : (
 				<AiIcon thinking={ isRunning } size={ 24 } />
 			) }
-			{ isRunning && <span className="sdaa-w-launcher-pulse" /> }
+			{ isRunning && (
+				<span className={ `${ LAUNCHER_CLASS_NAME }-pulse` } />
+			) }
 			{ alertCount > 0 && (
 				<span
-					className="sdaa-w-launcher-badge"
+					className={ `${ LAUNCHER_CLASS_NAME }-badge` }
 					aria-label={ sprintf(
 						/* translators: %d: number of alerts */
 						__( '%d alert(s)', 'sd-ai-agent' ),

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -73,6 +73,7 @@ const {
 } = require( '../slices/active-job-failure-diagnostic' );
 const apiFetch = require( '@wordpress/api-fetch' );
 const { executeClientAbility } = require( '../../abilities/registry' );
+const clientToolRunner = require( '../slices/client-tool-runner' );
 
 // ─── Default state ────────────────────────────────────────────────────────────
 
@@ -838,6 +839,67 @@ describe( 'actions', () => {
 				},
 			} );
 		} finally {
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
+	test( 'pollJob posts normalized failures when the client tool runner rejects', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		const runnerError = new Error( 'Client tool runner failed to load.' );
+		const runClientTools = jest
+			.spyOn( clientToolRunner, 'runClientTools' )
+			.mockRejectedValueOnce( runnerError );
+		apiFetch.mockImplementation( ( request ) => {
+			if ( request.path === '/sd-ai-agent/v1/job/runner-failure-job' ) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'runner-failure-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							annotations: { readonly: true },
+							args: { url: '/' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( { status: 'processing' } );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'runner-failure-job' ),
+		};
+
+		try {
+			actions.pollJob( 'runner-failure-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+
+			expect( runClientTools ).toHaveBeenCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'runner-failure-job',
+					tool_results: [
+						{
+							id: 'runner-failure-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							error: runnerError.message,
+						},
+					],
+				},
+			} );
+		} finally {
+			runClientTools.mockRestore();
 			jest.clearAllTimers();
 			jest.useRealTimers();
 		}

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -1055,6 +1055,88 @@ describe( 'actions', () => {
 						{
 							id: 'timed-out-readiness-screenshot',
 							name: 'sd-ai-agent-js/screenshot-url',
+							error: 'Client ability registration timed out after 30 seconds.',
+						},
+					],
+				},
+			} );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
+	test( 'pollJob gives a restored client ability its full timeout after readiness', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		executeClientAbility.mockReset();
+		let resolveReadiness;
+		window.__sdAiAgentAbilitiesRegistering = new Promise( ( resolve ) => {
+			resolveReadiness = resolve;
+		} );
+		executeClientAbility.mockImplementation(
+			() => new Promise( () => {} )
+		);
+		apiFetch.mockImplementation( ( request ) => {
+			if ( request.path === '/sd-ai-agent/v1/job/readiness-window-job' ) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'readiness-window-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							annotations: { readonly: true },
+							args: { url: '/' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( {} );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'readiness-window-job' ),
+		};
+
+		try {
+			actions.pollJob(
+				'readiness-window-job',
+				17
+			)( {
+				dispatch,
+				select,
+			} );
+			await jest.advanceTimersByTimeAsync( 29000 );
+			resolveReadiness();
+			await jest.advanceTimersByTimeAsync( 0 );
+			await jest.advanceTimersByTimeAsync( 29000 );
+
+			expect( executeClientAbility ).toHaveBeenCalledTimes( 1 );
+			expect(
+				apiFetch.mock.calls.filter(
+					( [ request ] ) =>
+						request.path === '/sd-ai-agent/v1/chat/tool-result'
+				)
+			).toHaveLength( 0 );
+
+			await jest.advanceTimersByTimeAsync( 1000 );
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'readiness-window-job',
+					tool_results: [
+						{
+							id: 'readiness-window-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
 							error: 'Client tool timed out after 30 seconds.',
 						},
 					],

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -973,9 +973,7 @@ describe( 'actions', () => {
 				select,
 			} );
 			await jest.advanceTimersByTimeAsync( 2000 );
-			rejectReadiness(
-				new Error( 'Client ability registration failed.' )
-			);
+			rejectReadiness( new Error( '' ) );
 			await jest.advanceTimersByTimeAsync( 0 );
 
 			expect( executeClientAbility ).not.toHaveBeenCalled();
@@ -989,7 +987,75 @@ describe( 'actions', () => {
 						{
 							id: 'failed-readiness-screenshot',
 							name: 'sd-ai-agent-js/screenshot-url',
-							error: 'Error: Client ability registration failed.',
+							error: 'Error',
+						},
+					],
+				},
+			} );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
+	test( 'pollJob times out stalled client-ability registration without executing abilities', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		executeClientAbility.mockReset();
+		window.__sdAiAgentAbilitiesRegistering = new Promise( () => {} );
+		apiFetch.mockImplementation( ( request ) => {
+			if (
+				request.path === '/sd-ai-agent/v1/job/readiness-timeout-job'
+			) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'timed-out-readiness-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							annotations: { readonly: true },
+							args: { url: '/' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( {} );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'readiness-timeout-job' ),
+		};
+
+		try {
+			actions.pollJob(
+				'readiness-timeout-job',
+				17
+			)( {
+				dispatch,
+				select,
+			} );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			await jest.advanceTimersByTimeAsync( 30_000 );
+
+			expect( executeClientAbility ).not.toHaveBeenCalled();
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'readiness-timeout-job',
+					tool_results: [
+						{
+							id: 'timed-out-readiness-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							error: 'Client tool timed out after 30 seconds.',
 						},
 					],
 				},

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -843,6 +843,164 @@ describe( 'actions', () => {
 		}
 	} );
 
+	test( 'pollJob waits for restored client-ability callbacks before executing or posting once', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		executeClientAbility.mockReset();
+		let resolveReadiness;
+		window.__sdAiAgentAbilitiesRegistering = new Promise( ( resolve ) => {
+			resolveReadiness = resolve;
+		} );
+		executeClientAbility.mockResolvedValue( { captured: true } );
+		apiFetch.mockImplementation( ( request ) => {
+			if (
+				request.path === '/sd-ai-agent/v1/job/restored-client-tool-job'
+			) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'restored-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							annotations: { readonly: true },
+							args: { url: '/' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( {} );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'restored-client-tool-job' ),
+		};
+
+		try {
+			actions.pollJob(
+				'restored-client-tool-job',
+				17
+			)( {
+				dispatch,
+				select,
+			} );
+			await jest.advanceTimersByTimeAsync( 2000 );
+
+			expect( executeClientAbility ).not.toHaveBeenCalled();
+			expect(
+				apiFetch.mock.calls.filter(
+					( [ request ] ) =>
+						request.path === '/sd-ai-agent/v1/chat/tool-result'
+				)
+			).toHaveLength( 0 );
+
+			resolveReadiness();
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( executeClientAbility ).toHaveBeenCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'restored-client-tool-job',
+					tool_results: [
+						{
+							id: 'restored-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							result: { captured: true },
+						},
+					],
+				},
+			} );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
+	test( 'pollJob posts a bounded readiness failure without executing client abilities', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		executeClientAbility.mockReset();
+		let rejectReadiness;
+		window.__sdAiAgentAbilitiesRegistering = new Promise(
+			( _resolve, reject ) => {
+				rejectReadiness = reject;
+			}
+		);
+		apiFetch.mockImplementation( ( request ) => {
+			if (
+				request.path === '/sd-ai-agent/v1/job/readiness-failure-job'
+			) {
+				return Promise.resolve( {
+					status: 'awaiting_client_tools',
+					pending_client_tool_calls: [
+						{
+							id: 'failed-readiness-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							annotations: { readonly: true },
+							args: { url: '/' },
+						},
+					],
+				} );
+			}
+
+			return Promise.resolve( {} );
+		} );
+
+		const dispatch = {
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'readiness-failure-job' ),
+		};
+
+		try {
+			actions.pollJob(
+				'readiness-failure-job',
+				17
+			)( {
+				dispatch,
+				select,
+			} );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			rejectReadiness(
+				new Error( 'Client ability registration failed.' )
+			);
+			await jest.advanceTimersByTimeAsync( 0 );
+
+			expect( executeClientAbility ).not.toHaveBeenCalled();
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/sd-ai-agent/v1/chat/tool-result',
+				method: 'POST',
+				data: {
+					session_id: 17,
+					job_id: 'readiness-failure-job',
+					tool_results: [
+						{
+							id: 'failed-readiness-screenshot',
+							name: 'sd-ai-agent-js/screenshot-url',
+							error: 'Client ability registration failed.',
+						},
+					],
+				},
+			} );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
 	test( 'pollJob posts a timeout error when a client ability never resolves', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -832,7 +832,7 @@ describe( 'actions', () => {
 						{
 							id: 'call-unconfirmed-insert',
 							name: 'sd-ai-agent-js/insert-block',
-							error: 'Client-side ability requires explicit user confirmation.',
+							error: 'Confirmation required.',
 						},
 					],
 				},
@@ -989,7 +989,7 @@ describe( 'actions', () => {
 						{
 							id: 'failed-readiness-screenshot',
 							name: 'sd-ai-agent-js/screenshot-url',
-							error: 'Client ability registration failed.',
+							error: 'Error: Client ability registration failed.',
 						},
 					],
 				},

--- a/src/store/slices/client-tool-runner.js
+++ b/src/store/slices/client-tool-runner.js
@@ -1,0 +1,93 @@
+import { __ } from '@wordpress/i18n';
+import { executeClientAbility } from '../../abilities/registry';
+
+/**
+ * Reject a promise after a bounded interval and clear the timer on settlement.
+ *
+ * @param {Promise|*} promise   Value or promise to await.
+ * @param {number}    timeoutMs Maximum wait in milliseconds.
+ * @param {string}    message   Timeout error message.
+ * @return {Promise<*>} The bounded promise.
+ */
+function withTimeout( promise, timeoutMs, message ) {
+	let timeoutId;
+	return Promise.race( [
+		Promise.resolve( promise ).finally( () => clearTimeout( timeoutId ) ),
+		new Promise( ( _resolve, reject ) => {
+			timeoutId = setTimeout( reject, timeoutMs, new Error( message ) );
+		} ),
+	] );
+}
+
+/**
+ * Run a server-approved batch of browser abilities with bounded readiness and
+ * per-ability execution windows.
+ *
+ * @param {Array<Object>} pendingClientToolCalls Pending browser calls.
+ * @return {Promise<Array<Object>>} Serializable tool results.
+ */
+export async function runClientTools( pendingClientToolCalls ) {
+	const readiness = pendingClientToolCalls.some(
+		( { annotations, user_confirmed: userConfirmed } ) =>
+			annotations?.readonly === true || userConfirmed === true
+	)
+		? withTimeout(
+				window.__sdAiAgentAbilitiesRegistering,
+				30000,
+				'Client ability registration timed out after 30 seconds.'
+		  )
+		: null;
+
+	return Promise.all(
+		pendingClientToolCalls.map(
+			async ( {
+				id,
+				name,
+				client_name: clientName,
+				args = {},
+				annotations,
+				user_confirmed: userConfirmed,
+			} ) => {
+				const abilityName = clientName || name;
+				const timeoutMs =
+					abilityName === 'sd-ai-agent-js/validate-page-quality'
+						? 120000
+						: 30000;
+
+				if (
+					annotations?.readonly !== true &&
+					userConfirmed !== true
+				) {
+					return {
+						id,
+						name,
+						error: __(
+							'Confirmation required.',
+							'superdav-ai-agent'
+						),
+					};
+				}
+
+				try {
+					await readiness;
+					const abilityResult = await withTimeout(
+						executeClientAbility( abilityName, args ),
+						timeoutMs,
+						`Client tool timed out after ${
+							timeoutMs / 1000
+						} seconds.`
+					);
+					return { id, name, result: abilityResult };
+				} catch ( execErr ) {
+					return {
+						id,
+						name,
+						error: String(
+							execErr?.message || execErr || Error.name
+						),
+					};
+				}
+			}
+		)
+	);
+}

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -645,6 +645,15 @@ export const actions = {
 						const pendingCalls =
 							result.pending_client_tool_calls || [];
 
+						// Restored jobs can begin polling before the asynchronously loaded
+						// browser-ability bundles finish registration. Wait once for the
+						// shared callback pipeline before running the batch, so a valid
+						// saved call cannot become a false "not registered" result.
+						const readinessError =
+							await window.__sdAiAgentAbilitiesRegistering?.catch(
+								( err ) => err.message
+							);
+
 						const toolResults = await Promise.all(
 							pendingCalls.map( async ( call ) => {
 								const abilityName =
@@ -654,12 +663,11 @@ export const actions = {
 									'sd-ai-agent-js/validate-page-quality'
 										? 120000
 										: 30000;
-								const isReadonly =
-									call.annotations?.readonly === true;
-								const isUserConfirmed =
-									call.user_confirmed === true;
 
-								if ( ! isReadonly && ! isUserConfirmed ) {
+								if (
+									call.annotations?.readonly !== true &&
+									call.user_confirmed !== true
+								) {
 									// Mutating client abilities need an explicit server
 									// confirmation marker before browser execution.
 									return {
@@ -669,6 +677,14 @@ export const actions = {
 											'Client-side ability requires explicit user confirmation.',
 											'superdav-ai-agent'
 										),
+									};
+								}
+
+								if ( readinessError ) {
+									return {
+										id: call.id,
+										name: call.name,
+										error: readinessError,
 									};
 								}
 

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -14,7 +14,6 @@ import {
 	notifyConfirmationNeeded,
 } from '../../utils/notification-manager';
 import { playDing, playDong, playThinking } from '../../utils/sound-manager';
-import { executeClientAbility } from '../../abilities/registry';
 import { emitReflectionEvents } from '../reflection-emitter';
 
 // A session/job pair must have exactly one polling loop. Multiple mounted chat
@@ -22,38 +21,6 @@ import { emitReflectionEvents } from '../reflection-emitter';
 // duplicate pollers can execute one browser-tool batch twice and consume the
 // single-use paused state before the first poller receives its response.
 const activePollersByDispatch = new WeakMap();
-const CLIENT_ABILITY_READINESS_TIMEOUT_MS = 30000;
-
-/**
- * Wait for asynchronously loaded browser abilities without consuming an
- * individual ability's execution allowance.
- *
- * @return {Promise<void>} Resolves once browser abilities are ready.
- */
-function waitForClientAbilityReadiness() {
-	return new Promise( ( resolve, reject ) => {
-		const timeoutId = setTimeout( () => {
-			reject(
-				new Error(
-					`Client ability registration timed out after ${
-						CLIENT_ABILITY_READINESS_TIMEOUT_MS / 1000
-					} seconds.`
-				)
-			);
-		}, CLIENT_ABILITY_READINESS_TIMEOUT_MS );
-
-		Promise.resolve( window.__sdAiAgentAbilitiesRegistering ).then(
-			() => {
-				clearTimeout( timeoutId );
-				resolve();
-			},
-			( error ) => {
-				clearTimeout( timeoutId );
-				reject( error );
-			}
-		);
-	} );
-}
 
 /**
  * Merge real tool calls with assistant channel messages for live rendering.
@@ -678,91 +645,12 @@ export const actions = {
 						// browser-ability bundles finish registration. Wait once for the
 						// shared callback pipeline before running the batch, so a valid
 						// saved call cannot become a false "not registered" result.
-						const pendingClientToolCalls =
-							result.pending_client_tool_calls || [];
-						const readiness = pendingClientToolCalls.some(
-							( {
-								annotations,
-								user_confirmed: userConfirmed,
-							} ) =>
-								annotations?.readonly === true ||
-								userConfirmed === true
-						)
-							? waitForClientAbilityReadiness()
-							: null;
-						const toolResults = await Promise.all(
-							pendingClientToolCalls.map(
-								async ( {
-									id,
-									name,
-									client_name: clientName,
-									args = {},
-									annotations,
-									user_confirmed: userConfirmed,
-								} ) => {
-									const abilityName = clientName || name;
-									const timeoutMs =
-										abilityName ===
-										'sd-ai-agent-js/validate-page-quality'
-											? 120000
-											: 30000;
-
-									if (
-										annotations?.readonly !== true &&
-										userConfirmed !== true
-									) {
-										// Mutating client abilities need an explicit server
-										// confirmation marker before browser execution.
-										return {
-											id,
-											name,
-											error: __(
-												'Confirmation required.',
-												'superdav-ai-agent'
-											),
-										};
-									}
-
-									try {
-										await readiness;
-										const abilityResult =
-											await Promise.race( [
-												executeClientAbility(
-													abilityName,
-													args
-												),
-												new Promise(
-													( _resolve, reject ) =>
-														setTimeout(
-															reject,
-															timeoutMs,
-															new Error(
-																`Client tool timed out after ${
-																	timeoutMs /
-																	1000
-																} seconds.`
-															)
-														)
-												),
-											] );
-										return {
-											id,
-											name,
-											result: abilityResult,
-										};
-									} catch ( execErr ) {
-										return {
-											id,
-											name,
-											error: String(
-												execErr?.message ||
-													execErr ||
-													Error.name
-											),
-										};
-									}
-								}
-							)
+						const { runClientTools } = await import(
+							/* webpackChunkName: "client-tool-runner" */
+							'./client-tool-runner'
+						);
+						const toolResults = await runClientTools(
+							result.pending_client_tool_calls || []
 						);
 
 						// POST results back to the server so the agent loop

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -646,11 +646,6 @@ export const actions = {
 						// browser-ability bundles finish registration. Wait once for the
 						// shared callback pipeline before running the batch, so a valid
 						// saved call cannot become a false "not registered" result.
-						const readinessError =
-							await window.__sdAiAgentAbilitiesRegistering?.catch(
-								String
-							);
-
 						const toolResults = await Promise.all(
 							( result.pending_client_tool_calls || [] ).map(
 								async ( {
@@ -684,20 +679,16 @@ export const actions = {
 										};
 									}
 
-									if ( readinessError ) {
-										return {
-											id,
-											name,
-											error: readinessError,
-										};
-									}
-
 									try {
 										const abilityResult =
 											await Promise.race( [
-												executeClientAbility(
-													abilityName,
-													args
+												Promise.resolve(
+													window.__sdAiAgentAbilitiesRegistering
+												).then( () =>
+													executeClientAbility(
+														abilityName,
+														args
+													)
 												),
 												new Promise(
 													( _resolve, reject ) =>
@@ -723,7 +714,9 @@ export const actions = {
 											id,
 											name,
 											error: String(
-												execErr?.message ?? execErr
+												execErr?.message ||
+													execErr ||
+													Error.name
 											),
 										};
 									}

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -645,13 +645,27 @@ export const actions = {
 						// browser-ability bundles finish registration. Wait once for the
 						// shared callback pipeline before running the batch, so a valid
 						// saved call cannot become a false "not registered" result.
-						const { runClientTools } = await import(
-							/* webpackChunkName: "client-tool-runner" */
-							'./client-tool-runner'
-						);
-						const toolResults = await runClientTools(
-							result.pending_client_tool_calls || []
-						);
+						const pendingClientToolCalls =
+							result.pending_client_tool_calls || [];
+						let toolResults;
+						try {
+							const { runClientTools } = await import(
+								/* webpackChunkName: "client-tool-runner" */
+								'./client-tool-runner'
+							);
+							toolResults = await runClientTools(
+								pendingClientToolCalls
+							);
+						} catch ( runnerError ) {
+							const error = String(
+								runnerError?.message ||
+									runnerError ||
+									Error.name
+							);
+							toolResults = pendingClientToolCalls.map(
+								( { id, name } ) => ( { id, name, error } )
+							);
+						}
 
 						// POST results back to the server so the agent loop
 						// can continue with the screenshot/DOM data.

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -22,6 +22,38 @@ import { emitReflectionEvents } from '../reflection-emitter';
 // duplicate pollers can execute one browser-tool batch twice and consume the
 // single-use paused state before the first poller receives its response.
 const activePollersByDispatch = new WeakMap();
+const CLIENT_ABILITY_READINESS_TIMEOUT_MS = 30000;
+
+/**
+ * Wait for asynchronously loaded browser abilities without consuming an
+ * individual ability's execution allowance.
+ *
+ * @return {Promise<void>} Resolves once browser abilities are ready.
+ */
+function waitForClientAbilityReadiness() {
+	return new Promise( ( resolve, reject ) => {
+		const timeoutId = setTimeout( () => {
+			reject(
+				new Error(
+					`Client ability registration timed out after ${
+						CLIENT_ABILITY_READINESS_TIMEOUT_MS / 1000
+					} seconds.`
+				)
+			);
+		}, CLIENT_ABILITY_READINESS_TIMEOUT_MS );
+
+		Promise.resolve( window.__sdAiAgentAbilitiesRegistering ).then(
+			() => {
+				clearTimeout( timeoutId );
+				resolve();
+			},
+			( error ) => {
+				clearTimeout( timeoutId );
+				reject( error );
+			}
+		);
+	} );
+}
 
 /**
  * Merge real tool calls with assistant channel messages for live rendering.
@@ -646,8 +678,20 @@ export const actions = {
 						// browser-ability bundles finish registration. Wait once for the
 						// shared callback pipeline before running the batch, so a valid
 						// saved call cannot become a false "not registered" result.
+						const pendingClientToolCalls =
+							result.pending_client_tool_calls || [];
+						const readiness = pendingClientToolCalls.some(
+							( {
+								annotations,
+								user_confirmed: userConfirmed,
+							} ) =>
+								annotations?.readonly === true ||
+								userConfirmed === true
+						)
+							? waitForClientAbilityReadiness()
+							: null;
 						const toolResults = await Promise.all(
-							( result.pending_client_tool_calls || [] ).map(
+							pendingClientToolCalls.map(
 								async ( {
 									id,
 									name,
@@ -680,15 +724,12 @@ export const actions = {
 									}
 
 									try {
+										await readiness;
 										const abilityResult =
 											await Promise.race( [
-												Promise.resolve(
-													window.__sdAiAgentAbilitiesRegistering
-												).then( () =>
-													executeClientAbility(
-														abilityName,
-														args
-													)
+												executeClientAbility(
+													abilityName,
+													args
 												),
 												new Promise(
 													( _resolve, reject ) =>

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -642,86 +642,93 @@ export const actions = {
 						// confirmation dialog (screenshots, DOM reads, etc.).
 						// A mutating client ability executes only when the server
 						// returned `user_confirmed: true` after user approval.
-						const pendingCalls =
-							result.pending_client_tool_calls || [];
-
 						// Restored jobs can begin polling before the asynchronously loaded
 						// browser-ability bundles finish registration. Wait once for the
 						// shared callback pipeline before running the batch, so a valid
 						// saved call cannot become a false "not registered" result.
 						const readinessError =
 							await window.__sdAiAgentAbilitiesRegistering?.catch(
-								( err ) => err.message
+								String
 							);
 
 						const toolResults = await Promise.all(
-							pendingCalls.map( async ( call ) => {
-								const abilityName =
-									call.client_name || call.name;
-								const timeoutMs =
-									abilityName ===
-									'sd-ai-agent-js/validate-page-quality'
-										? 120000
-										: 30000;
+							( result.pending_client_tool_calls || [] ).map(
+								async ( {
+									id,
+									name,
+									client_name: clientName,
+									args = {},
+									annotations,
+									user_confirmed: userConfirmed,
+								} ) => {
+									const abilityName = clientName || name;
+									const timeoutMs =
+										abilityName ===
+										'sd-ai-agent-js/validate-page-quality'
+											? 120000
+											: 30000;
 
-								if (
-									call.annotations?.readonly !== true &&
-									call.user_confirmed !== true
-								) {
-									// Mutating client abilities need an explicit server
-									// confirmation marker before browser execution.
-									return {
-										id: call.id,
-										name: call.name,
-										error: __(
-											'Client-side ability requires explicit user confirmation.',
-											'superdav-ai-agent'
-										),
-									};
-								}
+									if (
+										annotations?.readonly !== true &&
+										userConfirmed !== true
+									) {
+										// Mutating client abilities need an explicit server
+										// confirmation marker before browser execution.
+										return {
+											id,
+											name,
+											error: __(
+												'Confirmation required.',
+												'superdav-ai-agent'
+											),
+										};
+									}
 
-								if ( readinessError ) {
-									return {
-										id: call.id,
-										name: call.name,
-										error: readinessError,
-									};
-								}
+									if ( readinessError ) {
+										return {
+											id,
+											name,
+											error: readinessError,
+										};
+									}
 
-								try {
-									const abilityResult = await Promise.race( [
-										executeClientAbility(
-											abilityName,
-											call.args || {}
-										),
-										new Promise( ( _resolve, reject ) =>
-											setTimeout(
-												reject,
-												timeoutMs,
-												new Error(
-													`Client tool timed out after ${
-														timeoutMs / 1000
-													} seconds.`
-												)
-											)
-										),
-									] );
-									return {
-										id: call.id,
-										name: call.name,
-										result: abilityResult,
-									};
-								} catch ( execErr ) {
-									return {
-										id: call.id,
-										name: call.name,
-										error:
-											execErr instanceof Error
-												? execErr.message
-												: String( execErr ),
-									};
+									try {
+										const abilityResult =
+											await Promise.race( [
+												executeClientAbility(
+													abilityName,
+													args
+												),
+												new Promise(
+													( _resolve, reject ) =>
+														setTimeout(
+															reject,
+															timeoutMs,
+															new Error(
+																`Client tool timed out after ${
+																	timeoutMs /
+																	1000
+																} seconds.`
+															)
+														)
+												),
+											] );
+										return {
+											id,
+											name,
+											result: abilityResult,
+										};
+									} catch ( execErr ) {
+										return {
+											id,
+											name,
+											error: String(
+												execErr?.message ?? execErr
+											),
+										};
+									}
 								}
-							} )
+							)
 						);
 
 						// POST results back to the server so the agent loop

--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -1718,11 +1718,11 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const fab = page.locator( '.sdaa-w-launcher' );
+		const fab = page.locator( '.sd-ai-agent-w-launcher' );
 		await expect( fab ).toBeVisible();
 
 		// Badge should not be present when count is 0.
-		const badge = fab.locator( '.sdaa-w-launcher-badge' );
+		const badge = fab.locator( '.sd-ai-agent-w-launcher-badge' );
 		await expect( badge ).toHaveCount( 0 );
 	} );
 
@@ -1740,11 +1740,11 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const fab = page.locator( '.sdaa-w-launcher' );
+		const fab = page.locator( '.sd-ai-agent-w-launcher' );
 		await expect( fab ).toBeVisible();
 
 		// Badge should appear with the count.
-		const badge = fab.locator( '.sdaa-w-launcher-badge' );
+		const badge = fab.locator( '.sd-ai-agent-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 10_000 } );
 		await expect( badge ).toContainText( '3' );
 	} );
@@ -1766,7 +1766,7 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		// Use 20 s — the badge appears after fetchAlerts() resolves, which can
 		// take longer than 10 s on CI runners under load with 3 parallel workers.
-		const badge = page.locator( '.sdaa-w-launcher-badge' );
+		const badge = page.locator( '.sd-ai-agent-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 20_000 } );
 		await expect( badge ).toContainText( '9+' );
 	} );
@@ -1780,7 +1780,7 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const badge = page.locator( '.sdaa-w-launcher-badge' );
+		const badge = page.locator( '.sd-ai-agent-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 10_000 } );
 
 		// aria-label should include the count for screen readers.

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -1146,6 +1146,13 @@ test.describe( 'client-abilities — restored polling', () => {
 			decodeURIComponent( url.toString() ).includes(
 				'sd-ai-agent/v1/chat/tool-result'
 			);
+		const isSessionEndpoint = ( url ) => {
+			const decoded = decodeURIComponent( url.toString() );
+			return (
+				decoded.includes( `sd-ai-agent/v1/sessions/${ sessionId }` ) &&
+				! decoded.includes( `/sessions/${ sessionId }/active-job` )
+			);
+		};
 
 		const handleActiveJobs = async ( route ) => {
 			await route.fulfill( {
@@ -1205,6 +1212,25 @@ test.describe( 'client-abilities — restored polling', () => {
 				body: JSON.stringify( { status: 'processing' } ),
 			} );
 		};
+		const handleSession = async ( route ) => {
+			const messages = toolResultPayloads.length
+				? [
+						{
+							role: 'model',
+							parts: [ { text: terminalReply } ],
+						},
+				  ]
+				: [];
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					id: sessionId,
+					messages,
+					tool_calls: [],
+				} ),
+			} );
+		};
 
 		await loginToWordPress( page );
 		await page.goto( '/wp-admin/index.php' );
@@ -1219,6 +1245,7 @@ test.describe( 'client-abilities — restored polling', () => {
 		await page.route( isActiveJobsEndpoint, handleActiveJobs );
 		await page.route( isJobEndpoint, handleJob );
 		await page.route( isToolResultEndpoint, handleToolResult );
+		await page.route( isSessionEndpoint, handleSession );
 
 		try {
 			await page.reload();
@@ -1249,6 +1276,7 @@ test.describe( 'client-abilities — restored polling', () => {
 			await page.unroute( isActiveJobsEndpoint, handleActiveJobs );
 			await page.unroute( isJobEndpoint, handleJob );
 			await page.unroute( isToolResultEndpoint, handleToolResult );
+			await page.unroute( isSessionEndpoint, handleSession );
 		}
 	} );
 } );

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -1120,7 +1120,134 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 9: No relevant console errors
+// Test suite 9: Restored polling
+// ---------------------------------------------------------------------------
+
+test.describe( 'client-abilities — restored polling', () => {
+	test( 'restores a refreshed job, executes each client call once, and persists one terminal response', async ( {
+		page,
+	} ) => {
+		const jobId = 'e2e-restored-client-abilities-job';
+		const sessionId = 101;
+		const terminalReply =
+			'Restored client abilities completed exactly once after refresh.';
+		const toolResultPayloads = [];
+		let jobPollCount = 0;
+
+		const isActiveJobsEndpoint = ( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				'sd-ai-agent/v1/sessions/active-jobs'
+			);
+		const isJobEndpoint = ( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				`sd-ai-agent/v1/job/${ jobId }`
+			);
+		const isToolResultEndpoint = ( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				'sd-ai-agent/v1/chat/tool-result'
+			);
+
+		const handleActiveJobs = async ( route ) => {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( [ { job_id: jobId, session_id: sessionId } ] ),
+			} );
+		};
+		const handleJob = async ( route ) => {
+			jobPollCount++;
+			const body =
+				toolResultPayloads.length === 0
+					? {
+							status: 'awaiting_client_tools',
+							pending_client_tool_calls: [
+								{
+									id: 'restored-screenshot-url',
+									name: 'sd-ai-agent-js/screenshot-url',
+									annotations: { readonly: true },
+									// An invalid URL produces a fast, structured browser result.
+									args: { url: '' },
+								},
+								{
+									id: 'restored-page-quality',
+									name: 'sd-ai-agent-js/validate-page-quality',
+									annotations: { readonly: true },
+									// Empty targets exercise the real callback without loading iframes.
+									args: {
+										profile: 'incremental',
+										quality_token: 'restored-e2e-token',
+										render_mode: 'public',
+										visual_review_required: false,
+										pages: [],
+										hero_contract: {},
+										viewports: [],
+									},
+								},
+							],
+						}
+					: {
+							status: 'complete',
+							session_id: sessionId,
+							reply: terminalReply,
+						};
+
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( body ),
+			} );
+		};
+		const handleToolResult = async ( route ) => {
+			toolResultPayloads.push( route.request().postDataJSON() );
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( { status: 'processing' } ),
+			} );
+		};
+
+		await loginToWordPress( page );
+		await page.goto( '/wp-admin/index.php' );
+		await page.waitForLoadState( 'domcontentloaded' );
+		await page.evaluate( ( restore ) => {
+			sessionStorage.setItem(
+				'sdAiAgent_refreshRestore',
+				JSON.stringify( restore )
+			);
+		}, { sessionId, open: true, minimized: false } );
+
+		await page.route( isActiveJobsEndpoint, handleActiveJobs );
+		await page.route( isJobEndpoint, handleJob );
+		await page.route( isToolResultEndpoint, handleToolResult );
+
+		try {
+			await page.reload();
+			await page
+				.locator( '.sdaa-w-launcher' )
+				.waitFor( { state: 'visible', timeout: 30_000 } );
+			await requireAbilitiesApi( page );
+			await waitForAbilitiesRegistered( page );
+			await expect.poll( () => toolResultPayloads.length ).toBe( 1 );
+			await expect( page.getByText( terminalReply ) ).toBeVisible();
+
+			expect( jobPollCount ).toBe( 2 );
+			expect( toolResultPayloads[ 0 ]?.tool_results ).toHaveLength( 2 );
+			expect(
+				toolResultPayloads[ 0 ].tool_results.map(
+					( result ) => result.id
+				)
+			).toEqual( [ 'restored-screenshot-url', 'restored-page-quality' ] );
+			expect( page.getByText( terminalReply ) ).toHaveCount( 1 );
+		} finally {
+			await page.unroute( isActiveJobsEndpoint, handleActiveJobs );
+			await page.unroute( isJobEndpoint, handleJob );
+			await page.unroute( isToolResultEndpoint, handleToolResult );
+		}
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Test suite 10: No relevant console errors
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — no relevant console errors', () => {

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -56,9 +56,9 @@ async function goToDashboard( page ) {
 	await page.waitForLoadState( 'domcontentloaded' );
 	// Wait for the launcher button — it renders once React has mounted and the
 	// floating-widget bundle has executed (triggering ensureRegistered()).
-	// The redesign (#1157) renamed .sdaa-fab to .sdaa-w-launcher.
+	// The redesign (#1157) renamed .sdaa-fab to .sd-ai-agent-w-launcher.
 	await page
-		.locator( '.sdaa-w-launcher' )
+		.locator( '.sd-ai-agent-w-launcher' )
 		.waitFor( { state: 'visible', timeout: 30_000 } );
 }
 
@@ -1222,16 +1222,18 @@ test.describe( 'client-abilities — restored polling', () => {
 
 		try {
 			await page.reload();
-			await page
-				.locator( '.sdaa-w-launcher' )
-				.waitFor( { state: 'visible', timeout: 30_000 } );
-			await requireAbilitiesApi( page );
 			await waitForAbilitiesRegistered( page );
+			await requireAbilitiesApi( page );
 			await expect.poll( () => toolResultPayloads.length ).toBe( 1 );
 			await expect( page.getByText( terminalReply ) ).toBeVisible();
 
 			expect( jobPollCount ).toBe( 2 );
 			expect( toolResultPayloads[ 0 ]?.tool_results ).toHaveLength( 2 );
+			expect(
+				toolResultPayloads[ 0 ].tool_results.map(
+					( result ) => result.error
+				)
+			).toEqual( [ undefined, undefined ] );
 			expect(
 				toolResultPayloads[ 0 ].tool_results.map(
 					( result ) => result.id

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -1225,6 +1225,11 @@ test.describe( 'client-abilities — restored polling', () => {
 			await waitForAbilitiesRegistered( page );
 			await requireAbilitiesApi( page );
 			await expect.poll( () => toolResultPayloads.length ).toBe( 1 );
+			// A backgrounded CI page uses the intentional 15-second polling
+			// interval, so wait for the terminal poll before checking the UI.
+			await expect
+				.poll( () => jobPollCount, { timeout: 20_000 } )
+				.toBe( 2 );
 			await expect( page.getByText( terminalReply ) ).toBeVisible();
 
 			expect( jobPollCount ).toBe( 2 );

--- a/tests/e2e/floating-widget.spec.js
+++ b/tests/e2e/floating-widget.spec.js
@@ -5,7 +5,7 @@
  * Requires a running wp-env environment with the plugin active.
  *
  * The chat widget was redesigned in #1157. Class names changed:
- *   .sdaa-fab         → .sdaa-w-launcher  (WidgetLauncher)
+ *   .sdaa-fab         → .sd-ai-agent-w-launcher  (WidgetLauncher)
  *   .sdaa-floating-panel → .sdaa-w-panel  (WidgetPanel)
  *   .sdaa-chat-panel  → .sdaa-w-body-wrap (panel body area)
  *   .sdaa-input       → .sdaa-w-input-textarea

--- a/tests/e2e/utils/wp-admin.js
+++ b/tests/e2e/utils/wp-admin.js
@@ -144,9 +144,9 @@ async function goToAdminDashboard( page ) {
 	// The launcher (FAB) renders after FloatingWidget mounts and fetchSettings()
 	// resolves. Without this wait, tests that immediately click the launcher can
 	// time out when the CI runner is under load.
-	// The redesign (#1157) renamed .sdaa-fab to .sdaa-w-launcher.
+	// The redesign (#1157) renamed .sdaa-fab to .sd-ai-agent-w-launcher.
 	await page
-		.locator( '.sdaa-w-launcher' )
+		.locator( '.sd-ai-agent-w-launcher' )
 		.waitFor( { state: 'visible', timeout: 15_000 } )
 		.catch( () => {} ); // Non-fatal: some tests may not need the launcher.
 }
@@ -155,13 +155,13 @@ async function goToAdminDashboard( page ) {
  * Wait for the floating action button (launcher) to be visible.
  *
  * The redesign (#1157) replaced the legacy .sdaa-fab class with
- * .sdaa-w-launcher in the new WidgetLauncher component.
+ * .sd-ai-agent-w-launcher in the new WidgetLauncher component.
  *
  * @param {import('@playwright/test').Page} page - Playwright page object.
  * @return {import('@playwright/test').Locator} The launcher locator.
  */
 function getFloatingButton( page ) {
-	return page.locator( '.sdaa-w-launcher' );
+	return page.locator( '.sd-ai-agent-w-launcher' );
 }
 
 /**


### PR DESCRIPTION
## Summary

Wait for the shared browser callback registration promise before restored client-tool batches execute, bound registration separately from each ability's full execution timeout, normalize rejection results, and cover refresh restoration through Jest and Playwright. Lazy-load the client-tool batch runner to keep the initial floating-widget bundle within budget.

Use the canonical `sd-ai-agent-` launcher class prefix and make restored-polling coverage account for the hidden-page polling interval without waiting for a launcher that is intentionally hidden while the restored panel is open.

## Files Changed

- `src/store/slices/jobSlice.js`
- `src/store/slices/client-tool-runner.js`
- `src/store/__tests__/index.test.js`
- `src/components/chat-widget/widget-launcher.js`
- `src/components/chat-widget/widget-launcher.css`
- `tests/e2e/client-abilities.spec.js`
- `tests/e2e/automations.spec.js`
- `tests/e2e/floating-widget.spec.js`
- `tests/e2e/utils/wp-admin.js`

## Runtime Testing

- **Risk level:** Medium
- `pnpm run verify`
- `pnpm run test:js` — 583 tests passed
- Focused store tests — 141 tests passed
- Focused local Playwright launch unavailable because the matching browser binary is not installed; required E2E coverage runs in CI.

## Worker self-verification
- PHPUnit: Tests: 4257, Assertions: 19597, Errors: 0, Failures: 0, Skipped: 137
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed (`floating-widget`: 86.5 KiB / 87 KiB)

Resolves #2625


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 30m and 384,382 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restored job handling while browser abilities are loading.
  * Prevented pending client actions from running before ability registration is ready.
  * Added clear error reporting for registration failures and timeouts.
  * Prevented duplicate client action execution and result submissions during polling restoration.
  * Enforced confirmation before running unapproved client actions.

* **Tests**
  * Added coverage for delayed, failed, and timed-out ability registration.
  * Added end-to-end coverage for restoring and polling jobs after a dashboard reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
