### PR TITLE
GH#2630: preserve customer runtime during review migration

### DIFF
--- a/includes/Models/CustomerAgentRuntimeRepository.php
+++ b/includes/Models/CustomerAgentRuntimeRepository.php
@@ -335,7 +335,7 @@ class CustomerAgentRuntimeRepository {
 	/**
 	 * Return every job identifier that belongs to a conversation, then purge it.
 	 *
-	 * @return array{deleted:bool,job_ids:list<string>}
+	 * @return array{deleted:bool,job_ids:list<string>,phase:string}
 	 */
 	public static function purge_conversation( string $conversation_id ): array {
 		global $wpdb;
@@ -348,6 +348,7 @@ class CustomerAgentRuntimeRepository {
 			return array(
 				'deleted' => false,
 				'job_ids' => array(),
+				'phase'   => 'source_cleanup_begin',
 			);
 		}
 
@@ -364,6 +365,7 @@ class CustomerAgentRuntimeRepository {
 			return array(
 				'deleted' => false,
 				'job_ids' => array(),
+				'phase'   => 'source_cleanup_lookup',
 			);
 		}
 		$job_ids = array();
@@ -375,12 +377,14 @@ class CustomerAgentRuntimeRepository {
 
 		// A runtime close must also remove its separate display-safe review
 		// projection. This never exposes the private runtime row to reviewers.
-		if ( ! CustomerConversationReviewRepository::delete_by_runtime_conversation( $conversation_id ) ) {
+		$review_storage_available = CustomerConversationReviewRepository::is_storage_available();
+		if ( $review_storage_available && ! CustomerConversationReviewRepository::delete_by_runtime_conversation( $conversation_id ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reverts source deletion when the review projection cannot be deleted.
 			$wpdb->query( 'ROLLBACK' );
 			return array(
 				'deleted' => false,
 				'job_ids' => array(),
+				'phase'   => 'review_projection_cleanup',
 			);
 		}
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purging a private runtime record requires an atomic direct delete.
@@ -393,12 +397,14 @@ class CustomerAgentRuntimeRepository {
 			return array(
 				'deleted' => false,
 				'job_ids' => array(),
+				'phase'   => 'source_cleanup_commit',
 			);
 		}
 
 		return array(
 			'deleted' => true,
 			'job_ids' => $job_ids,
+			'phase'   => 'complete',
 		);
 	}
 

--- a/includes/Models/CustomerConversationReviewRepository.php
+++ b/includes/Models/CustomerConversationReviewRepository.php
@@ -49,6 +49,26 @@ final class CustomerConversationReviewRepository {
 	}
 
 	/**
+	 * Return whether both optional review-projection tables are available.
+	 *
+	 * Customer delivery must continue while a rolling deployment has installed the
+	 * runtime tables but has not yet installed this display-only projection.
+	 */
+	public static function is_storage_available(): bool {
+		global $wpdb;
+
+		foreach ( array( self::table_name(), self::turns_table_name() ) as $table_name ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Detects whether an optional display-only projection is available during a rolling schema upgrade.
+			$table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+			if ( $table_name !== $table ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Create an anonymous public-embed review shell after visitor consent.
 	 *
 	 * The review identifier is stored only in the signed-session transient. It is

--- a/includes/Services/CustomerAgentRuntimeService.php
+++ b/includes/Services/CustomerAgentRuntimeService.php
@@ -838,9 +838,12 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 		$purged = CustomerAgentRuntimeRepository::purge_conversation( (string) $conversation['conversation_id'] );
 		if ( ! $purged['deleted'] ) {
 			return new WP_Error(
-				'sd_ai_agent_customer_agent_storage_failed',
+				'sd_ai_agent_customer_agent_conversation_cleanup_failed',
 				__( 'The customer-agent runtime could not close the conversation.', 'superdav-ai-agent' ),
-				array( 'status' => 500 )
+				array(
+					'status' => 500,
+					'phase'  => (string) ( $purged['phase'] ?? 'source_cleanup_unknown' ),
+				)
 			);
 		}
 

--- a/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
+++ b/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
@@ -614,6 +614,21 @@ class CustomerAgentRuntimeServiceTest extends WP_UnitTestCase {
 		$this->assertFalse( $missing['recovered'] );
 	}
 
+	/** The managed-profile contract processes, inspects, and closes an isolated answer. */
+	public function test_isolated_answer_completes_and_closes_on_current_schema(): void {
+		$job = $this->service->enqueue_turn( self::INTEGRATION, 'customer-session-isolated-answer', 'message-isolated-answer', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+		$this->service->process_job( $job['job_id'] );
+
+		$status = $this->service->inspect_job( self::INTEGRATION, 'customer-session-isolated-answer', $job['job_id'] );
+		$this->assertNotInstanceOf( WP_Error::class, $status );
+		$this->assertSame( 'complete', $status['status'] );
+
+		$closed = $this->service->close_conversation( self::INTEGRATION, 'customer-session-isolated-answer' );
+		$this->assertNotInstanceOf( WP_Error::class, $closed );
+		$this->assertSame( 'closed', $closed['status'] );
+	}
+
 	/**
 	 * @param array<string,array<string,mixed>> $integrations Existing registrations.
 	 * @return array<string,array<string,mixed>>


### PR DESCRIPTION
## Summary

Keeps the optional customer-conversation review projection fail-open during mixed-schema deployment while preserving atomic cleanup when its tables exist, and returns a safe cleanup phase for trusted callers.

## Files Changed

includes/Models/CustomerAgentRuntimeRepository.php, includes/Models/CustomerConversationReviewRepository.php, includes/Services/CustomerAgentRuntimeService.php, tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused CustomerAgentRuntimeServiceTest: 22 tests, 172 assertions; PHPCS and PHPStan passed; JS/CSS/PHP lint, production build, and bundle budgets passed. Full PHP suite attempted: 4260 tests, 3 errors, 7 failures caused by concurrent shared-test-database deadlocks and schema DDL, outside changed customer-runtime paths.

Resolves #2630


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 16m and 142,526 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation cleanup now works safely when optional review storage is unavailable.
  * Cleanup failures provide a dedicated error status and identify the stage where processing stopped.
  * Isolated answers now complete and close conversations correctly on the current database schema.

* **Tests**
  * Added coverage for successful answer processing and conversation closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->