### PR TITLE
GH#2631: Fix lifecycle lock release across routed database connections

### DIFF
--- a/includes/Services/CustomerAgentRuntimeService.php
+++ b/includes/Services/CustomerAgentRuntimeService.php
@@ -93,6 +93,9 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 
 	private static ?self $instance = null;
 
+	/** @var array<string,\mysqli> Connections that own request-scoped advisory locks. */
+	private array $integration_lock_connections = array();
+
 	/**
 	 * Optional test seam. Production execution always uses AgentLoop directly.
 	 *
@@ -1194,6 +1197,10 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 				array( 'status' => 503 )
 			);
 		}
+		$connection = $this->database_connection_handle( $wpdb );
+		if ( null !== $connection ) {
+			$this->integration_lock_connections[ $lock_name ] = $connection;
+		}
 
 		return $lock_name;
 	}
@@ -1203,8 +1210,40 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the request-scoped advisory lock acquired for this integration.
-		$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+		$query      = $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name );
+		$connection = $this->integration_lock_connections[ $lock_name ] ?? null;
+		unset( $this->integration_lock_connections[ $lock_name ] );
+		if ( ! is_string( $query ) ) {
+			return;
+		}
+
+		if ( $connection instanceof \mysqli ) {
+			try {
+				// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_query -- Advisory locks are connection-scoped, so release must use the exact connection that acquired the lock instead of a router-selected wpdb connection.
+				$result = mysqli_query( $connection, $query );
+				if ( $result instanceof \mysqli_result ) {
+					$result->free();
+				}
+			} catch ( \Throwable $exception ) {
+				// The database releases request-owned advisory locks when the connection closes.
+			}
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- The query was prepared above; fallback supports wpdb drivers that do not expose their connection handle.
+		$wpdb->get_var( $query );
+	}
+
+	/** Return the current driver connection without assuming wpdb property visibility. */
+	private function database_connection_handle( \wpdb $database ): ?\mysqli {
+		try {
+			$property   = new \ReflectionProperty( $database, 'dbh' );
+			$connection = $property->getValue( $database );
+		} catch ( \ReflectionException $exception ) {
+			return null;
+		}
+
+		return $connection instanceof \mysqli ? $connection : null;
 	}
 
 	/** Return the independent opaque tombstone option name for one integration key. */


### PR DESCRIPTION
## Summary

- capture the exact `mysqli` connection that acquires each customer-agent lifecycle advisory lock
- release the lock through its owning connection so routed WordPress database reads cannot strand it
- preserve the existing non-throwing `$wpdb` fallback for drivers without an exposed `mysqli` handle

## Verification

- `php -l includes/Services/CustomerAgentRuntimeService.php`
- `pnpm run lint:php`
- `composer phpstan`
- focused `CustomerAgentRuntimeServiceTest`: 21 tests, 167 assertions
- full isolated `pnpm run verify`: 4,259 tests, 19,586 assertions; build and bundle budgets passed

Resolves #2631

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 28m and 1,094,080 tokens on this with the user in an interactive session.