### PR TITLE
GH#2634: Enforce managed journey budget headers

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2944,6 +2944,20 @@ PROMPT;
 			);
 		}
 
+		$journey_id      = '';
+		$idempotency_key = '';
+		if ( SuperdavAiProvider::PROVIDER_ID === $provider_id ) {
+			$journey_context = SuperdavJourneyBudgetContext::resolve_for_session( $this->session_id );
+			if ( is_wp_error( $journey_context ) ) {
+				return $journey_context;
+			}
+
+			if ( is_string( $journey_context ) ) {
+				$journey_id      = $journey_context;
+				$idempotency_key = wp_generate_uuid4();
+			}
+		}
+
 		try {
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 			if ( ! $registry->hasProvider( $provider_id ) ) {
@@ -3043,7 +3057,9 @@ PROMPT;
 				$provider_id,
 				$model_id,
 				$this->session_id,
-				$this->provider_retry_baseline_envelope_bytes
+				$this->provider_retry_baseline_envelope_bytes,
+				$journey_id,
+				$idempotency_key
 			);
 			try {
 				$result = $builder->generate_text_result();

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -41,6 +41,8 @@ class ProviderTraceLogger {
 	 *     provider_id:string,
 	 *     model_id:string,
 	 *     session_id:int,
+	 *     journey_id:string,
+	 *     idempotency_key:string,
 	 *     retry_baseline_request_bytes:int,
 	 *     request_bytes:int,
 	 *     request_tokens_estimate:int,
@@ -54,6 +56,8 @@ class ProviderTraceLogger {
 		'provider_id'                  => '',
 		'model_id'                     => '',
 		'session_id'                   => 0,
+		'journey_id'                   => '',
+		'idempotency_key'              => '',
 		'retry_baseline_request_bytes' => 0,
 		'request_bytes'                => 0,
 		'request_tokens_estimate'      => 0,
@@ -125,12 +129,18 @@ class ProviderTraceLogger {
 	 * @param string $model_id                     Runtime-selected model ID.
 	 * @param int    $session_id                   Owning chat session, if any.
 	 * @param int    $retry_baseline_request_bytes Full-envelope bytes from an upstream 413 retry baseline.
+	 * @param string $journey_id                   Validated managed journey UUID, if active.
+	 * @param string $idempotency_key              Stable logical-request UUID, if active.
 	 */
-	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0 ): void {
-		self::$runtimeContext = array(
+	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0, string $journey_id = '', string $idempotency_key = '' ): void {
+		$has_valid_managed_attribution = self::is_valid_managed_request_identifier( $journey_id )
+			&& self::is_valid_managed_request_identifier( $idempotency_key );
+		self::$runtimeContext          = array(
 			'provider_id'                  => sanitize_key( $provider_id ),
 			'model_id'                     => sanitize_text_field( $model_id ),
 			'session_id'                   => max( 0, $session_id ),
+			'journey_id'                   => $has_valid_managed_attribution ? strtolower( $journey_id ) : '',
+			'idempotency_key'              => $has_valid_managed_attribution ? strtolower( $idempotency_key ) : '',
 			'retry_baseline_request_bytes' => max( 0, $retry_baseline_request_bytes ),
 			'request_bytes'                => 0,
 			'request_tokens_estimate'      => 0,
@@ -145,12 +155,31 @@ class ProviderTraceLogger {
 		return self::$runtimeContext['session_id'];
 	}
 
+	/**
+	 * Return non-secret managed request attribution for the synchronous request.
+	 *
+	 * @return array{journey_id:string, idempotency_key:string}
+	 */
+	public static function get_runtime_managed_request_attribution(): array {
+		return array(
+			'journey_id'      => self::$runtimeContext['journey_id'],
+			'idempotency_key' => self::$runtimeContext['idempotency_key'],
+		);
+	}
+
+	/** Validate opaque UUID request attribution before retaining it at runtime. */
+	private static function is_valid_managed_request_identifier( string $identifier ): bool {
+		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $identifier );
+	}
+
 	/** Clear runtime provider attribution after a synchronous request. */
 	public static function clear_runtime_context(): void {
 		self::$runtimeContext = array(
 			'provider_id'                  => '',
 			'model_id'                     => '',
 			'session_id'                   => 0,
+			'journey_id'                   => '',
+			'idempotency_key'              => '',
 			'retry_baseline_request_bytes' => 0,
 			'request_bytes'                => 0,
 			'request_tokens_estimate'      => 0,

--- a/includes/Core/SuperdavJourneyBudgetContext.php
+++ b/includes/Core/SuperdavJourneyBudgetContext.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves the narrowly scoped r002 managed-edge journey reservation.
+ *
+ * The option contains attribution only. It must never contain an edge token,
+ * customer data, prompt content, or an endpoint URL.
+ */
+final class SuperdavJourneyBudgetContext {
+
+	public const OPTION_NAME = 'sd_ai_agent_superdav_r002_journey_context';
+	public const RUN_MARKER  = 'r002';
+	public const QA_EMAIL    = 'qa-contact@example.com';
+
+	/** Activate the fixed QA reservation context without autoloading it. */
+	public static function activate( string $journey_id, int $qa_user_id, string $expires_at ): bool {
+		$user = $qa_user_id > 0 ? get_userdata( $qa_user_id ) : false;
+		if (
+			! self::is_valid_journey_id( $journey_id )
+			|| ! $user instanceof \WP_User
+			|| self::QA_EMAIL !== $user->user_email
+			|| ! self::is_valid_utc_expiry( $expires_at )
+			|| strtotime( $expires_at ) <= time()
+		) {
+			return false;
+		}
+		$context = array(
+			'journey_id' => strtolower( $journey_id ),
+			'run_marker' => self::RUN_MARKER,
+			'qa_user_id' => $qa_user_id,
+			'expires_at' => $expires_at,
+		);
+		if ( $context === get_option( self::OPTION_NAME, null ) ) {
+			return true;
+		}
+
+		return update_option(
+			self::OPTION_NAME,
+			$context,
+			false
+		);
+	}
+
+	/** Remove the active QA reservation context. */
+	public static function deactivate(): bool {
+		return false === get_option( self::OPTION_NAME, false ) || delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * Resolve the reservation for a server-owned chat session.
+	 *
+	 * @return string|\WP_Error|null Opaque journey ID, local validation error, or no matching context.
+	 */
+	public static function resolve_for_session( int $session_id ): string|\WP_Error|null {
+		$context = get_option( self::OPTION_NAME, null );
+		if ( ! is_array( $context ) ) {
+			return null;
+		}
+
+		$session = $session_id > 0 ? Database::get_session( $session_id ) : null;
+		$user_id = is_object( $session ) ? (int) ( $session->user_id ?? 0 ) : 0;
+		$user    = $user_id > 0 ? get_userdata( $user_id ) : false;
+		$email   = $user instanceof \WP_User ? $user->user_email : '';
+
+		// A reservation can never leak onto a different user's session.
+		if ( self::QA_EMAIL !== $email ) {
+			return null;
+		}
+
+		$journey_id = $context['journey_id'] ?? null;
+		$run_marker = $context['run_marker'] ?? null;
+		$qa_user_id = $context['qa_user_id'] ?? null;
+		$expires_at = $context['expires_at'] ?? null;
+		if (
+			! is_string( $journey_id )
+			|| ! is_string( $run_marker )
+			|| ! is_int( $qa_user_id )
+			|| ! is_string( $expires_at )
+			|| self::RUN_MARKER !== $run_marker
+			|| $user_id !== $qa_user_id
+			|| ! self::is_valid_journey_id( $journey_id )
+			|| ! self::is_valid_utc_expiry( $expires_at )
+			|| strtotime( $expires_at ) <= time()
+		) {
+			return new \WP_Error(
+				'sd_ai_agent_journey_context_invalid',
+				__( 'The managed QA journey reservation is invalid or expired. The request was not sent.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return strtolower( $journey_id );
+	}
+
+	/** Validate a UUID-shaped opaque journey identifier. */
+	private static function is_valid_journey_id( string $journey_id ): bool {
+		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $journey_id );
+	}
+
+	/** Validate the canonical UTC expiry representation. */
+	private static function is_valid_utc_expiry( string $expires_at ): bool {
+		$date = \DateTimeImmutable::createFromFormat( 'Y-m-d\\TH:i:s\\Z', $expires_at, new \DateTimeZone( 'UTC' ) );
+		return $date instanceof \DateTimeImmutable && $date->format( 'Y-m-d\\TH:i:s\\Z' ) === $expires_at;
+	}
+}

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -32,6 +32,8 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const STRONG_MODEL_ID            = 'superdav-chat-strong';
 	public const IMAGE_MODEL_ID             = 'superdav-image';
 	public const SESSION_ATTRIBUTION_HEADER = 'X-Superdav-Session-ID';
+	public const JOURNEY_ATTRIBUTION_HEADER = 'X-Superdav-Journey-ID';
+	public const IDEMPOTENCY_HEADER         = 'Idempotency-Key';
 
 	/**
 	 * Reasoning effort hints for managed Superdav model aliases.
@@ -65,6 +67,29 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 		}
 
 		return $headers;
+	}
+
+	/**
+	 * Add active r002 reservation headers to a managed chat-completion request.
+	 *
+	 * @param array<string, string|list<string>> $headers Existing request headers.
+	 * @return array<string, string|list<string>> Headers with safe managed attribution.
+	 */
+	public static function with_managed_chat_attribution( array $headers ): array {
+		$headers     = self::with_session_attribution( $headers );
+		$attribution = ProviderTraceLogger::get_runtime_managed_request_attribution();
+
+		if ( self::is_valid_request_identifier( $attribution['journey_id'] ) && self::is_valid_request_identifier( $attribution['idempotency_key'] ) ) {
+			$headers[ self::JOURNEY_ATTRIBUTION_HEADER ] = $attribution['journey_id'];
+			$headers[ self::IDEMPOTENCY_HEADER ]         = $attribution['idempotency_key'];
+		}
+
+		return $headers;
+	}
+
+	/** Validate opaque UUID attribution without accepting arbitrary headers. */
+	private static function is_valid_request_identifier( string $identifier ): bool {
+		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $identifier );
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -84,7 +84,11 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	 * @return Request
 	 */
 	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
-		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
+		$request_headers = 'responses' === trim( $path, '/' )
+			? SuperdavAiProvider::with_managed_chat_attribution( $headers )
+			: SuperdavAiProvider::with_session_attribution( $headers );
+
+		return new Request( $method, SuperdavAiProvider::url( $path ), $request_headers, $data, $this->getRequestOptions() );
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -78,7 +78,11 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 			}
 		}
 
-		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
+		$request_headers = 'chat/completions' === trim( $path, '/' )
+			? SuperdavAiProvider::with_managed_chat_attribution( $headers )
+			: SuperdavAiProvider::with_session_attribution( $headers );
+
+		return new Request( $method, SuperdavAiProvider::url( $path ), $request_headers, $data, $this->getRequestOptions() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -39,9 +39,12 @@ use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\SuperdavJourneyBudgetContext;
 use SdAiAgent\Core\SystemInstructionBuilder;
 use SdAiAgent\Core\ToolPermissionResolver;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Tools\ToolDiscovery;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -191,7 +194,11 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 		delete_option( 'openai_compat_endpoint_url' );
 		delete_option( 'openai_compat_api_key' );
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 		delete_option( Settings::OPTION_NAME );
+		SuperdavJourneyBudgetContext::deactivate();
+		ProviderTraceLogger::clear_runtime_context();
+		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 
 		// Remove any lingering pre_http_request filters added by tests.
 		remove_all_filters( 'pre_http_request' );
@@ -1086,6 +1093,46 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( [ 0 ], $delays->getValue( $overridden ) );
 		$this->assertFalse( $jitter->getValue( $overridden ) );
 		$this->assertSame( 0, $resolve->invoke( $overridden, 1, null ) );
+	}
+
+	/** An invalid active QA context fails before any managed request is sent. */
+	public function test_invalid_managed_journey_context_fails_locally_without_forwarding(): void {
+		$qa_user_id = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
+		$session_id = Database::create_session( array( 'user_id' => $qa_user_id, 'title' => 'Invalid managed journey' ) );
+		update_option(
+			SuperdavJourneyBudgetContext::OPTION_NAME,
+			array(
+				'journey_id' => 'not-a-uuid',
+				'run_marker' => SuperdavJourneyBudgetContext::RUN_MARKER,
+				'qa_user_id' => $qa_user_id,
+				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ),
+			),
+			false
+		);
+
+		$call_count = 0;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$options                = $this->no_sleep_retry_options( 2 );
+		$options['provider_id'] = SuperdavAiProvider::PROVIDER_ID;
+		$options['model_id']    = SuperdavAiProvider::DEFAULT_MODEL_ID;
+		$options['session_id']  = $session_id;
+		$result                 = ( new AgentLoop( 'Do not forward this request.', array(), array(), $options ) )->run();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_journey_context_invalid', $result->get_error_code() );
+		$this->assertSame( 0, $call_count );
+		$this->assertSame( array( 'journey_id' => '', 'idempotency_key' => '' ), ProviderTraceLogger::get_runtime_managed_request_attribution() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/SuperdavJourneyBudgetContextTest.php
+++ b/tests/SdAiAgent/Core/SuperdavJourneyBudgetContextTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\SuperdavJourneyBudgetContext;
+use WP_UnitTestCase;
+
+final class SuperdavJourneyBudgetContextTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		SuperdavJourneyBudgetContext::deactivate();
+		parent::tear_down();
+	}
+
+	/** Only the exact reserved QA identity can resolve an active reservation. */
+	public function test_resolve_binds_the_reservation_to_the_qa_session_owner(): void {
+		$qa_user_id    = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
+		$other_user_id = self::factory()->user->create( array( 'user_email' => 'other@example.com' ) );
+		$qa_session    = Database::create_session( array( 'user_id' => $qa_user_id, 'title' => 'QA' ) );
+		$other_session = Database::create_session( array( 'user_id' => $other_user_id, 'title' => 'Other' ) );
+		$journey_id    = '123e4567-e89b-42d3-a456-426614174000';
+
+		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ) ) );
+		$this->assertSame( $journey_id, SuperdavJourneyBudgetContext::resolve_for_session( (int) $qa_session ) );
+		$this->assertNull( SuperdavJourneyBudgetContext::resolve_for_session( (int) $other_session ) );
+	}
+
+	/** Activation accepts only a future reservation for the exact QA identity. */
+	public function test_activate_rejects_invalid_or_non_qa_contexts_and_is_idempotent(): void {
+		$qa_user_id    = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
+		$other_user_id = self::factory()->user->create( array( 'user_email' => 'other@example.com' ) );
+		$journey_id    = '123e4567-e89b-42d3-a456-426614174000';
+		$future        = gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS );
+
+		$this->assertFalse( SuperdavJourneyBudgetContext::activate( 'not-a-uuid', $qa_user_id, $future ) );
+		$this->assertFalse( SuperdavJourneyBudgetContext::activate( $journey_id, $other_user_id, $future ) );
+		$this->assertFalse( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, gmdate( 'Y-m-d\\TH:i:s\\Z', time() - HOUR_IN_SECONDS ) ) );
+		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, $future ) );
+		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, $future ) );
+		$this->assertTrue( SuperdavJourneyBudgetContext::deactivate() );
+		$this->assertTrue( SuperdavJourneyBudgetContext::deactivate() );
+	}
+
+	/** Expired or malformed contexts fail locally for the reserved identity. */
+	public function test_resolve_fails_closed_for_expired_or_malformed_context(): void {
+		$qa_user_id = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
+		$session_id = Database::create_session( array( 'user_id' => $qa_user_id, 'title' => 'QA' ) );
+
+		update_option(
+			SuperdavJourneyBudgetContext::OPTION_NAME,
+			array(
+				'journey_id' => '123e4567-e89b-42d3-a456-426614174000',
+				'run_marker' => SuperdavJourneyBudgetContext::RUN_MARKER,
+				'qa_user_id' => $qa_user_id,
+				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() - HOUR_IN_SECONDS ),
+			),
+			false
+		);
+
+		$result = SuperdavJourneyBudgetContext::resolve_for_session( (int) $session_id );
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_journey_context_invalid', $result->get_error_code() );
+
+		update_option(
+			SuperdavJourneyBudgetContext::OPTION_NAME,
+			array(
+				'journey_id' => 'not-a-uuid',
+				'run_marker' => SuperdavJourneyBudgetContext::RUN_MARKER,
+				'qa_user_id' => $qa_user_id,
+				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ),
+			),
+			false
+		);
+		$this->assertWPError( SuperdavJourneyBudgetContext::resolve_for_session( (int) $session_id ) );
+
+		update_option(
+			SuperdavJourneyBudgetContext::OPTION_NAME,
+			array(
+				'journey_id' => '123e4567-e89b-42d3-a456-426614174000',
+				'run_marker' => 'another-run',
+				'qa_user_id' => $qa_user_id,
+				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ),
+			),
+			false
+		);
+		$this->assertWPError( SuperdavJourneyBudgetContext::resolve_for_session( (int) $session_id ) );
+	}
+}

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -798,6 +798,30 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertTrue( $params['tools'][1]['tools'][0]['defer_loading'] );
 	}
 
+	/** Managed Responses inference carries the active journey reservation. */
+	public function test_responses_tool_search_request_includes_managed_journey_attribution(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model  = new SuperdavAiResponsesToolSearchTextGenerationModel(
+			new ModelMetadata( 'gpt-5.5', 'GPT-5.5', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$method = new \ReflectionMethod( $model, 'createRequest' );
+		$method->setAccessible( true );
+
+		$journey_id     = '123e4567-e89b-42d3-a456-426614174000';
+		$idempotency_key = '123e4567-e89b-42d3-a456-426614174001';
+		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'gpt-5.5', 42, 0, $journey_id, $idempotency_key );
+
+		$request = $method->invoke( $model, HttpMethodEnum::POST(), '/responses', array(), array( 'model' => 'gpt-5.5' ) );
+		$this->assertSame( $journey_id, $request->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertSame( $idempotency_key, $request->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+
+		$non_inference_request = $method->invoke( $model, HttpMethodEnum::GET(), '/models', array(), null );
+		$this->assertNull( $non_inference_request->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertNull( $non_inference_request->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+	}
+
 	/**
 	 * Responses function_call output items map back to SDK FunctionCall parts.
 	 */

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -14,6 +14,7 @@ use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\SuperdavJourneyBudgetContext;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiImageGenerationModel;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
@@ -52,6 +53,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	 */
 	public function tear_down(): void {
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		SuperdavJourneyBudgetContext::deactivate();
 		ModelCapabilityRegistry::forget( 'example-model' );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 		remove_all_filters( 'sd_ai_agent_superdav_default_model' );
@@ -265,6 +267,58 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			array( 'model' => 'example-model' )
 		);
 		$this->assertNull( $unattributed_request->getHeaderAsString( SuperdavAiProvider::SESSION_ATTRIBUTION_HEADER ) );
+	}
+
+	/** A valid reserved QA session receives journey and idempotency headers. */
+	public function test_text_generation_request_includes_validated_journey_attribution(): void {
+		$this->skip_if_sdk_unavailable();
+		$user_id    = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
+		$session_id = \SdAiAgent\Core\Database::create_session( array( 'user_id' => $user_id, 'title' => 'Reserved QA session' ) );
+		$journey_id = '123e4567-e89b-42d3-a456-426614174000';
+		$expiry     = gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS );
+
+		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $user_id, $expiry ) );
+		$this->assertSame( $journey_id, SuperdavJourneyBudgetContext::resolve_for_session( (int) $session_id ) );
+
+		$model  = new SuperdavAiTextGenerationModel(
+			new ModelMetadata( 'example-model', 'Example Model', array(), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$method = new \ReflectionMethod( $model, 'createRequest' );
+		$method->setAccessible( true );
+		$idempotency_key = '123e4567-e89b-42d3-a456-426614174001';
+		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'example-model', (int) $session_id, 0, $journey_id, $idempotency_key );
+		$request       = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
+		$retry_request = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
+
+		$this->assertSame( $journey_id, $request->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertSame( $idempotency_key, $request->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+		$this->assertSame( $journey_id, $retry_request->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertSame( $idempotency_key, $retry_request->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+
+		ProviderTraceLogger::clear_runtime_context();
+		$cleared_request = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
+		$this->assertNull( $cleared_request->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertNull( $cleared_request->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+	}
+
+	/** Invalid runtime attribution and non-chat requests cannot receive journey headers. */
+	public function test_journey_attribution_is_rejected_for_invalid_identifiers_and_non_chat_requests(): void {
+		$this->skip_if_sdk_unavailable();
+		$model  = new SuperdavAiTextGenerationModel(
+			new ModelMetadata( 'example-model', 'Example Model', array(), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$method = new \ReflectionMethod( $model, 'createRequest' );
+		$method->setAccessible( true );
+		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'example-model', 0, 0, 'not-a-journey', 'not-an-idempotency-key' );
+
+		$invalid = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
+		$this->assertNull( $invalid->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertNull( $invalid->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+
+		$non_chat = $method->invoke( $model, HttpMethodEnum::POST(), 'models', array(), null );
+		$this->assertNull( $non_chat->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Bind active r002 reservations to the authoritative WordPress session owner, attach validated journey and idempotency headers only to managed chat-completion requests, fail locally before upstream forwarding on invalid active context, and clear runtime attribution on every exit path.

## Files Changed

includes/Core/AgentLoop.php, includes/Core/ProviderTraceLogger.php, includes/Core/SuperdavJourneyBudgetContext.php, includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php, includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php, tests/SdAiAgent/Core/AgentLoopTest.php, tests/SdAiAgent/Core/SuperdavJourneyBudgetContextTest.php, tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — CI=true pnpm run verify (4,265 tests; 19,618 assertions; 137 skipped; 4 incomplete; PHPStan clean; lint clean; build and bundle budgets pass). Focused managed journey tests: 41 tests, 146 assertions.

Resolves #2634


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 19h 32m and 2,721,607 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure journey tracking for eligible managed AI requests.
  - Supported requests now include validated journey and idempotency information for improved traceability.
- **Bug Fixes**
  - Invalid, expired, or unauthorized journey reservations are rejected before requests are sent.
  - Non-chat requests and malformed tracking identifiers no longer receive journey attribution.
- **Tests**
  - Added coverage for valid attribution, invalid reservations, expiration handling, authorization checks, and safe request rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->