### PR TITLE
GH#2634: Align managed journey identifier format

### DIFF
--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -129,12 +129,12 @@ class ProviderTraceLogger {
 	 * @param string $model_id                     Runtime-selected model ID.
 	 * @param int    $session_id                   Owning chat session, if any.
 	 * @param int    $retry_baseline_request_bytes Full-envelope bytes from an upstream 413 retry baseline.
-	 * @param string $journey_id                   Validated managed journey UUID, if active.
+	 * @param string $journey_id                   Validated managed journey ID, if active.
 	 * @param string $idempotency_key              Stable logical-request UUID, if active.
 	 */
 	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0, string $journey_id = '', string $idempotency_key = '' ): void {
-		$has_valid_managed_attribution = self::is_valid_managed_request_identifier( $journey_id )
-			&& self::is_valid_managed_request_identifier( $idempotency_key );
+		$has_valid_managed_attribution = SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
+			&& SuperdavManagedRequestIdentifiers::is_idempotency_key( $idempotency_key );
 		self::$runtimeContext          = array(
 			'provider_id'                  => sanitize_key( $provider_id ),
 			'model_id'                     => sanitize_text_field( $model_id ),
@@ -165,11 +165,6 @@ class ProviderTraceLogger {
 			'journey_id'      => self::$runtimeContext['journey_id'],
 			'idempotency_key' => self::$runtimeContext['idempotency_key'],
 		);
-	}
-
-	/** Validate opaque UUID request attribution before retaining it at runtime. */
-	private static function is_valid_managed_request_identifier( string $identifier ): bool {
-		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $identifier );
 	}
 
 	/** Clear runtime provider attribution after a synchronous request. */

--- a/includes/Core/SuperdavJourneyBudgetContext.php
+++ b/includes/Core/SuperdavJourneyBudgetContext.php
@@ -24,7 +24,7 @@ final class SuperdavJourneyBudgetContext {
 	public static function activate( string $journey_id, int $qa_user_id, string $expires_at ): bool {
 		$user = $qa_user_id > 0 ? get_userdata( $qa_user_id ) : false;
 		if (
-			! self::is_valid_journey_id( $journey_id )
+			! SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
 			|| ! $user instanceof \WP_User
 			|| self::QA_EMAIL !== $user->user_email
 			|| ! self::is_valid_utc_expiry( $expires_at )
@@ -86,7 +86,7 @@ final class SuperdavJourneyBudgetContext {
 			|| ! is_string( $expires_at )
 			|| self::RUN_MARKER !== $run_marker
 			|| $user_id !== $qa_user_id
-			|| ! self::is_valid_journey_id( $journey_id )
+			|| ! SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
 			|| ! self::is_valid_utc_expiry( $expires_at )
 			|| strtotime( $expires_at ) <= time()
 		) {
@@ -98,11 +98,6 @@ final class SuperdavJourneyBudgetContext {
 		}
 
 		return strtolower( $journey_id );
-	}
-
-	/** Validate a UUID-shaped opaque journey identifier. */
-	private static function is_valid_journey_id( string $journey_id ): bool {
-		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $journey_id );
 	}
 
 	/** Validate the canonical UTC expiry representation. */

--- a/includes/Core/SuperdavManagedRequestIdentifiers.php
+++ b/includes/Core/SuperdavManagedRequestIdentifiers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Validates opaque identifiers used by managed journey requests. */
+final class SuperdavManagedRequestIdentifiers {
+
+	/** Validate the managed edge's canonical journey identifier. */
+	public static function is_journey_id( string $journey_id ): bool {
+		return str_starts_with( $journey_id, 'journey_' ) && self::is_uuid( substr( $journey_id, 8 ) );
+	}
+
+	/** Validate a logical-request idempotency key. */
+	public static function is_idempotency_key( string $idempotency_key ): bool {
+		return self::is_uuid( $idempotency_key );
+	}
+
+	/** Validate an RFC 4122 UUID from the accepted version family. */
+	private static function is_uuid( string $identifier ): bool {
+		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $identifier );
+	}
+}

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\SuperdavManagedRequestIdentifiers;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
@@ -79,17 +80,12 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 		$headers     = self::with_session_attribution( $headers );
 		$attribution = ProviderTraceLogger::get_runtime_managed_request_attribution();
 
-		if ( self::is_valid_request_identifier( $attribution['journey_id'] ) && self::is_valid_request_identifier( $attribution['idempotency_key'] ) ) {
+		if ( SuperdavManagedRequestIdentifiers::is_journey_id( $attribution['journey_id'] ) && SuperdavManagedRequestIdentifiers::is_idempotency_key( $attribution['idempotency_key'] ) ) {
 			$headers[ self::JOURNEY_ATTRIBUTION_HEADER ] = $attribution['journey_id'];
 			$headers[ self::IDEMPOTENCY_HEADER ]         = $attribution['idempotency_key'];
 		}
 
 		return $headers;
-	}
-
-	/** Validate opaque UUID attribution without accepting arbitrary headers. */
-	private static function is_valid_request_identifier( string $identifier ): bool {
-		return 1 === preg_match( '/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i', $identifier );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/SuperdavJourneyBudgetContextTest.php
+++ b/tests/SdAiAgent/Core/SuperdavJourneyBudgetContextTest.php
@@ -21,7 +21,7 @@ final class SuperdavJourneyBudgetContextTest extends WP_UnitTestCase {
 		$other_user_id = self::factory()->user->create( array( 'user_email' => 'other@example.com' ) );
 		$qa_session    = Database::create_session( array( 'user_id' => $qa_user_id, 'title' => 'QA' ) );
 		$other_session = Database::create_session( array( 'user_id' => $other_user_id, 'title' => 'Other' ) );
-		$journey_id    = '123e4567-e89b-42d3-a456-426614174000';
+		$journey_id    = 'journey_123e4567-e89b-42d3-a456-426614174000';
 
 		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ) ) );
 		$this->assertSame( $journey_id, SuperdavJourneyBudgetContext::resolve_for_session( (int) $qa_session ) );
@@ -32,10 +32,11 @@ final class SuperdavJourneyBudgetContextTest extends WP_UnitTestCase {
 	public function test_activate_rejects_invalid_or_non_qa_contexts_and_is_idempotent(): void {
 		$qa_user_id    = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
 		$other_user_id = self::factory()->user->create( array( 'user_email' => 'other@example.com' ) );
-		$journey_id    = '123e4567-e89b-42d3-a456-426614174000';
+		$journey_id    = 'journey_123e4567-e89b-42d3-a456-426614174000';
 		$future        = gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS );
 
 		$this->assertFalse( SuperdavJourneyBudgetContext::activate( 'not-a-uuid', $qa_user_id, $future ) );
+		$this->assertFalse( SuperdavJourneyBudgetContext::activate( '123e4567-e89b-42d3-a456-426614174000', $qa_user_id, $future ) );
 		$this->assertFalse( SuperdavJourneyBudgetContext::activate( $journey_id, $other_user_id, $future ) );
 		$this->assertFalse( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, gmdate( 'Y-m-d\\TH:i:s\\Z', time() - HOUR_IN_SECONDS ) ) );
 		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $qa_user_id, $future ) );
@@ -52,7 +53,7 @@ final class SuperdavJourneyBudgetContextTest extends WP_UnitTestCase {
 		update_option(
 			SuperdavJourneyBudgetContext::OPTION_NAME,
 			array(
-				'journey_id' => '123e4567-e89b-42d3-a456-426614174000',
+				'journey_id' => 'journey_123e4567-e89b-42d3-a456-426614174000',
 				'run_marker' => SuperdavJourneyBudgetContext::RUN_MARKER,
 				'qa_user_id' => $qa_user_id,
 				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() - HOUR_IN_SECONDS ),
@@ -79,7 +80,7 @@ final class SuperdavJourneyBudgetContextTest extends WP_UnitTestCase {
 		update_option(
 			SuperdavJourneyBudgetContext::OPTION_NAME,
 			array(
-				'journey_id' => '123e4567-e89b-42d3-a456-426614174000',
+				'journey_id' => 'journey_123e4567-e89b-42d3-a456-426614174000',
 				'run_marker' => 'another-run',
 				'qa_user_id' => $qa_user_id,
 				'expires_at' => gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS ),

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -274,7 +274,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->skip_if_sdk_unavailable();
 		$user_id    = self::factory()->user->create( array( 'user_email' => SuperdavJourneyBudgetContext::QA_EMAIL ) );
 		$session_id = \SdAiAgent\Core\Database::create_session( array( 'user_id' => $user_id, 'title' => 'Reserved QA session' ) );
-		$journey_id = '123e4567-e89b-42d3-a456-426614174000';
+		$journey_id = 'journey_123e4567-e89b-42d3-a456-426614174000';
 		$expiry     = gmdate( 'Y-m-d\\TH:i:s\\Z', time() + HOUR_IN_SECONDS );
 
 		$this->assertTrue( SuperdavJourneyBudgetContext::activate( $journey_id, $user_id, $expiry ) );
@@ -316,6 +316,18 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$invalid = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
 		$this->assertNull( $invalid->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
 		$this->assertNull( $invalid->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
+
+		ProviderTraceLogger::set_runtime_context(
+			SuperdavAiProvider::PROVIDER_ID,
+			'example-model',
+			0,
+			0,
+			'123e4567-e89b-42d3-a456-426614174000',
+			'123e4567-e89b-42d3-a456-426614174001'
+		);
+		$unprefixed = $method->invoke( $model, HttpMethodEnum::POST(), 'chat/completions', array(), array( 'model' => 'example-model' ) );
+		$this->assertNull( $unprefixed->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
+		$this->assertNull( $unprefixed->getHeaderAsString( SuperdavAiProvider::IDEMPOTENCY_HEADER ) );
 
 		$non_chat = $method->invoke( $model, HttpMethodEnum::POST(), 'models', array(), null );
 		$this->assertNull( $non_chat->getHeaderAsString( SuperdavAiProvider::JOURNEY_ATTRIBUTION_HEADER ) );
@@ -809,7 +821,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$method = new \ReflectionMethod( $model, 'createRequest' );
 		$method->setAccessible( true );
 
-		$journey_id     = '123e4567-e89b-42d3-a456-426614174000';
+		$journey_id     = 'journey_123e4567-e89b-42d3-a456-426614174000';
 		$idempotency_key = '123e4567-e89b-42d3-a456-426614174001';
 		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'gpt-5.5', 42, 0, $journey_id, $idempotency_key );
 


### PR DESCRIPTION
## Summary

- Accept the managed edge's canonical `journey_<UUID>` reservation identifier rather than an incompatible bare UUID.
- Keep logical-request idempotency keys as strict UUIDs.
- Centralize both identifier formats so activation, runtime context, and outgoing headers cannot drift independently.
- Reject bare UUID journey IDs and retain the existing fail-closed behavior.

## Evidence

The released managed edge at `da2c598360d4d588cd3fb1c12646aa4c5f0d7654` formats reservations as `journey_<UUID>` and validates the same prefix on query, cancellation, and admission. The previous plugin merge accepted only bare UUIDs, so every real reservation would fail local activation.

## Verification

- Focused context tests: 3 tests, 15 assertions.
- Focused provider tests: 38 tests, 134 assertions.
- Targeted PHPCS: clean.
- `composer phpstan`: no errors across 343 files.
- `git diff --check`: clean.

Resolves #2634

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 20h 14m and 962,942 tokens on this with the user in an interactive session. Overall, 1h 40m since this issue was created.
