### PR TITLE
feat: add account-gated Advanced distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,18 +111,35 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: superdav-ai-agent-release-zips
-          path: |
-            build/superdav-ai-agent-${{ env.VERSION }}.zip
-            build/superdav-ai-agent-advanced-${{ env.VERSION }}.zip
+          name: superdav-ai-agent-core-release-zip
+          path: build/superdav-ai-agent-${{ env.VERSION }}.zip
           retention-days: 7
+
+      - name: Publish Advanced to authenticated package storage
+        if: ${{ env.IS_PRERELEASE != 'true' }}
+        env:
+          SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN: ${{ secrets.SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN}" ]; then
+            echo "::error::SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN is required to publish Advanced."
+            exit 1
+          fi
+
+          curl --fail --show-error --silent \
+            --retry 3 \
+            --request PUT \
+            --header "Authorization: Bearer ${SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN}" \
+            --header "Content-Type: application/zip" \
+            --data-binary "@build/superdav-ai-agent-advanced-${VERSION}.zip" \
+            --output /dev/null \
+            "https://api.sdaiagent.com/v1/admin/packages/superdav-ai-agent-advanced/${VERSION}"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             build/superdav-ai-agent-${{ env.VERSION }}.zip
-            build/superdav-ai-agent-advanced-${{ env.VERSION }}.zip
           name: Superdav AI Agent v${{ env.VERSION }}
           draft: false
           prerelease: ${{ env.IS_PRERELEASE == 'true' }}
@@ -132,15 +149,13 @@ jobs:
             ## Downloads
 
             - `superdav-ai-agent-${{ env.VERSION }}.zip` — core plugin. This is the WordPress.org package and is also attached here for direct GitHub installs.
-            - `superdav-ai-agent-advanced-${{ env.VERSION }}.zip` — advanced companion plugin for self-hosted administrator/developer tools. This package is attached to the GitHub release only and is not deployed to WordPress.org SVN.
+            - SD AI Agent Advanced — stable packages are published to authenticated SD AI package storage. Connect a verified SD AI account in the plugin settings to install it.
 
             ## WordPress.org
 
             Stable `v*.*.*` releases publish only the core `superdav-ai-agent` package to the WordPress.org SVN trunk and tag. Pre-release tags create GitHub release assets but skip SVN deployment.
 
-            ## WooCommerce Marketplace
-
-            This repository does not publish either package to the WooCommerce Marketplace. The advanced companion ZIP remains a GitHub release asset only unless a separate marketplace deployment workflow is added later with explicit product targets and credentials.
+            The Advanced package is not attached publicly to this GitHub release and does not require a WooCommerce purchase.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -150,13 +165,15 @@ jobs:
           {
             echo "## Release channels"
             echo ""
-            echo "- GitHub release: core and advanced ZIP assets uploaded."
+            echo "- GitHub release: core ZIP uploaded."
             if [ "${IS_PRERELEASE}" = "true" ]; then
               echo "- WordPress.org SVN: skipped for pre-release tag."
+              echo "- Advanced package: authenticated publishing skipped for pre-release tag."
             else
               echo "- WordPress.org SVN: core package deploy runs in the dependent job."
+              echo "- Advanced package: published to authenticated SD AI package storage."
             fi
-            echo "- WooCommerce Marketplace: not configured for this repository; no marketplace upload is attempted."
+            echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy-to-wporg:
@@ -175,7 +192,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: superdav-ai-agent-release-zips
+          name: superdav-ai-agent-core-release-zip
           path: build/
 
       - name: Extract core build artifact
@@ -295,6 +312,6 @@ jobs:
             echo "## WordPress.org deployment"
             echo ""
             echo "- Core package: deployed to WordPress.org SVN trunk and tag ${VERSION}."
-            echo "- Advanced companion package: not deployed to WordPress.org SVN."
-            echo "- WooCommerce Marketplace: not configured for this repository; no marketplace upload is attempted."
+            echo "- Advanced companion package: distributed through authenticated SD AI package storage, not WordPress.org SVN."
+            echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -233,6 +233,8 @@ System notices:
 - Use **Link a different user** as a secondary action. Relinking must open the managed confirmation flow rather than accepting identity details in WordPress.
 - **Open account portal**, **Manage payment methods**, and **Add credits** are buttons that request a fresh one-time URL when clicked; do not render, inspect, or persist action tickets in the settings page.
 - Open account actions in a separate tab when the browser permits, clear `window.opener`, and show one neutral retry notice if URL minting fails.
+- Keep Advanced installation inside the SD AI account surface rather than linking to a manual-download card elsewhere. Disable **Install and activate** until a verified account is linked and WordPress allows plugin changes.
+- After activation, replace the install action with concise version status and an **Automatic updates** toggle. Keep download credentials and storage paths out of browser state.
 - Keep the account tab and each account card padded on every viewport: use the 2xl spacing token on desktop, the xl token on compact screens, and never let card content touch the settings panel edge.
 
 ### Tooltips

--- a/advanced-plugin/superdav-ai-agent-advanced.php
+++ b/advanced-plugin/superdav-ai-agent-advanced.php
@@ -10,6 +10,7 @@
  * Requires at least: 7.0
  * Requires PHP: 8.2
  * Requires Plugins: superdav-ai-agent
+ * Update URI:  https://api.sdaiagent.com/v1/site/packages/superdav-ai-agent-advanced
  * Text Domain: superdav-ai-agent-advanced
  *
  * @package SdAiAgentAdvanced

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"automattic/jetpack-autoloader": "^5.0.19",
 		"psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
 		"smalot/pdfparser": "^2.12.5",
-		"x-wp/di": "dev-fix/rest-context-plain-permalink-support as 1.9.99"
+		"x-wp/di": "dev-fix/rest-context-plain-permalink-support as 1.9.99",
+		"yahnis-elsts/plugin-update-checker": "^5.6"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce64d11cc73ac39af00680511946ed06",
+    "content-hash": "d7c092ef391fbab51402b92d675a9b93",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -820,6 +820,56 @@
                 }
             ],
             "time": "2025-06-08T10:17:19+00:00"
+        },
+        {
+            "name": "yahnis-elsts/plugin-update-checker",
+            "version": "v5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
+                "reference": "275a96a2a18d03c34c87f35cb68673c8c49ac3b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/275a96a2a18d03c34c87f35cb68673c8c49ac3b1",
+                "reference": "275a96a2a18d03c34c87f35cb68673c8c49ac3b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "load-v5p7.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Yahnis Elsts",
+                    "email": "whiteshadow@w-shadow.com",
+                    "homepage": "https://w-shadow.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A custom update checker for WordPress plugins and themes. Useful if you can't host your plugin in the official WP repository but still want it to support automatic updates.",
+            "homepage": "https://github.com/YahnisElsts/plugin-update-checker/",
+            "keywords": [
+                "automatic updates",
+                "plugin updates",
+                "theme updates",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/YahnisElsts/plugin-update-checker/issues",
+                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v5.7"
+            },
+            "time": "2026-05-26T12:48:45+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -38,7 +38,7 @@ class FileAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by SD AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, upload it via Plugins > Add New > Upload Plugin, install it, then activate the installed plugin.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by SD AI Agent Advanced. Connect a verified SD AI account in the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -33,7 +33,7 @@ class WordPressAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by SD AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, upload it via Plugins > Add New > Upload Plugin, install it, then activate the installed plugin.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by SD AI Agent Advanced. Connect a verified SD AI account in the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Core/AdvancedPluginManager.php
+++ b/includes/Core/AdvancedPluginManager.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+use WP_Error;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Filter;
+use XWP\DI\Decorators\Handler;
+use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Installs and updates the separately distributed Advanced companion plugin.
+ */
+#[Handler(
+	container: 'sd-ai-agent',
+	context: Handler::CTX_GLOBAL,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class AdvancedPluginManager {
+
+	public const PLUGIN_BASENAME    = 'superdav-ai-agent-advanced/superdav-ai-agent-advanced.php';
+	public const AUTO_UPDATE_OPTION = 'sd_ai_agent_advanced_auto_update';
+
+	private SuperdavSiteConnectionService $connection;
+
+	public function __construct( SuperdavSiteConnectionService $connection ) {
+		$this->connection = $connection;
+	}
+
+	/** Register PUC for a separately installed Advanced plugin. */
+	#[Action( tag: 'init', priority: 20 )]
+	public function register_update_checker(): void {
+		$plugin_file = $this->plugin_file();
+		$endpoint    = $this->connection->get_advanced_plugin_metadata_endpoint();
+		if ( $this->is_bundled_copy() || ! file_exists( $plugin_file ) || '' === $endpoint || ! class_exists( PucFactory::class ) ) {
+			return;
+		}
+
+		$update_checker = PucFactory::buildUpdateChecker(
+			$endpoint,
+			$plugin_file,
+			'superdav-ai-agent-advanced',
+			12
+		);
+
+		if ( method_exists( $update_checker, 'addHttpRequestArgFilter' ) ) {
+			$update_checker->addHttpRequestArgFilter( array( $this->connection, 'add_package_authorization' ) );
+		}
+	}
+
+	/**
+	 * Download the exact authenticated package and verify its service checksum.
+	 *
+	 * @param false|string|WP_Error $reply      Prior short-circuit value.
+	 * @param string                $package    Requested package URL.
+	 * @param mixed                 $upgrader   WordPress upgrader instance.
+	 * @param array<string, mixed>  $hook_extra Upgrader context.
+	 * @return false|string|WP_Error Verified temporary ZIP path or prior value.
+	 */
+	#[Filter( tag: 'upgrader_pre_download', priority: 10, args: 4 )]
+	public function authenticated_package_download( false|string|WP_Error $reply, string $package, mixed $upgrader, array $hook_extra ): false|string|WP_Error {
+		unset( $upgrader, $hook_extra );
+
+		if ( false !== $reply || $package !== $this->connection->get_advanced_plugin_download_endpoint() ) {
+			return $reply;
+		}
+
+		$metadata = $this->connection->request_advanced_plugin_metadata();
+		if ( $metadata instanceof WP_Error ) {
+			return $metadata;
+		}
+
+		if ( ! function_exists( 'wp_tempnam' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$temporary_file = wp_tempnam( self::PLUGIN_BASENAME );
+		if ( ! is_string( $temporary_file ) || '' === $temporary_file ) {
+			return new WP_Error( 'sd_ai_agent_advanced_download_failed', __( 'WordPress could not create a temporary file for Advanced.', 'superdav-ai-agent' ) );
+		}
+
+		$response = wp_remote_get(
+			$metadata['download_url'],
+			$this->connection->add_package_authorization(
+				array(
+					'timeout'     => 300.0,
+					'redirection' => 0,
+					'stream'      => true,
+					'filename'    => $temporary_file,
+					'headers'     => array( 'Accept' => 'application/zip, application/octet-stream' ),
+				)
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			wp_delete_file( $temporary_file );
+			return new WP_Error( 'sd_ai_agent_advanced_download_failed', __( 'SD AI Agent Advanced could not be downloaded.', 'superdav-ai-agent' ) );
+		}
+
+		$checksum        = hash_file( 'sha256', $temporary_file );
+		$response_header = wp_remote_retrieve_header( $response, 'x-package-sha256' );
+		$header_matches  = '' === $response_header
+			|| ( is_string( $response_header ) && hash_equals( $metadata['package_sha256'], strtolower( $response_header ) ) );
+		if ( ! is_string( $checksum )
+			|| ! hash_equals( $metadata['package_sha256'], $checksum )
+			|| ! $header_matches
+		) {
+			wp_delete_file( $temporary_file );
+			return new WP_Error( 'sd_ai_agent_advanced_checksum_mismatch', __( 'SD AI Agent Advanced failed integrity verification.', 'superdav-ai-agent' ) );
+		}
+
+		return $temporary_file;
+	}
+
+	/**
+	 * Enable or disable WordPress automatic updates for Advanced.
+	 *
+	 * @param bool|null $update Existing automatic-update decision.
+	 * @param mixed     $item   WordPress plugin update item.
+	 * @return bool|null Automatic-update decision.
+	 */
+	#[Filter( tag: 'auto_update_plugin', priority: 10, args: 2 )]
+	public function filter_auto_update( ?bool $update, mixed $item ): ?bool {
+		$plugin = is_object( $item ) && isset( $item->plugin ) && is_string( $item->plugin ) ? $item->plugin : '';
+		if ( self::PLUGIN_BASENAME !== $plugin ) {
+			return $update;
+		}
+
+		return $this->auto_updates_enabled();
+	}
+
+	/**
+	 * Return browser-safe local installation state.
+	 *
+	 * @return array<string, bool|string|null>
+	 */
+	public function get_status(): array {
+		$installed      = file_exists( $this->plugin_file() );
+		$active         = $installed && $this->is_active();
+		$bundled        = $this->is_bundled_copy();
+		$account_status = $this->connection->get_status();
+		$linked_account = isset( $account_status['linked_user'] ) && is_array( $account_status['linked_user'] );
+		$plugin_data    = $installed ? $this->plugin_data() : array();
+
+		return array(
+			'installed'            => $installed,
+			'active'               => $active,
+			'bundled'              => $bundled,
+			'version'              => isset( $plugin_data['Version'] ) && is_string( $plugin_data['Version'] ) ? $plugin_data['Version'] : null,
+			'auto_updates_enabled' => $this->auto_updates_enabled(),
+			'account_linked'       => $linked_account,
+			'file_mods_allowed'    => $this->file_mods_allowed(),
+			'can_manage'           => self::current_user_can_manage() && ! $bundled,
+		);
+	}
+
+	/** Install Advanced from the managed service and activate it. */
+	public function install_and_activate(): array|WP_Error {
+		$permission = $this->validate_management_permission();
+		if ( $permission instanceof WP_Error ) {
+			return $permission;
+		}
+
+		if ( $this->is_bundled_copy() ) {
+			return new WP_Error( 'sd_ai_agent_advanced_bundled', __( 'The repository-bundled Advanced plugin is already loaded.', 'superdav-ai-agent' ), array( 'status' => 409 ) );
+		}
+
+		if ( ! file_exists( $this->plugin_file() ) ) {
+			$metadata = $this->connection->request_advanced_plugin_metadata();
+			if ( $metadata instanceof WP_Error ) {
+				return $metadata;
+			}
+
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+
+			$skin     = new \Automatic_Upgrader_Skin();
+			$upgrader = new \Plugin_Upgrader( $skin );
+			add_filter( 'upgrader_pre_download', array( $this, 'authenticated_package_download' ), 10, 4 );
+			try {
+				$result = $upgrader->install( $metadata['download_url'] );
+			} finally {
+				remove_filter( 'upgrader_pre_download', array( $this, 'authenticated_package_download' ), 10 );
+			}
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+			if ( true !== $result || ! file_exists( $this->plugin_file() ) ) {
+				return new WP_Error( 'sd_ai_agent_advanced_install_failed', __( 'SD AI Agent Advanced could not be installed.', 'superdav-ai-agent' ), array( 'status' => 500 ) );
+			}
+		}
+
+		if ( ! function_exists( 'activate_plugin' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$network_wide = is_multisite() && is_plugin_active_for_network( plugin_basename( SD_AI_AGENT_DIR . '/superdav-ai-agent.php' ) );
+		$activation   = activate_plugin( self::PLUGIN_BASENAME, '', $network_wide, true );
+		if ( $activation instanceof WP_Error ) {
+			return $activation;
+		}
+
+		update_option( self::AUTO_UPDATE_OPTION, true, false );
+
+		return $this->get_status();
+	}
+
+	/** Persist the administrator's Advanced automatic-update preference. */
+	public function set_auto_updates_enabled( bool $enabled ): array|WP_Error {
+		$permission = $this->validate_management_permission();
+		if ( $permission instanceof WP_Error ) {
+			return $permission;
+		}
+
+		update_option( self::AUTO_UPDATE_OPTION, $enabled, false );
+
+		return $this->get_status();
+	}
+
+	/** Whether the current administrator may install and activate plugins. */
+	public static function current_user_can_manage(): bool {
+		return current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' );
+	}
+
+	private function validate_management_permission(): true|WP_Error {
+		if ( ! self::current_user_can_manage() ) {
+			return new WP_Error( 'rest_forbidden', __( 'You are not allowed to manage plugins on this site.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+
+		if ( ! $this->file_mods_allowed() ) {
+			return new WP_Error( 'sd_ai_agent_file_mods_disabled', __( 'Plugin installation is disabled by this site configuration.', 'superdav-ai-agent' ), array( 'status' => 409 ) );
+		}
+
+		return true;
+	}
+
+	private function file_mods_allowed(): bool {
+		return wp_is_file_mod_allowed( 'sd_ai_agent_advanced' );
+	}
+
+	private function auto_updates_enabled(): bool {
+		return true === (bool) get_option( self::AUTO_UPDATE_OPTION, true );
+	}
+
+	private function plugin_file(): string {
+		return WP_PLUGIN_DIR . '/' . self::PLUGIN_BASENAME;
+	}
+
+	private function is_bundled_copy(): bool {
+		return defined( 'SD_AI_AGENT_DIR' ) && file_exists( SD_AI_AGENT_DIR . '/advanced-plugin/superdav-ai-agent-advanced.php' );
+	}
+
+	private function is_active(): bool {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return is_plugin_active( self::PLUGIN_BASENAME ) || ( is_multisite() && is_plugin_active_for_network( self::PLUGIN_BASENAME ) );
+	}
+
+	/** @return array<string, mixed> */
+	private function plugin_data(): array {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return get_plugin_data( $this->plugin_file(), false, false );
+	}
+}

--- a/includes/Core/AdvancedPluginManager.php
+++ b/includes/Core/AdvancedPluginManager.php
@@ -121,12 +121,12 @@ final class AdvancedPluginManager {
 	/**
 	 * Enable or disable WordPress automatic updates for Advanced.
 	 *
-	 * @param bool|null $update Existing automatic-update decision.
-	 * @param mixed     $item   WordPress plugin update item.
-	 * @return bool|null Automatic-update decision.
+	 * @param mixed $update Existing automatic-update decision.
+	 * @param mixed $item   WordPress plugin update item.
+	 * @return mixed Automatic-update decision.
 	 */
 	#[Filter( tag: 'auto_update_plugin', priority: 10, args: 2 )]
-	public function filter_auto_update( ?bool $update, mixed $item ): ?bool {
+	public function filter_auto_update( mixed $update, mixed $item ): mixed {
 		$plugin = is_object( $item ) && isset( $item->plugin ) && is_string( $item->plugin ) ? $item->plugin : '';
 		if ( self::PLUGIN_BASENAME !== $plugin ) {
 			return $update;

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -31,6 +31,8 @@ final class SuperdavSiteConnectionService {
 	private const ACCOUNT_STATUS_ENDPOINT_PATH            = 'site/account';
 	private const ACCOUNT_ACTION_ENDPOINT_PATH            = 'site/account/action';
 	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'site/account/redeem-coupon';
+	private const ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH  = 'site/packages/superdav-ai-agent-advanced';
+	private const ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT_PATH  = 'site/packages/superdav-ai-agent-advanced/download';
 
 	/**
 	 * Maximum number of newest-first credit activity rows retained for display.
@@ -422,6 +424,106 @@ final class SuperdavSiteConnectionService {
 	 */
 	public function has_remote_registration_endpoint(): bool {
 		return '' !== $this->get_registration_endpoint();
+	}
+
+	/**
+	 * Add the private site bearer token to one server-to-server package request.
+	 *
+	 * This callback is also passed to Plugin Update Checker. It must never be
+	 * used for browser responses or URLs.
+	 *
+	 * @param array<string, mixed> $request_args WordPress HTTP request arguments.
+	 * @return array<string, mixed> Request arguments with site authorization.
+	 * @phpstan-param array{timeout?:float,redirection?:int,headers?:array<string,string>|string,stream?:bool,filename?:string,...} $request_args
+	 * @phpstan-return array{timeout?:float,redirection?:int,headers?:array<string,string>|string,stream?:bool,filename?:string,...}
+	 */
+	public function add_package_authorization( array $request_args ): array {
+		$token = $this->get_stored_token();
+		if ( '' === $token ) {
+			return $request_args;
+		}
+
+		$headers                  = isset( $request_args['headers'] ) && is_array( $request_args['headers'] ) ? $request_args['headers'] : array();
+		$headers['Authorization'] = 'Bearer ' . $token;
+		$request_args['headers']  = $headers;
+
+		return $request_args;
+	}
+
+	/** Return the authenticated PUC metadata endpoint for Advanced. */
+	public function get_advanced_plugin_metadata_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT', self::ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH );
+		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_metadata_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+	}
+
+	/** Return the authenticated package download endpoint for Advanced. */
+	public function get_advanced_plugin_download_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT', self::ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT_PATH );
+		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_download_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+	}
+
+	/**
+	 * Fetch and validate the Advanced package metadata used for installation.
+	 *
+	 * @return array{version:string,download_url:string,package_sha256:string}|WP_Error
+	 */
+	public function request_advanced_plugin_metadata(): array|WP_Error {
+		$endpoint = $this->get_advanced_plugin_metadata_endpoint();
+		if ( '' === $endpoint || '' === $this->get_stored_token() ) {
+			return new WP_Error( 'sd_ai_agent_advanced_connection_required', __( 'Connect SD AI before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 412 ) );
+		}
+
+		$response = wp_remote_get(
+			$endpoint,
+			$this->add_package_authorization(
+				array(
+					'timeout'     => 15.0,
+					'redirection' => 0,
+					'headers'     => array( 'Accept' => 'application/json' ),
+				)
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sd_ai_agent_advanced_package_unavailable', __( 'SD AI Agent Advanced is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( 401 === $status ) {
+			return new WP_Error( 'sd_ai_agent_advanced_connection_expired', __( 'Reconnect SD AI before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 401 ) );
+		}
+		if ( 403 === $status ) {
+			return new WP_Error( 'sd_ai_agent_advanced_account_link_required', __( 'Connect a verified SD AI account to this site before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error( 'sd_ai_agent_advanced_package_unavailable', __( 'SD AI Agent Advanced is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+
+		$body              = json_decode( wp_remote_retrieve_body( $response ), true );
+		$download_endpoint = $this->get_advanced_plugin_download_endpoint();
+		if ( ! is_array( $body )
+			|| 'superdav-ai-agent-advanced' !== ( $body['slug'] ?? null )
+			|| ! isset( $body['version'], $body['download_url'], $body['package_sha256'] )
+			|| ! is_string( $body['version'] )
+			|| ! is_string( $body['download_url'] )
+			|| ! is_string( $body['package_sha256'] )
+			|| 1 !== preg_match( '/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/', $body['version'] )
+			|| 1 !== preg_match( '/^[a-f0-9]{64}$/', $body['package_sha256'] )
+			|| '' === $download_endpoint
+			|| $download_endpoint !== esc_url_raw( $body['download_url'] )
+		) {
+			return new WP_Error( 'sd_ai_agent_advanced_package_invalid', __( 'The SD AI Agent Advanced package response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		return array(
+			'version'        => $body['version'],
+			'download_url'   => $download_endpoint,
+			'package_sha256' => $body['package_sha256'],
+		);
 	}
 
 	/**

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -455,7 +455,7 @@ final class SuperdavSiteConnectionService {
 		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT', self::ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH );
 		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_metadata_endpoint', $endpoint );
 
-		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		return $this->sanitize_account_url( $endpoint );
 	}
 
 	/** Return the authenticated package download endpoint for Advanced. */
@@ -463,7 +463,7 @@ final class SuperdavSiteConnectionService {
 		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT', self::ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT_PATH );
 		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_download_endpoint', $endpoint );
 
-		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		return $this->sanitize_account_url( $endpoint );
 	}
 
 	/**
@@ -514,7 +514,7 @@ final class SuperdavSiteConnectionService {
 			|| 1 !== preg_match( '/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/', $body['version'] )
 			|| 1 !== preg_match( '/^[a-f0-9]{64}$/', $body['package_sha256'] )
 			|| '' === $download_endpoint
-			|| $download_endpoint !== esc_url_raw( $body['download_url'] )
+			|| $download_endpoint !== $this->sanitize_account_url( $body['download_url'] )
 		) {
 			return new WP_Error( 'sd_ai_agent_advanced_package_invalid', __( 'The SD AI Agent Advanced package response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -523,7 +523,7 @@ class SystemInstructionBuilder {
 			. 'Your active ability manifest is authoritative. Treat questions such as “Is Advanced enabled?” or “Can you generate plugins?” as read-only capability-status questions: answer directly from that manifest without calling site-inspection tools such as list-options, list-posts, or get-plugins. '
 			. 'Plugin generation is available in the current session only when `sd-ai-agent/generate-plugin` appears in the active ability manifest or direct tool list. If it is present, say that plugin generation is available; if it is absent, say that plugin generation is not currently available and requires SD AI Agent Advanced. Do not infer availability from installed plugin files, options, or source-checkout contents. '
 			. 'If another requested action needs an ability that is not available, or a tool returns the `sd_ai_agent_advanced_plugin_required` error, explain that the capability is provided by SD AI Agent Advanced. '
-			. 'Do not attempt to download, install, activate, or update Advanced automatically. Direct the site administrator to https://sdaiagent.com/advanced/ for the direct ZIP download and manual installation instructions.';
+			. 'Do not attempt to download, install, activate, or update Advanced automatically. Direct the site administrator to the SD AI account settings, where they can connect a verified account and choose Install and activate.';
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -43,6 +43,7 @@ use SdAiAgent\Bootstrap\KnowledgeHooksHandler;
 use SdAiAgent\Bootstrap\OnboardingHandler;
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Bootstrap\ToolDiscoveryHandler;
+use SdAiAgent\Core\AdvancedPluginManager;
 use SdAiAgent\Contracts\BudgetCheckerInterface;
 use SdAiAgent\Contracts\SessionRepositoryInterface;
 use SdAiAgent\Contracts\SettingsProviderInterface;
@@ -98,6 +99,7 @@ use XWP\DI\Decorators\Module;
 		UsageInstructionsFilter::class,
 		RequestTimeoutFilter::class,
 		SuperdavAiProviderHandler::class,
+		AdvancedPluginManager::class,
 		CliHandler::class,
 		AbilitiesHandler::class,
 		WooCommerceIntegrationHandler::class,

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -17,6 +17,7 @@ use SdAiAgent\Abilities\InternetSearchAbilities;
 use SdAiAgent\Abilities\SmsAbilities;
 use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\AdvancedPluginManager;
 use SdAiAgent\Core\BudgetManager;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Features;
@@ -176,6 +177,32 @@ final class SettingsController {
 						'required'          => true,
 						'type'              => 'string',
 						'validate_callback' => static fn( mixed $value ): bool => is_string( $value ) && '' !== trim( $value ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/superdav-account/advanced-plugin/install',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_install_advanced_plugin' ),
+				'permission_callback' => array( AdvancedPluginManager::class, 'current_user_can_manage' ),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/superdav-account/advanced-plugin/auto-updates',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_advanced_plugin_auto_updates' ),
+				'permission_callback' => array( AdvancedPluginManager::class, 'current_user_can_manage' ),
+				'args'                => array(
+					'enabled' => array(
+						'required' => true,
+						'type'     => 'boolean',
 					),
 				),
 			)
@@ -560,6 +587,8 @@ final class SettingsController {
 	public function handle_get_superdav_account(): WP_REST_Response {
 		$status = ( new SuperdavSiteConnectionService() )->get_status();
 
+		$status['advanced_plugin'] = $this->advanced_plugin_manager()->get_status();
+
 		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
 	}
 
@@ -573,8 +602,34 @@ final class SettingsController {
 		if ( $status instanceof WP_Error ) {
 			return $status;
 		}
+		$status['advanced_plugin'] = $this->advanced_plugin_manager()->get_status();
 
 		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
+	}
+
+	/** Install and activate the authenticated Advanced package. */
+	public function handle_install_advanced_plugin(): WP_REST_Response|WP_Error {
+		$status = $this->advanced_plugin_manager()->install_and_activate();
+		if ( $status instanceof WP_Error ) {
+			return $status;
+		}
+
+		return new WP_REST_Response( $status, 200 );
+	}
+
+	/** Persist the Advanced automatic-update preference. */
+	public function handle_advanced_plugin_auto_updates( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$enabled = $request->get_param( 'enabled' );
+		if ( ! is_bool( $enabled ) && ! is_int( $enabled ) && ! is_string( $enabled ) ) {
+			return new WP_Error( 'sd_ai_agent_advanced_auto_updates_invalid', __( 'Choose whether automatic updates should be enabled.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+		}
+
+		$status = $this->advanced_plugin_manager()->set_auto_updates_enabled( rest_sanitize_boolean( $enabled ) );
+		if ( $status instanceof WP_Error ) {
+			return $status;
+		}
+
+		return new WP_REST_Response( $status, 200 );
 	}
 
 	/**
@@ -662,6 +717,11 @@ final class SettingsController {
 		$status['chat_sessions'] = $chat_sessions;
 
 		return $status;
+	}
+
+	/** Build the package manager outside DI so existing controller tests remain stable. */
+	private function advanced_plugin_manager(): AdvancedPluginManager {
+		return new AdvancedPluginManager( new SuperdavSiteConnectionService() );
 	}
 
 	/**

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -52,6 +52,18 @@ jest.mock( '@wordpress/components', () => {
 					onChange: ( event ) => onChange( event.target.value ),
 				} )
 			),
+		ToggleControl: ( { label, checked, onChange, disabled } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'input', {
+					type: 'checkbox',
+					checked,
+					disabled,
+					onChange: ( event ) => onChange( event.target.checked ),
+				} )
+			),
 	};
 } );
 
@@ -375,6 +387,56 @@ describe( 'SuperdavAccountManager', () => {
 
 		expect( findButton( 'Connect account to site' ) ).toBeDefined();
 		expect( findButton( 'Link a different user' ) ).toBeUndefined();
+	} );
+
+	test( 'installs Advanced from the connected account and enables automatic updates', async () => {
+		apiFetch
+			.mockResolvedValueOnce( {
+				configured: true,
+				linked_user: {
+					display_name: 'Verified Customer',
+					masked_email: 'v***@example.test',
+					email_verified: true,
+				},
+				advanced_plugin: {
+					installed: false,
+					active: false,
+					bundled: false,
+					can_manage: true,
+					file_mods_allowed: true,
+				},
+			} )
+			.mockResolvedValueOnce( {
+				installed: true,
+				active: true,
+				bundled: false,
+				version: '1.22.4',
+				auto_updates_enabled: true,
+				can_manage: true,
+				file_mods_allowed: true,
+			} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		await act( async () => {
+			findButton( 'Install and activate' ).click();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/sd-ai-agent/v1/superdav-account/advanced-plugin/install',
+			method: 'POST',
+		} );
+		expect( container.textContent ).toContain( 'Active — version 1.22.4' );
+		expect( container.textContent ).toContain( 'Automatic updates' );
+		expect(
+			container.querySelector( 'input[type="checkbox"]' ).checked
+		).toBe( true );
 	} );
 
 	test( 'redeems a coupon, disables submission while pending, and updates the balance', async () => {

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -1998,39 +1998,6 @@ export default function SettingsApp() {
 							case 'advanced':
 								return (
 									<div className="sdaa-settings-section">
-										<div className="sd-ai-agent-advanced-companion-card">
-											<div>
-												<p className="sd-ai-agent-advanced-companion-card__eyebrow">
-													{ __(
-														'Extend your toolkit',
-														'superdav-ai-agent'
-													) }
-												</p>
-												<h3>
-													{ __(
-														'SD AI Agent Advanced',
-														'superdav-ai-agent'
-													) }
-												</h3>
-												<p>
-													{ __(
-														'Add self-hosted administrator and developer tools, including advanced plugin and file-management capabilities.',
-														'superdav-ai-agent'
-													) }
-												</p>
-											</div>
-											<a
-												className="button button-primary"
-												href="https://sdaiagent.com/advanced/"
-												rel="noopener noreferrer"
-												target="_blank"
-											>
-												{ __(
-													'Get Advanced',
-													'superdav-ai-agent'
-												) }
-											</a>
-										</div>
 										<h3 className="sdaa-settings-section-title">
 											{ __(
 												'Model Parameters',

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -127,53 +127,6 @@
 	gap: 8px;
 }
 
-/* Advanced companion */
-.sd-ai-agent-advanced-companion-card {
-	align-items: center;
-	background: linear-gradient(135deg, #f0f6fc, #fff);
-	border: 1px solid #72aee6;
-	border-radius: 4px;
-	display: flex;
-	gap: 24px;
-	justify-content: space-between;
-	padding: 20px;
-}
-
-.sd-ai-agent-advanced-companion-card h3,
-.sd-ai-agent-advanced-companion-card p {
-	margin: 0;
-}
-
-.sd-ai-agent-advanced-companion-card h3 {
-	font-size: 16px;
-	margin-bottom: 4px;
-}
-
-.sd-ai-agent-advanced-companion-card p:not(.sd-ai-agent-advanced-companion-card__eyebrow) {
-	max-width: 620px;
-}
-
-.sd-ai-agent-advanced-companion-card__eyebrow {
-	color: #135e96;
-	font-size: 12px;
-	font-weight: 600;
-	letter-spacing: 0.04em;
-	margin-bottom: 6px !important;
-	text-transform: uppercase;
-}
-
-.sd-ai-agent-advanced-companion-card .button {
-	flex: 0 0 auto;
-}
-
-@media screen and (max-width: 600px) {
-	.sd-ai-agent-advanced-companion-card {
-		align-items: flex-start;
-		flex-direction: column;
-		gap: 16px;
-	}
-}
-
 /* YOLO mode section */
 .sdaa-settings-yolo-section {
 	display: flex;
@@ -555,6 +508,7 @@
 
 .sd-ai-agent-superdav-account-overview,
 .sd-ai-agent-superdav-linked-user,
+.sd-ai-agent-superdav-advanced-plugin,
 .sd-ai-agent-superdav-session-usage,
 .sd-ai-agent-superdav-credit-activity {
 	box-sizing: border-box;
@@ -569,6 +523,28 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: 16px;
+}
+
+.sd-ai-agent-superdav-advanced-plugin {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 24px;
+}
+
+.sd-ai-agent-superdav-advanced-plugin h4 {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-superdav-advanced-status {
+	display: block;
+	margin-top: 12px;
+}
+
+.sd-ai-agent-superdav-advanced-actions {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
 }
 
 .sd-ai-agent-superdav-linked-user h4 {
@@ -848,12 +824,14 @@
 
 	.sd-ai-agent-superdav-account-overview,
 	.sd-ai-agent-superdav-linked-user,
+	.sd-ai-agent-superdav-advanced-plugin,
 	.sd-ai-agent-superdav-session-usage,
 	.sd-ai-agent-superdav-credit-activity {
 		padding: 16px;
 	}
 
-	.sd-ai-agent-superdav-linked-user {
+	.sd-ai-agent-superdav-linked-user,
+	.sd-ai-agent-superdav-advanced-plugin {
 		align-items: flex-start;
 		flex-direction: column;
 	}

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -8,6 +8,7 @@ import {
 	Notice,
 	Spinner,
 	TextControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -404,6 +405,8 @@ export default function SuperdavAccountManager() {
 	const [ redemptionNotice, setRedemptionNotice ] = useState( null );
 	const [ actionNotice, setActionNotice ] = useState( null );
 	const [ openingAction, setOpeningAction ] = useState( '' );
+	const [ advancedNotice, setAdvancedNotice ] = useState( null );
+	const [ advancedAction, setAdvancedAction ] = useState( '' );
 	const [ error, setError ] = useState( '' );
 	const [ hasLoadedAccount, setHasLoadedAccount ] = useState( false );
 
@@ -558,6 +561,91 @@ export default function SuperdavAccountManager() {
 		[ couponCode, redeeming ]
 	);
 
+	const installAdvanced = useCallback( async () => {
+		if ( advancedAction ) {
+			return;
+		}
+
+		setAdvancedAction( 'install' );
+		setAdvancedNotice( null );
+		try {
+			const result = await apiFetch( {
+				path: '/sd-ai-agent/v1/superdav-account/advanced-plugin/install',
+				method: 'POST',
+			} );
+			setAccount( ( current ) => ( {
+				...current,
+				advanced_plugin: result,
+			} ) );
+			setAdvancedNotice( {
+				status: 'success',
+				message: __(
+					'SD AI Agent Advanced is installed, active, and set to update automatically.',
+					'superdav-ai-agent'
+				),
+			} );
+		} catch ( err ) {
+			setAdvancedNotice( {
+				status: 'error',
+				message:
+					err?.message ||
+					__(
+						'SD AI Agent Advanced could not be installed.',
+						'superdav-ai-agent'
+					),
+			} );
+		} finally {
+			setAdvancedAction( '' );
+		}
+	}, [ advancedAction ] );
+
+	const setAdvancedAutoUpdates = useCallback(
+		async ( enabled ) => {
+			if ( advancedAction ) {
+				return;
+			}
+
+			setAdvancedAction( 'auto-updates' );
+			setAdvancedNotice( null );
+			try {
+				const result = await apiFetch( {
+					path: '/sd-ai-agent/v1/superdav-account/advanced-plugin/auto-updates',
+					method: 'POST',
+					data: { enabled },
+				} );
+				setAccount( ( current ) => ( {
+					...current,
+					advanced_plugin: result,
+				} ) );
+				setAdvancedNotice( {
+					status: 'success',
+					message: enabled
+						? __(
+								'Automatic updates are enabled for Advanced.',
+								'superdav-ai-agent'
+						  )
+						: __(
+								'Automatic updates are disabled for Advanced.',
+								'superdav-ai-agent'
+						  ),
+				} );
+			} catch ( err ) {
+				setAdvancedNotice( {
+					status: 'error',
+					message:
+						err?.message ||
+						__(
+							'Unable to change automatic updates for Advanced.',
+							'superdav-ai-agent'
+						),
+				} );
+			} finally {
+				setAdvancedAction( '' );
+			}
+		},
+		[ advancedAction ]
+	);
+
 	useEffect( () => {
 		loadAccount();
 	}, [ loadAccount ] );
@@ -576,6 +664,28 @@ export default function SuperdavAccountManager() {
 	const paymentMethodsAvailable = !! account?.payment_methods_available;
 	const linkAccountAvailable = !! account?.link_account_available;
 	const linkedUser = account?.linked_user || null;
+	const advancedPlugin = account?.advanced_plugin || {};
+	let advancedStatusLabel = __( 'Not installed', 'superdav-ai-agent' );
+	if ( advancedPlugin.bundled ) {
+		advancedStatusLabel = __(
+			'Loaded from this development repository',
+			'superdav-ai-agent'
+		);
+	} else if ( advancedPlugin.active ) {
+		advancedStatusLabel = sprintf(
+			/* translators: %s: installed plugin version. */
+			__( 'Active — version %s', 'superdav-ai-agent' ),
+			advancedPlugin.version || '—'
+		);
+	} else if ( advancedPlugin.installed ) {
+		advancedStatusLabel = __(
+			'Installed but inactive',
+			'superdav-ai-agent'
+		);
+	}
+	const advancedActionLabel = advancedPlugin.installed
+		? __( 'Activate Advanced', 'superdav-ai-agent' )
+		: __( 'Install and activate', 'superdav-ai-agent' );
 	const hasAccountActions =
 		purchaseCreditsAvailable ||
 		paymentMethodsAvailable ||
@@ -756,6 +866,14 @@ export default function SuperdavAccountManager() {
 					{ actionNotice.message }
 				</Notice>
 			) }
+			{ advancedNotice && (
+				<Notice
+					status={ advancedNotice.status }
+					isDismissible={ false }
+				>
+					{ advancedNotice.message }
+				</Notice>
+			) }
 
 			{ hasLoadedAccount &&
 				( ! configured ? (
@@ -814,6 +932,81 @@ export default function SuperdavAccountManager() {
 										  ) }
 								</Button>
 							) }
+						</section>
+
+						<section className="sd-ai-agent-superdav-advanced-plugin">
+							<div>
+								<h4>
+									{ __(
+										'SD AI Agent Advanced',
+										'superdav-ai-agent'
+									) }
+								</h4>
+								<p className="description">
+									{ __(
+										'Add self-hosted code, filesystem, database, WP-CLI, REST dispatcher, and plugin-builder tools.',
+										'superdav-ai-agent'
+									) }
+								</p>
+								<strong className="sd-ai-agent-superdav-advanced-status">
+									{ advancedStatusLabel }
+								</strong>
+								{ ! linkedUser && ! advancedPlugin.bundled && (
+									<p className="description">
+										{ __(
+											'Connect a verified SD AI account to this site to install Advanced.',
+											'superdav-ai-agent'
+										) }
+									</p>
+								) }
+								{ ! advancedPlugin.file_mods_allowed &&
+									! advancedPlugin.bundled && (
+										<p className="description">
+											{ __(
+												'Plugin installation is disabled by this site configuration.',
+												'superdav-ai-agent'
+											) }
+										</p>
+									) }
+							</div>
+							<div className="sd-ai-agent-superdav-advanced-actions">
+								{ advancedPlugin.active &&
+									! advancedPlugin.bundled && (
+										<ToggleControl
+											label={ __(
+												'Automatic updates',
+												'superdav-ai-agent'
+											) }
+											checked={
+												!! advancedPlugin.auto_updates_enabled
+											}
+											onChange={ setAdvancedAutoUpdates }
+											disabled={
+												!! advancedAction ||
+												! advancedPlugin.can_manage
+											}
+											__nextHasNoMarginBottom
+										/>
+									) }
+								{ ! advancedPlugin.active &&
+									! advancedPlugin.bundled && (
+										<Button
+											variant="primary"
+											onClick={ installAdvanced }
+											isBusy={
+												advancedAction === 'install'
+											}
+											disabled={
+												!! advancedAction ||
+												! linkedUser ||
+												! advancedPlugin.can_manage ||
+												! advancedPlugin.file_mods_allowed
+											}
+										>
+											{ advancedActionLabel }
+										</Button>
+									) }
+							</div>
 						</section>
 
 						<section

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3002,18 +3002,19 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the Advanced companion guidance gives administrators a manual path.
+	 * Test the Advanced companion guidance gives administrators the account-settings path.
 	 */
-	public function test_advanced_companion_guidance_links_to_manual_download(): void {
+	public function test_advanced_companion_guidance_links_to_account_settings(): void {
 		$builder     = new SystemInstructionBuilder();
 		$guidance    = SystemInstructionBuilder::build_advanced_companion_section();
 		$instruction = $builder->build( array() );
 
 		$this->assertStringContainsString( 'sd_ai_agent_advanced_plugin_required', $guidance );
-		$this->assertStringContainsString( 'https://sdaiagent.com/advanced/', $guidance );
+		$this->assertStringContainsString( 'SD AI account settings', $guidance );
+		$this->assertStringContainsString( 'Install and activate', $guidance );
 		$this->assertStringContainsString( 'Do not attempt to download, install, activate, or update', $guidance );
 		$this->assertStringContainsString( 'sd_ai_agent_advanced_plugin_required', $instruction );
-		$this->assertStringContainsString( 'https://sdaiagent.com/advanced/', $instruction );
+		$this->assertStringContainsString( 'SD AI account settings', $instruction );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- add one-click installation and activation of SD AI Agent Advanced
- add Plugin Update Checker integration, checksum verification, multisite activation, and automatic-update controls
- add the Advanced status and management card to SD AI account settings
- add the initial authenticated package publishing workflow

## Follow-up

This merged the initial account-gated distribution model. Advanced is now intended to be free and served publicly; that correction continues in:

- https://github.com/Ultimate-Multisite/superdav-ai-agent/pull/2642
- https://github.com/Ultimate-Multisite/superdav-ai-service/pull/100
- https://github.com/superdav42/tgc.church/pull/506
