### PR TITLE
fix: use WordPress update server for free Advanced downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           path: build/superdav-ai-agent-${{ env.VERSION }}.zip
           retention-days: 7
 
-      - name: Publish Advanced to public web storage
+      - name: Publish Advanced to the WordPress update server
         if: ${{ env.IS_PRERELEASE != 'true' }}
         env:
           SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN: ${{ secrets.SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
             --header "Content-Type: application/zip" \
             --data-binary "@build/superdav-ai-agent-advanced-${VERSION}.zip" \
             --output /dev/null \
-            "https://api.sdaiagent.com/v1/admin/packages/superdav-ai-agent-advanced/${VERSION}"
+            "https://sdaiagent.com/wp-json/superdav-ai-service/v1/packages/superdav-ai-agent-advanced/${VERSION}"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -149,13 +149,13 @@ jobs:
             ## Downloads
 
             - `superdav-ai-agent-${{ env.VERSION }}.zip` — core plugin. This is the WordPress.org package and is also attached here for direct GitHub installs.
-            - SD AI Agent Advanced — stable packages are published as free downloads on the SD AI web server. Install it from the SD AI account settings.
+            - SD AI Agent Advanced — stable packages are published as free downloads through the SD AI WordPress update server. Install it from the SD AI account settings.
 
             ## WordPress.org
 
             Stable `v*.*.*` releases publish only the core `superdav-ai-agent` package to the WordPress.org SVN trunk and tag. Pre-release tags create GitHub release assets but skip SVN deployment.
 
-            The Advanced package is free, served by the SD AI web server, and does not require a WooCommerce purchase or linked account.
+            The Advanced package is free, served by the SD AI WordPress update server, and does not require a WooCommerce purchase or linked account.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -168,10 +168,10 @@ jobs:
             echo "- GitHub release: core ZIP uploaded."
             if [ "${IS_PRERELEASE}" = "true" ]; then
               echo "- WordPress.org SVN: skipped for pre-release tag."
-              echo "- Advanced package: public web publishing skipped for pre-release tag."
+              echo "- Advanced package: WordPress update-server publishing skipped for pre-release tag."
             else
               echo "- WordPress.org SVN: core package deploy runs in the dependent job."
-              echo "- Advanced package: published to the public SD AI web server."
+              echo "- Advanced package: published to the SD AI WordPress update server."
             fi
             echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -312,6 +312,6 @@ jobs:
             echo "## WordPress.org deployment"
             echo ""
             echo "- Core package: deployed to WordPress.org SVN trunk and tag ${VERSION}."
-            echo "- Advanced companion package: distributed as a free download from the SD AI web server, not WordPress.org SVN."
+            echo "- Advanced companion package: distributed as a free download through the SD AI WordPress update server, not WordPress.org SVN."
             echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           path: build/superdav-ai-agent-${{ env.VERSION }}.zip
           retention-days: 7
 
-      - name: Publish Advanced to authenticated package storage
+      - name: Publish Advanced to public web storage
         if: ${{ env.IS_PRERELEASE != 'true' }}
         env:
           SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN: ${{ secrets.SUPERDAV_ADVANCED_PLUGIN_PUBLISH_TOKEN }}
@@ -149,13 +149,13 @@ jobs:
             ## Downloads
 
             - `superdav-ai-agent-${{ env.VERSION }}.zip` — core plugin. This is the WordPress.org package and is also attached here for direct GitHub installs.
-            - SD AI Agent Advanced — stable packages are published to authenticated SD AI package storage. Connect a verified SD AI account in the plugin settings to install it.
+            - SD AI Agent Advanced — stable packages are published as free downloads on the SD AI web server. Install it from the SD AI account settings.
 
             ## WordPress.org
 
             Stable `v*.*.*` releases publish only the core `superdav-ai-agent` package to the WordPress.org SVN trunk and tag. Pre-release tags create GitHub release assets but skip SVN deployment.
 
-            The Advanced package is not attached publicly to this GitHub release and does not require a WooCommerce purchase.
+            The Advanced package is free, served by the SD AI web server, and does not require a WooCommerce purchase or linked account.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -168,10 +168,10 @@ jobs:
             echo "- GitHub release: core ZIP uploaded."
             if [ "${IS_PRERELEASE}" = "true" ]; then
               echo "- WordPress.org SVN: skipped for pre-release tag."
-              echo "- Advanced package: authenticated publishing skipped for pre-release tag."
+              echo "- Advanced package: public web publishing skipped for pre-release tag."
             else
               echo "- WordPress.org SVN: core package deploy runs in the dependent job."
-              echo "- Advanced package: published to authenticated SD AI package storage."
+              echo "- Advanced package: published to the public SD AI web server."
             fi
             echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -312,6 +312,6 @@ jobs:
             echo "## WordPress.org deployment"
             echo ""
             echo "- Core package: deployed to WordPress.org SVN trunk and tag ${VERSION}."
-            echo "- Advanced companion package: distributed through authenticated SD AI package storage, not WordPress.org SVN."
+            echo "- Advanced companion package: distributed as a free download from the SD AI web server, not WordPress.org SVN."
             echo "- WooCommerce Marketplace: not used."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -233,8 +233,8 @@ System notices:
 - Use **Link a different user** as a secondary action. Relinking must open the managed confirmation flow rather than accepting identity details in WordPress.
 - **Open account portal**, **Manage payment methods**, and **Add credits** are buttons that request a fresh one-time URL when clicked; do not render, inspect, or persist action tickets in the settings page.
 - Open account actions in a separate tab when the browser permits, clear `window.opener`, and show one neutral retry notice if URL minting fails.
-- Keep Advanced installation inside the SD AI account surface rather than linking to a manual-download card elsewhere. Disable **Install and activate** until a verified account is linked and WordPress allows plugin changes.
-- After activation, replace the install action with concise version status and an **Automatic updates** toggle. Keep download credentials and storage paths out of browser state.
+- Keep free Advanced installation inside the SD AI account surface rather than linking to a manual-download card elsewhere. Disable **Install and activate** only when WordPress does not permit the current administrator to change plugins.
+- After activation, replace the install action with concise version status and an **Automatic updates** toggle. Keep release publishing credentials out of browser state.
 - Keep the account tab and each account card padded on every viewport: use the 2xl spacing token on desktop, the xl token on compact screens, and never let card content touch the settings panel edge.
 
 ### Tooltips

--- a/advanced-plugin/superdav-ai-agent-advanced.php
+++ b/advanced-plugin/superdav-ai-agent-advanced.php
@@ -10,7 +10,7 @@
  * Requires at least: 7.0
  * Requires PHP: 8.2
  * Requires Plugins: superdav-ai-agent
- * Update URI:  https://api.sdaiagent.com/v1/site/packages/superdav-ai-agent-advanced
+ * Update URI:  https://sdaiagent.com/?sdai_update_action=get_metadata&sdai_update_slug=superdav-ai-agent-advanced
  * Text Domain: superdav-ai-agent-advanced
  *
  * @package SdAiAgentAdvanced

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -38,7 +38,7 @@ class FileAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by SD AI Agent Advanced. Connect a verified SD AI account in the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by the free SD AI Agent Advanced plugin. Open the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -33,7 +33,7 @@ class WordPressAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by SD AI Agent Advanced. Connect a verified SD AI account in the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by the free SD AI Agent Advanced plugin. Open the SD AI account settings, then choose Install and activate.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Core/AdvancedPluginManager.php
+++ b/includes/Core/AdvancedPluginManager.php
@@ -51,7 +51,7 @@ final class AdvancedPluginManager {
 	}
 
 	/**
-	 * Download the exact public package and verify its service checksum.
+	 * Download the exact public package and verify its update-server checksum.
 	 *
 	 * @param false|string|WP_Error $reply      Prior short-circuit value.
 	 * @param string                $package    Requested package URL.
@@ -63,10 +63,8 @@ final class AdvancedPluginManager {
 	public function verified_package_download( false|string|WP_Error $reply, string $package, mixed $upgrader, array $hook_extra ): false|string|WP_Error {
 		unset( $upgrader, $hook_extra );
 
-		$package_path = wp_parse_url( $package, PHP_URL_PATH );
 		if ( false !== $reply
-			|| ! is_string( $package_path )
-			|| 1 !== preg_match( '#/superdav-ai-agent-advanced-\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\.zip$#', $package_path )
+			|| ! $this->is_advanced_package_url( $package )
 		) {
 			return $reply;
 		}
@@ -240,6 +238,23 @@ final class AdvancedPluginManager {
 
 	private function auto_updates_enabled(): bool {
 		return true === (bool) get_option( self::AUTO_UPDATE_OPTION, true );
+	}
+
+	/** Determine whether a URL is the public Advanced download endpoint. */
+	private function is_advanced_package_url( string $url ): bool {
+		$endpoint = $this->connection->get_advanced_plugin_metadata_endpoint();
+		$query    = array();
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+		return '' !== $endpoint
+			&& wp_parse_url( $endpoint, PHP_URL_SCHEME ) === wp_parse_url( $url, PHP_URL_SCHEME )
+			&& wp_parse_url( $endpoint, PHP_URL_HOST ) === wp_parse_url( $url, PHP_URL_HOST )
+			&& wp_parse_url( $endpoint, PHP_URL_PORT ) === wp_parse_url( $url, PHP_URL_PORT )
+			&& wp_parse_url( $endpoint, PHP_URL_PATH ) === wp_parse_url( $url, PHP_URL_PATH )
+			&& array(
+				'sdai_update_action' => 'download',
+				'sdai_update_slug'   => 'superdav-ai-agent-advanced',
+			) === $query;
 	}
 
 	private function plugin_file(): string {

--- a/includes/Core/AdvancedPluginManager.php
+++ b/includes/Core/AdvancedPluginManager.php
@@ -76,7 +76,7 @@ final class AdvancedPluginManager {
 			return $metadata;
 		}
 		if ( $package !== $metadata['download_url'] ) {
-			return $reply;
+			return new WP_Error( 'sd_ai_agent_advanced_download_mismatch', __( 'SD AI Agent Advanced package metadata changed before download.', 'superdav-ai-agent' ) );
 		}
 
 		if ( ! function_exists( 'wp_tempnam' ) ) {

--- a/includes/Core/AdvancedPluginManager.php
+++ b/includes/Core/AdvancedPluginManager.php
@@ -42,20 +42,16 @@ final class AdvancedPluginManager {
 			return;
 		}
 
-		$update_checker = PucFactory::buildUpdateChecker(
+		PucFactory::buildUpdateChecker(
 			$endpoint,
 			$plugin_file,
 			'superdav-ai-agent-advanced',
 			12
 		);
-
-		if ( method_exists( $update_checker, 'addHttpRequestArgFilter' ) ) {
-			$update_checker->addHttpRequestArgFilter( array( $this->connection, 'add_package_authorization' ) );
-		}
 	}
 
 	/**
-	 * Download the exact authenticated package and verify its service checksum.
+	 * Download the exact public package and verify its service checksum.
 	 *
 	 * @param false|string|WP_Error $reply      Prior short-circuit value.
 	 * @param string                $package    Requested package URL.
@@ -64,16 +60,23 @@ final class AdvancedPluginManager {
 	 * @return false|string|WP_Error Verified temporary ZIP path or prior value.
 	 */
 	#[Filter( tag: 'upgrader_pre_download', priority: 10, args: 4 )]
-	public function authenticated_package_download( false|string|WP_Error $reply, string $package, mixed $upgrader, array $hook_extra ): false|string|WP_Error {
+	public function verified_package_download( false|string|WP_Error $reply, string $package, mixed $upgrader, array $hook_extra ): false|string|WP_Error {
 		unset( $upgrader, $hook_extra );
 
-		if ( false !== $reply || $package !== $this->connection->get_advanced_plugin_download_endpoint() ) {
+		$package_path = wp_parse_url( $package, PHP_URL_PATH );
+		if ( false !== $reply
+			|| ! is_string( $package_path )
+			|| 1 !== preg_match( '#/superdav-ai-agent-advanced-\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\.zip$#', $package_path )
+		) {
 			return $reply;
 		}
 
 		$metadata = $this->connection->request_advanced_plugin_metadata();
 		if ( $metadata instanceof WP_Error ) {
 			return $metadata;
+		}
+		if ( $package !== $metadata['download_url'] ) {
+			return $reply;
 		}
 
 		if ( ! function_exists( 'wp_tempnam' ) ) {
@@ -87,14 +90,12 @@ final class AdvancedPluginManager {
 
 		$response = wp_remote_get(
 			$metadata['download_url'],
-			$this->connection->add_package_authorization(
-				array(
-					'timeout'     => 300.0,
-					'redirection' => 0,
-					'stream'      => true,
-					'filename'    => $temporary_file,
-					'headers'     => array( 'Accept' => 'application/zip, application/octet-stream' ),
-				)
+			array(
+				'timeout'     => 300.0,
+				'redirection' => 0,
+				'stream'      => true,
+				'filename'    => $temporary_file,
+				'headers'     => array( 'Accept' => 'application/zip, application/octet-stream' ),
 			)
 		);
 
@@ -141,12 +142,10 @@ final class AdvancedPluginManager {
 	 * @return array<string, bool|string|null>
 	 */
 	public function get_status(): array {
-		$installed      = file_exists( $this->plugin_file() );
-		$active         = $installed && $this->is_active();
-		$bundled        = $this->is_bundled_copy();
-		$account_status = $this->connection->get_status();
-		$linked_account = isset( $account_status['linked_user'] ) && is_array( $account_status['linked_user'] );
-		$plugin_data    = $installed ? $this->plugin_data() : array();
+		$installed   = file_exists( $this->plugin_file() );
+		$active      = $installed && $this->is_active();
+		$bundled     = $this->is_bundled_copy();
+		$plugin_data = $installed ? $this->plugin_data() : array();
 
 		return array(
 			'installed'            => $installed,
@@ -154,7 +153,6 @@ final class AdvancedPluginManager {
 			'bundled'              => $bundled,
 			'version'              => isset( $plugin_data['Version'] ) && is_string( $plugin_data['Version'] ) ? $plugin_data['Version'] : null,
 			'auto_updates_enabled' => $this->auto_updates_enabled(),
-			'account_linked'       => $linked_account,
 			'file_mods_allowed'    => $this->file_mods_allowed(),
 			'can_manage'           => self::current_user_can_manage() && ! $bundled,
 		);
@@ -183,12 +181,7 @@ final class AdvancedPluginManager {
 
 			$skin     = new \Automatic_Upgrader_Skin();
 			$upgrader = new \Plugin_Upgrader( $skin );
-			add_filter( 'upgrader_pre_download', array( $this, 'authenticated_package_download' ), 10, 4 );
-			try {
-				$result = $upgrader->install( $metadata['download_url'] );
-			} finally {
-				remove_filter( 'upgrader_pre_download', array( $this, 'authenticated_package_download' ), 10 );
-			}
+			$result   = $upgrader->install( $metadata['download_url'] );
 			if ( $result instanceof WP_Error ) {
 				return $result;
 			}

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -32,7 +32,6 @@ final class SuperdavSiteConnectionService {
 	private const ACCOUNT_ACTION_ENDPOINT_PATH            = 'site/account/action';
 	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'site/account/redeem-coupon';
 	private const ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH  = 'site/packages/superdav-ai-agent-advanced';
-	private const ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT_PATH  = 'site/packages/superdav-ai-agent-advanced/download';
 
 	/**
 	 * Maximum number of newest-first credit activity rows retained for display.
@@ -426,42 +425,10 @@ final class SuperdavSiteConnectionService {
 		return '' !== $this->get_registration_endpoint();
 	}
 
-	/**
-	 * Add the private site bearer token to one server-to-server package request.
-	 *
-	 * This callback is also passed to Plugin Update Checker. It must never be
-	 * used for browser responses or URLs.
-	 *
-	 * @param array<string, mixed> $request_args WordPress HTTP request arguments.
-	 * @return array<string, mixed> Request arguments with site authorization.
-	 * @phpstan-param array{timeout?:float,redirection?:int,headers?:array<string,string>|string,stream?:bool,filename?:string,...} $request_args
-	 * @phpstan-return array{timeout?:float,redirection?:int,headers?:array<string,string>|string,stream?:bool,filename?:string,...}
-	 */
-	public function add_package_authorization( array $request_args ): array {
-		$token = $this->get_stored_token();
-		if ( '' === $token ) {
-			return $request_args;
-		}
-
-		$headers                  = isset( $request_args['headers'] ) && is_array( $request_args['headers'] ) ? $request_args['headers'] : array();
-		$headers['Authorization'] = 'Bearer ' . $token;
-		$request_args['headers']  = $headers;
-
-		return $request_args;
-	}
-
-	/** Return the authenticated PUC metadata endpoint for Advanced. */
+	/** Return the public PUC metadata endpoint for Advanced. */
 	public function get_advanced_plugin_metadata_endpoint(): string {
 		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT', self::ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH );
 		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_metadata_endpoint', $endpoint );
-
-		return $this->sanitize_account_url( $endpoint );
-	}
-
-	/** Return the authenticated package download endpoint for Advanced. */
-	public function get_advanced_plugin_download_endpoint(): string {
-		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT', self::ADVANCED_PLUGIN_DOWNLOAD_ENDPOINT_PATH );
-		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_download_endpoint', $endpoint );
 
 		return $this->sanitize_account_url( $endpoint );
 	}
@@ -473,18 +440,16 @@ final class SuperdavSiteConnectionService {
 	 */
 	public function request_advanced_plugin_metadata(): array|WP_Error {
 		$endpoint = $this->get_advanced_plugin_metadata_endpoint();
-		if ( '' === $endpoint || '' === $this->get_stored_token() ) {
-			return new WP_Error( 'sd_ai_agent_advanced_connection_required', __( 'Connect SD AI before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 412 ) );
+		if ( '' === $endpoint ) {
+			return new WP_Error( 'sd_ai_agent_advanced_package_unavailable', __( 'SD AI Agent Advanced is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
 		}
 
 		$response = wp_remote_get(
 			$endpoint,
-			$this->add_package_authorization(
-				array(
-					'timeout'     => 15.0,
-					'redirection' => 0,
-					'headers'     => array( 'Accept' => 'application/json' ),
-				)
+			array(
+				'timeout'     => 15.0,
+				'redirection' => 0,
+				'headers'     => array( 'Accept' => 'application/json' ),
 			)
 		);
 
@@ -493,35 +458,34 @@ final class SuperdavSiteConnectionService {
 		}
 
 		$status = (int) wp_remote_retrieve_response_code( $response );
-		if ( 401 === $status ) {
-			return new WP_Error( 'sd_ai_agent_advanced_connection_expired', __( 'Reconnect SD AI before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 401 ) );
-		}
-		if ( 403 === $status ) {
-			return new WP_Error( 'sd_ai_agent_advanced_account_link_required', __( 'Connect a verified SD AI account to this site before installing Advanced.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
 		if ( $status < 200 || $status >= 300 ) {
 			return new WP_Error( 'sd_ai_agent_advanced_package_unavailable', __( 'SD AI Agent Advanced is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
 		}
 
-		$body              = json_decode( wp_remote_retrieve_body( $response ), true );
-		$download_endpoint = $this->get_advanced_plugin_download_endpoint();
+		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+		$download_url  = is_array( $body ) ? $this->sanitize_account_url( $body['download_url'] ?? '' ) : '';
+		$version       = is_array( $body ) && isset( $body['version'] ) && is_string( $body['version'] ) ? $body['version'] : '';
+		$expected_path = '' !== $version ? '/packages/superdav-ai-agent-advanced-' . $version . '.zip' : '';
 		if ( ! is_array( $body )
 			|| 'superdav-ai-agent-advanced' !== ( $body['slug'] ?? null )
 			|| ! isset( $body['version'], $body['download_url'], $body['package_sha256'] )
 			|| ! is_string( $body['version'] )
 			|| ! is_string( $body['download_url'] )
 			|| ! is_string( $body['package_sha256'] )
-			|| 1 !== preg_match( '/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/', $body['version'] )
+			|| 1 !== preg_match( '/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/', $version )
 			|| 1 !== preg_match( '/^[a-f0-9]{64}$/', $body['package_sha256'] )
-			|| '' === $download_endpoint
-			|| $download_endpoint !== $this->sanitize_account_url( $body['download_url'] )
+			|| '' === $download_url
+			|| wp_parse_url( $endpoint, PHP_URL_SCHEME ) !== wp_parse_url( $download_url, PHP_URL_SCHEME )
+			|| wp_parse_url( $endpoint, PHP_URL_HOST ) !== wp_parse_url( $download_url, PHP_URL_HOST )
+			|| wp_parse_url( $endpoint, PHP_URL_PORT ) !== wp_parse_url( $download_url, PHP_URL_PORT )
+			|| $expected_path !== wp_parse_url( $download_url, PHP_URL_PATH )
 		) {
 			return new WP_Error( 'sd_ai_agent_advanced_package_invalid', __( 'The SD AI Agent Advanced package response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}
 
 		return array(
-			'version'        => $body['version'],
-			'download_url'   => $download_endpoint,
+			'version'        => $version,
+			'download_url'   => $download_url,
 			'package_sha256' => $body['package_sha256'],
 		);
 	}

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -31,7 +31,7 @@ final class SuperdavSiteConnectionService {
 	private const ACCOUNT_STATUS_ENDPOINT_PATH            = 'site/account';
 	private const ACCOUNT_ACTION_ENDPOINT_PATH            = 'site/account/action';
 	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'site/account/redeem-coupon';
-	private const ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH  = 'site/packages/superdav-ai-agent-advanced';
+	private const ADVANCED_PLUGIN_METADATA_ENDPOINT       = 'https://sdaiagent.com/?sdai_update_action=get_metadata&sdai_update_slug=superdav-ai-agent-advanced';
 
 	/**
 	 * Maximum number of newest-first credit activity rows retained for display.
@@ -427,7 +427,9 @@ final class SuperdavSiteConnectionService {
 
 	/** Return the public PUC metadata endpoint for Advanced. */
 	public function get_advanced_plugin_metadata_endpoint(): string {
-		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT', self::ADVANCED_PLUGIN_METADATA_ENDPOINT_PATH );
+		$endpoint = defined( 'SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT' ) && is_string( SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT )
+			? SD_AI_AGENT_ADVANCED_PLUGIN_METADATA_ENDPOINT
+			: self::ADVANCED_PLUGIN_METADATA_ENDPOINT;
 		$endpoint = apply_filters( 'sd_ai_agent_advanced_plugin_metadata_endpoint', $endpoint );
 
 		return $this->sanitize_account_url( $endpoint );
@@ -462,10 +464,11 @@ final class SuperdavSiteConnectionService {
 			return new WP_Error( 'sd_ai_agent_advanced_package_unavailable', __( 'SD AI Agent Advanced is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
 		}
 
-		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
-		$download_url  = is_array( $body ) ? $this->sanitize_account_url( $body['download_url'] ?? '' ) : '';
-		$version       = is_array( $body ) && isset( $body['version'] ) && is_string( $body['version'] ) ? $body['version'] : '';
-		$expected_path = '' !== $version ? '/packages/superdav-ai-agent-advanced-' . $version . '.zip' : '';
+		$body           = json_decode( wp_remote_retrieve_body( $response ), true );
+		$download_url   = is_array( $body ) ? $this->sanitize_account_url( $body['download_url'] ?? '' ) : '';
+		$version        = is_array( $body ) && isset( $body['version'] ) && is_string( $body['version'] ) ? $body['version'] : '';
+		$download_query = array();
+		parse_str( (string) wp_parse_url( $download_url, PHP_URL_QUERY ), $download_query );
 		if ( ! is_array( $body )
 			|| 'superdav-ai-agent-advanced' !== ( $body['slug'] ?? null )
 			|| ! isset( $body['version'], $body['download_url'], $body['package_sha256'] )
@@ -478,7 +481,11 @@ final class SuperdavSiteConnectionService {
 			|| wp_parse_url( $endpoint, PHP_URL_SCHEME ) !== wp_parse_url( $download_url, PHP_URL_SCHEME )
 			|| wp_parse_url( $endpoint, PHP_URL_HOST ) !== wp_parse_url( $download_url, PHP_URL_HOST )
 			|| wp_parse_url( $endpoint, PHP_URL_PORT ) !== wp_parse_url( $download_url, PHP_URL_PORT )
-			|| $expected_path !== wp_parse_url( $download_url, PHP_URL_PATH )
+			|| wp_parse_url( $endpoint, PHP_URL_PATH ) !== wp_parse_url( $download_url, PHP_URL_PATH )
+			|| array(
+				'sdai_update_action' => 'download',
+				'sdai_update_slug'   => 'superdav-ai-agent-advanced',
+			) !== $download_query
 		) {
 			return new WP_Error( 'sd_ai_agent_advanced_package_invalid', __( 'The SD AI Agent Advanced package response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -523,7 +523,7 @@ class SystemInstructionBuilder {
 			. 'Your active ability manifest is authoritative. Treat questions such as “Is Advanced enabled?” or “Can you generate plugins?” as read-only capability-status questions: answer directly from that manifest without calling site-inspection tools such as list-options, list-posts, or get-plugins. '
 			. 'Plugin generation is available in the current session only when `sd-ai-agent/generate-plugin` appears in the active ability manifest or direct tool list. If it is present, say that plugin generation is available; if it is absent, say that plugin generation is not currently available and requires SD AI Agent Advanced. Do not infer availability from installed plugin files, options, or source-checkout contents. '
 			. 'If another requested action needs an ability that is not available, or a tool returns the `sd_ai_agent_advanced_plugin_required` error, explain that the capability is provided by SD AI Agent Advanced. '
-			. 'Do not attempt to download, install, activate, or update Advanced automatically. Direct the site administrator to the SD AI account settings, where they can connect a verified account and choose Install and activate.';
+			. 'Do not attempt to download, install, activate, or update Advanced automatically. Explain that Advanced is free and direct the site administrator to the SD AI account settings, where they can choose Install and activate.';
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -656,7 +656,7 @@ final class SettingsController {
 		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
 	}
 
-	/** Install and activate the authenticated Advanced package. */
+	/** Install and activate the public Advanced package. */
 	public function handle_install_advanced_plugin(): WP_REST_Response|WP_Error {
 		$status = $this->advanced_plugin_manager()->install_and_activate();
 		if ( $status instanceof WP_Error ) {

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -389,15 +389,11 @@ describe( 'SuperdavAccountManager', () => {
 		expect( findButton( 'Link a different user' ) ).toBeUndefined();
 	} );
 
-	test( 'installs Advanced from the connected account and enables automatic updates', async () => {
+	test( 'installs free Advanced without a linked user and enables automatic updates', async () => {
 		apiFetch
 			.mockResolvedValueOnce( {
 				configured: true,
-				linked_user: {
-					display_name: 'Verified Customer',
-					masked_email: 'v***@example.test',
-					email_verified: true,
-				},
+				linked_user: null,
 				advanced_plugin: {
 					installed: false,
 					active: false,

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -951,14 +951,6 @@ export default function SuperdavAccountManager() {
 								<strong className="sd-ai-agent-superdav-advanced-status">
 									{ advancedStatusLabel }
 								</strong>
-								{ ! linkedUser && ! advancedPlugin.bundled && (
-									<p className="description">
-										{ __(
-											'Connect a verified SD AI account to this site to install Advanced.',
-											'superdav-ai-agent'
-										) }
-									</p>
-								) }
 								{ ! advancedPlugin.file_mods_allowed &&
 									! advancedPlugin.bundled && (
 										<p className="description">
@@ -998,7 +990,6 @@ export default function SuperdavAccountManager() {
 											}
 											disabled={
 												!! advancedAction ||
-												! linkedUser ||
 												! advancedPlugin.can_manage ||
 												! advancedPlugin.file_mods_allowed
 											}


### PR DESCRIPTION
## Summary

- keep Advanced free and installable without a linked account
- point Plugin Update Checker and one-click installation at the SD AI WordPress update server
- publish stable Advanced ZIPs to the WordPress plugin's protected REST endpoint
- validate same-origin HTTPS update-server URLs, reject redirects, and verify SHA-256 before installation
- retain the fail-closed package mismatch fix from review

## Verification

- account-manager suite — 13 tests passed
- production build completed
- PHPCS passed for changed PHP files
- focused PHPStan passed
- `composer validate --strict`
- release workflow YAML parsed successfully
- Advanced 1.22.4 release ZIP built and parsed successfully by `wp-update-server` v2.0.2

## Related work

- Follow-up to merged installation/update implementation: https://github.com/Ultimate-Multisite/superdav-ai-agent/pull/2641
- WordPress update server: https://github.com/Ultimate-Multisite/superdav-ai-service/pull/100
- Publishing-token deployment: https://github.com/superdav42/tgc.church/pull/506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced is now available as a free public download.
  * Install and activate Advanced without linking an account.
  * Automatic updates continue after installation.

* **Bug Fixes**
  * Updated guidance and error messages to clearly direct administrators to account settings for installation.
  * Improved validation and handling of Advanced package downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
