### PR TITLE
GH#2647: add managed two-way voice conversation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -288,6 +288,17 @@ Base unit: **4px**
 - Announce mutation progress and outcomes with one polite atomic live region. Confirm success only when the tool result explicitly reports `applied: true`; stale, rejected, unavailable, and uncertain results require truthful next-step copy.
 - On compact screens, let the chip and mutation copy occupy full rows. In forced-colour mode preserve explicit borders and focus outlines; under reduced-motion preferences stop spinner animation while retaining the textual progress label.
 
+### Managed Voice Conversation
+
+- Keep push-to-talk as the default. Voice mode is an explicit, user-scoped opt-in that submits a completed transcript and reads the corresponding response aloud.
+- Serialize each turn as `idle → listening → transcribing → sending → thinking → speaking → idle`. Never reopen the microphone after playback; every capture must begin from a fresh keyboard or pointer gesture on the microphone control.
+- Use the same coordinator and controls in the main chat and floating widget. Both surfaces expose keyboard-accessible microphone, read-aloud/stop, and voice-mode buttons with equivalent labels, pressed states, disabled states, and visible status text.
+- Deliberate barge-in is allowed: pressing the microphone while audio is playing stops playback, revokes its object URL, and only then requests microphone access.
+- Announce concise state changes through one polite live region. While audio is reading an assistant response, set the message list live region to `off` so screen readers do not announce the same content twice.
+- Stop capture, transcription, synthesis, and playback on failure, conversation changes, page hiding, or unmount. Do not retain audio blobs, transcript payloads, object URLs, or media tracks after the active turn.
+- Populate voice and speed controls from authenticated speech capabilities. Browser speech fallback remains disabled unless the current user explicitly enables it.
+- Preserve responsive parity: status copy may wrap above the composer, while icon controls retain the mobile touch-target rules and visible keyboard focus used by other chat actions.
+
 ### Border Radius Scale
 
 | Size | Value | Use |

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -32,8 +32,8 @@ const BUDGETS = [
 ];
 const DEFERRED_JAVASCRIPT_BUDGET = {
 	name: 'deferred-javascript',
-	minifiedBudgetKiB: 1700,
-	gzipBudgetKiB: 525,
+	minifiedBudgetKiB: 1720,
+	gzipBudgetKiB: 528,
 	largestMinifiedBudgetKiB: 270,
 	largestGzipBudgetKiB: 90,
 };

--- a/src/components/__tests__/use-audio-recorder.test.js
+++ b/src/components/__tests__/use-audio-recorder.test.js
@@ -1,0 +1,143 @@
+/**
+ * Focused MediaRecorder lifecycle tests.
+ */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import useAudioRecorder from '../use-audio-recorder';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+let latestRecorder;
+
+class FakeMediaRecorder {
+	static isTypeSupported( mimeType ) {
+		return mimeType === 'audio/webm;codecs=opus';
+	}
+
+	constructor( stream, options ) {
+		this.mimeType = options.mimeType;
+		this.state = 'inactive';
+		this.stream = stream;
+		latestRecorder = this;
+	}
+
+	start() {
+		this.state = 'recording';
+	}
+
+	stop() {
+		this.state = 'inactive';
+		this.onstop?.();
+	}
+}
+
+/**
+ * @param {Object}   root0
+ * @param {Function} root0.onComplete
+ * @return {JSX.Element} Recorder controls.
+ */
+function RecorderHarness( { onComplete } ) {
+	const recorder = useAudioRecorder( {
+		acceptedMimeTypes: [ 'audio/wav' ],
+		maxBytes: 100,
+		maxDurationMs: 5000,
+		onComplete,
+	} );
+	return (
+		<div>
+			<span data-status>{ recorder.status }</span>
+			<button type="button" data-start onClick={ recorder.start }>
+				Start
+			</button>
+			<button type="button" data-stop onClick={ recorder.stop }>
+				Stop
+			</button>
+			<button type="button" data-cancel onClick={ recorder.cancel }>
+				Cancel
+			</button>
+		</div>
+	);
+}
+
+describe( 'useAudioRecorder', () => {
+	let container;
+	let root;
+	let stopTrack;
+
+	beforeEach( () => {
+		latestRecorder = null;
+		stopTrack = jest.fn();
+		global.MediaRecorder = FakeMediaRecorder;
+		Object.defineProperty( navigator, 'mediaDevices', {
+			configurable: true,
+			value: {
+				getUserMedia: jest.fn().mockResolvedValue( {
+					getTracks: () => [ { stop: stopTrack } ],
+				} ),
+			},
+		} );
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( () => {
+		act( () => root.unmount() );
+		container.remove();
+		delete global.MediaRecorder;
+	} );
+
+	test( 'records one bounded turn and releases its media track', async () => {
+		const onComplete = jest.fn();
+		await act( async () => {
+			root.render( <RecorderHarness onComplete={ onComplete } /> );
+		} );
+		await act( async () => {
+			container.querySelector( '[data-start]' ).click();
+		} );
+		expect( latestRecorder.mimeType ).toBe( 'audio/webm;codecs=opus' );
+		expect( container.querySelector( '[data-status]' ).textContent ).toBe(
+			'recording'
+		);
+
+		act( () => {
+			latestRecorder.ondataavailable( {
+				data: new Blob( [ 'voice' ], {
+					type: latestRecorder.mimeType,
+				} ),
+			} );
+			container.querySelector( '[data-stop]' ).click();
+		} );
+
+		expect( stopTrack ).toHaveBeenCalledTimes( 1 );
+		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+		expect( onComplete.mock.calls[ 0 ][ 0 ].blob.size ).toBe( 5 );
+	} );
+
+	test( 'cancels a late permission result without retaining its stream', async () => {
+		let resolvePermission;
+		navigator.mediaDevices.getUserMedia.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolvePermission = resolve;
+			} )
+		);
+		await act( async () => {
+			root.render( <RecorderHarness onComplete={ jest.fn() } /> );
+		} );
+		act( () => container.querySelector( '[data-start]' ).click() );
+		act( () => container.querySelector( '[data-cancel]' ).click() );
+		await act( async () => {
+			resolvePermission( {
+				getTracks: () => [ { stop: stopTrack } ],
+			} );
+		} );
+
+		expect( latestRecorder ).toBeNull();
+		expect( stopTrack ).toHaveBeenCalledTimes( 1 );
+		expect( container.querySelector( '[data-status]' ).textContent ).toBe(
+			'idle'
+		);
+	} );
+} );

--- a/src/components/__tests__/use-text-to-speech.test.js
+++ b/src/components/__tests__/use-text-to-speech.test.js
@@ -1,0 +1,132 @@
+/**
+ * Focused managed synthesis queue tests.
+ */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import apiFetch from '@wordpress/api-fetch';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const createdAudio = [];
+
+class FakeAudio {
+	constructor( source ) {
+		this.source = source;
+		createdAudio.push( this );
+	}
+
+	pause() {}
+
+	removeAttribute() {}
+
+	play() {
+		return Promise.resolve().then( () => this.onended?.() );
+	}
+}
+
+global.Audio = FakeAudio;
+global.URL.createObjectURL = jest.fn( () => `blob:${ createdAudio.length }` );
+global.URL.revokeObjectURL = jest.fn();
+
+const useTextToSpeech = require( '../use-text-to-speech' ).default;
+
+/**
+ * @return {JSX.Element} Managed synthesis trigger.
+ */
+function SpeechHarness() {
+	const speech = useTextToSpeech( {
+		lang: 'en-US',
+		rate: 1.25,
+		sessionId: 'session-7',
+		voice: 'voice-1',
+	} );
+	return (
+		<div>
+			<span data-status>{ speech.isSpeaking ? 'speaking' : 'idle' }</span>
+			<button
+				type="button"
+				data-speak
+				onClick={ () => speech.speak( '**Hello.** Next.' ) }
+			>
+				Speak
+			</button>
+		</div>
+	);
+}
+
+describe( 'useTextToSpeech', () => {
+	let container;
+	let root;
+
+	beforeEach( () => {
+		createdAudio.length = 0;
+		apiFetch.mockReset();
+		global.URL.createObjectURL.mockClear();
+		global.URL.revokeObjectURL.mockClear();
+		apiFetch.mockImplementation( ( request ) => {
+			if ( request.path.endsWith( '/capabilities' ) ) {
+				return Promise.resolve( {
+					available: true,
+					locales: { initial_locale: 'en-US' },
+					text_to_speech: {
+						max_input_characters: 8,
+						max_response_bytes: 100,
+						output_formats: [ 'mp3' ],
+						output_mime_types: [ 'audio/mpeg' ],
+						speed: { minimum: 0.5, maximum: 2 },
+						voices: [
+							{
+								id: 'voice-1',
+								locales: [ 'en-US' ],
+								name: 'Voice One',
+							},
+						],
+					},
+					transcription: {},
+				} );
+			}
+			return Promise.resolve( {
+				audio: 'UklGRg==',
+				mime_type: 'audio/mpeg',
+			} );
+		} );
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( () => {
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	test( 'uses service voice contracts and revokes each sequential URL', async () => {
+		await act( async () => {
+			root.render( <SpeechHarness /> );
+		} );
+		await act( async () => {
+			container.querySelector( '[data-speak]' ).click();
+		} );
+
+		const synthesisCalls = apiFetch.mock.calls
+			.map( ( [ request ] ) => request )
+			.filter( ( request ) => request.path.endsWith( '/synthesis' ) );
+		expect( synthesisCalls ).toHaveLength( 2 );
+		expect( synthesisCalls[ 0 ].data ).toMatchObject( {
+			language: 'en-US',
+			mime_type: 'audio/mpeg',
+			session_id: 'session-7',
+			speed: 1.25,
+			voice: 'voice-1',
+		} );
+		expect( synthesisCalls[ 0 ].data ).not.toHaveProperty( 'voice_id' );
+		expect( createdAudio ).toHaveLength( 2 );
+		expect( global.URL.revokeObjectURL ).toHaveBeenCalledTimes( 2 );
+		expect( container.querySelector( '[data-status]' ).textContent ).toBe(
+			'idle'
+		);
+	} );
+} );

--- a/src/components/__tests__/use-voice-conversation.test.js
+++ b/src/components/__tests__/use-voice-conversation.test.js
@@ -26,6 +26,7 @@ jest.mock( '../use-speech-recognition', () => jest.fn() );
 jest.mock( '../use-text-to-speech', () => jest.fn() );
 
 let coordinator;
+let coordinators;
 
 /**
  * @param {Object} props         Harness properties.
@@ -34,6 +35,7 @@ let coordinator;
  */
 function VoiceHarness( { surface } ) {
 	coordinator = useVoiceConversation( { surface } );
+	coordinators[ surface || 'main' ] = coordinator;
 	return null;
 }
 
@@ -45,6 +47,7 @@ describe( 'useVoiceConversation', () => {
 	let store;
 
 	beforeEach( () => {
+		coordinators = {};
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
 		root = createRoot( container );
@@ -118,6 +121,42 @@ describe( 'useVoiceConversation', () => {
 		).toBeLessThan(
 			currentRecognition.startListening.mock.invocationCallOrder[ 0 ]
 		);
+	} );
+
+	test( 'barge-in cancels playback owned by another chat surface', async () => {
+		const widgetContainer = document.createElement( 'div' );
+		document.body.appendChild( widgetContainer );
+		const widgetRoot = createRoot( widgetContainer );
+		let finishPlayback;
+		currentSpeech.speak.mockReturnValue(
+			new Promise( ( resolve ) => {
+				finishPlayback = resolve;
+			} )
+		);
+
+		await act( async () => root.render( <VoiceHarness surface="main" /> ) );
+		await act( async () =>
+			widgetRoot.render( <VoiceHarness surface="widget" /> )
+		);
+		currentSpeech.cancel.mockClear();
+		currentRecognition.startListening.mockClear();
+
+		act( () => {
+			coordinators.main.readAloud( 'Playing response' );
+		} );
+		await act( async () => coordinators.widget.startListening() );
+
+		expect( currentSpeech.cancel ).toHaveBeenCalledTimes( 1 );
+		expect( currentRecognition.startListening ).toHaveBeenCalledTimes( 1 );
+		expect(
+			currentSpeech.cancel.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan(
+			currentRecognition.startListening.mock.invocationCallOrder[ 0 ]
+		);
+
+		await act( async () => finishPlayback( false ) );
+		act( () => widgetRoot.unmount() );
+		widgetContainer.remove();
 	} );
 
 	test( 'waits for the new model response before starting playback', async () => {

--- a/src/components/__tests__/use-voice-conversation.test.js
+++ b/src/components/__tests__/use-voice-conversation.test.js
@@ -196,6 +196,37 @@ describe( 'useVoiceConversation', () => {
 		);
 	} );
 
+	test( 'preserves response tracking when the first turn creates a session', async () => {
+		store.getCurrentSessionId = () => null;
+		store.isTtsEnabled = () => true;
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		store.isSending = () => true;
+		store.getCurrentSessionMessages = () => [
+			{ parts: [ { text: 'First message' } ], role: 'user' },
+		];
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		store.getCurrentSessionId = () => 'session-1';
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		store.isSending = () => false;
+		store.getCurrentSessionMessages = () => [
+			{ parts: [ { text: 'First message' } ], role: 'user' },
+			{
+				id: 'first-response',
+				parts: [ { text: 'First response' } ],
+				role: 'model',
+			},
+		];
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		expect( currentSpeech.speak ).toHaveBeenCalledWith(
+			'First response',
+			{}
+		);
+	} );
+
 	test( 'lets the main chat own automatic playback when both surfaces exist', async () => {
 		const mainSurface = document.createElement( 'div' );
 		mainSurface.className = 'sdaa-cr';

--- a/src/components/__tests__/use-voice-conversation.test.js
+++ b/src/components/__tests__/use-voice-conversation.test.js
@@ -1,0 +1,188 @@
+/**
+ * Focused turn coordinator tests.
+ */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+import useSpeechRecognition from '../use-speech-recognition';
+import useTextToSpeech from '../use-text-to-speech';
+import useVoiceConversation from '../use-voice-conversation';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '../../store', () => 'sd-ai-agent' );
+jest.mock( '../use-speech-recognition', () => jest.fn() );
+jest.mock( '../use-text-to-speech', () => jest.fn() );
+
+let coordinator;
+
+/**
+ * @param {Object} props         Harness properties.
+ * @param {string} props.surface Chat surface identity.
+ * @return {null} Hook test harness.
+ */
+function VoiceHarness( { surface } ) {
+	coordinator = useVoiceConversation( { surface } );
+	return null;
+}
+
+describe( 'useVoiceConversation', () => {
+	let container;
+	let currentRecognition;
+	let currentSpeech;
+	let root;
+	let store;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+		store = {
+			getCurrentSessionId: () => 'session-1',
+			getCurrentSessionMessages: () => [],
+			getTtsRate: () => 1,
+			getTtsVoiceURI: () => '',
+			isSending: () => false,
+			isSpeechFallbackEnabled: () => false,
+			isTtsEnabled: () => false,
+			isVoiceConversationEnabled: () => false,
+		};
+		useSelect.mockImplementation( ( callback ) => callback( () => store ) );
+		useDispatch.mockReturnValue( {
+			sendMessage: jest.fn(),
+			setVoiceConversationEnabled: jest.fn(),
+		} );
+		currentRecognition = {
+			cancelListening: jest.fn(),
+			detectedLanguage: '',
+			error: null,
+			isListening: false,
+			isSupported: true,
+			isTranscribing: false,
+			startListening: jest.fn().mockResolvedValue( true ),
+			status: 'idle',
+			stopListening: jest.fn(),
+		};
+		useSpeechRecognition.mockReturnValue( currentRecognition );
+		currentSpeech = {
+			cancel: jest.fn(),
+			error: null,
+			isSpeaking: false,
+			isSupported: true,
+			speak: jest.fn().mockResolvedValue( true ),
+		};
+		useTextToSpeech.mockReturnValue( currentSpeech );
+	} );
+
+	afterEach( () => {
+		act( () => root.unmount() );
+		container.remove();
+		jest.clearAllMocks();
+	} );
+
+	test( 'keeps push-to-talk as draft input until voice mode is enabled', async () => {
+		await act( async () => {
+			root.render( <VoiceHarness /> );
+		} );
+		const recognitionOptions =
+			useSpeechRecognition.mock.calls.at( -1 )[ 0 ];
+
+		act( () => recognitionOptions.onResult( 'Draft transcript' ) );
+		expect( coordinator.pendingTranscript.text ).toBe( 'Draft transcript' );
+		expect(
+			useDispatch.mock.results[ 0 ].value.sendMessage
+		).not.toHaveBeenCalled();
+	} );
+
+	test( 'barge-in cancels active playback before requesting the microphone', async () => {
+		currentSpeech.isSpeaking = true;
+		useTextToSpeech.mockReturnValue( currentSpeech );
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		await act( async () => coordinator.startListening() );
+		expect( currentSpeech.cancel ).toHaveBeenCalledTimes( 2 );
+		expect( currentRecognition.startListening ).toHaveBeenCalledTimes( 1 );
+		expect(
+			currentSpeech.cancel.mock.invocationCallOrder.at( -1 )
+		).toBeLessThan(
+			currentRecognition.startListening.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	test( 'waits for the new model response before starting playback', async () => {
+		store.isTtsEnabled = () => true;
+		store.getCurrentSessionMessages = () => [
+			{
+				id: 'old',
+				parts: [ { text: 'Earlier response' } ],
+				role: 'model',
+			},
+		];
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		store.isSending = () => true;
+		await act( async () => root.render( <VoiceHarness /> ) );
+		store.isSending = () => false;
+		await act( async () => root.render( <VoiceHarness /> ) );
+		expect( currentSpeech.speak ).not.toHaveBeenCalled();
+
+		store.getCurrentSessionMessages = () => [
+			{
+				id: 'old',
+				parts: [ { text: 'Earlier response' } ],
+				role: 'model',
+			},
+			{
+				id: 'new',
+				parts: [ { text: 'Current response' } ],
+				role: 'model',
+			},
+		];
+		await act( async () => root.render( <VoiceHarness /> ) );
+
+		expect( currentSpeech.speak ).toHaveBeenCalledWith(
+			'Current response',
+			{}
+		);
+	} );
+
+	test( 'lets the main chat own automatic playback when both surfaces exist', async () => {
+		const mainSurface = document.createElement( 'div' );
+		mainSurface.className = 'sdaa-cr';
+		document.body.appendChild( mainSurface );
+		store.isTtsEnabled = () => true;
+
+		await act( async () =>
+			root.render( <VoiceHarness surface="widget" /> )
+		);
+		store.isSending = () => true;
+		await act( async () =>
+			root.render( <VoiceHarness surface="widget" /> )
+		);
+		store.isSending = () => false;
+		store.getCurrentSessionMessages = () => [
+			{
+				id: 'new',
+				parts: [ { text: 'Only once' } ],
+				role: 'model',
+			},
+		];
+		await act( async () =>
+			root.render( <VoiceHarness surface="widget" /> )
+		);
+
+		expect( currentSpeech.speak ).not.toHaveBeenCalled();
+		mainSurface.remove();
+	} );
+} );

--- a/src/components/chat-composer/use-chat-composer.js
+++ b/src/components/chat-composer/use-chat-composer.js
@@ -8,7 +8,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 import STORE_NAME from '../../store';
-import useSpeechRecognition from '../use-speech-recognition';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const REMEMBER_PREFIX = '/remember ';
@@ -49,12 +48,14 @@ function readAsDataUrl( file ) {
  * @param {boolean} root0.isSimpleMode       Whether customer/simple mode is active.
  * @param {number}  root0.maxTextareaHeight  Maximum auto-grow height in pixels.
  * @param {string}  root0.defaultPlaceholder Surface-specific idle placeholder.
+ * @param {Object}  root0.voiceConversation  Shared managed voice coordinator.
  * @return {Object} Shared composer state and event handlers.
  */
 export default function useChatComposer( {
 	isSimpleMode = false,
 	maxTextareaHeight = 200,
 	defaultPlaceholder,
+	voiceConversation,
 } ) {
 	const {
 		sendMessage,
@@ -97,6 +98,8 @@ export default function useChatComposer( {
 	const textareaRef = useRef( null );
 	const fileInputRef = useRef( null );
 	const attachmentGenerationRef = useRef( 0 );
+	const pendingSpeechTranscript = voiceConversation?.pendingTranscript;
+	const consumeSpeechTranscript = voiceConversation?.consumeTranscript;
 
 	const focusTextarea = useCallback( () => {
 		setTimeout(
@@ -105,19 +108,16 @@ export default function useChatComposer( {
 		);
 	}, [] );
 
-	const handleSpeechResult = useCallback( ( transcript ) => {
+	useEffect( () => {
+		const pending = pendingSpeechTranscript;
+		if ( ! pending ) {
+			return;
+		}
 		setText( ( previous ) =>
-			previous ? previous + ' ' + transcript : transcript
+			previous ? `${ previous } ${ pending.text }` : pending.text
 		);
-	}, [] );
-	const {
-		isListening,
-		isSupported: micSupported,
-		toggleListening,
-	} = useSpeechRecognition( {
-		interimResults: true,
-		onResult: handleSpeechResult,
-	} );
+		consumeSpeechTranscript( pending.id );
+	}, [ consumeSpeechTranscript, pendingSpeechTranscript ] );
 
 	useEffect( () => {
 		const element = textareaRef.current;
@@ -439,9 +439,23 @@ export default function useChatComposer( {
 		sending,
 		queueCount,
 		currentSessionId,
-		isListening,
-		micSupported,
-		toggleListening,
+		isListening: voiceConversation?.isListening || false,
+		isSpeaking: voiceConversation?.isSpeaking || false,
+		micDisabled: ! [
+			'idle',
+			'error',
+			'listening',
+			'recording',
+			'requesting_permission',
+			'speaking',
+		].includes( voiceConversation?.phase ),
+		micSupported: voiceConversation?.isSupported || false,
+		speechPhase: voiceConversation?.phase || 'idle',
+		speechError: voiceConversation?.error || '',
+		speechStatus: voiceConversation?.statusLabel || '',
+		stopSpeaking: voiceConversation?.stopSpeaking,
+		toggleListening: voiceConversation?.toggleListening,
+		voiceModeEnabled: voiceConversation?.voiceModeEnabled || false,
 		canSend: !! text.trim() || attachments.length > 0,
 		placeholder,
 		processFiles,

--- a/src/components/chat-redesign/ConvoHeader.js
+++ b/src/components/chat-redesign/ConvoHeader.js
@@ -12,7 +12,7 @@ import STORE_NAME from '../../store';
 import { getBranding } from '../../utils/branding';
 import { isTTSSupported } from '../use-text-to-speech';
 import SessionContextMenu from '../session-context-menu';
-import { AiIcon, Speaker, SpeakerMuted } from './icons';
+import { AiIcon, Microphone, Speaker, SpeakerMuted } from './icons';
 
 /**
  *
@@ -22,6 +22,7 @@ import { AiIcon, Speaker, SpeakerMuted } from './icons';
  * @param {*}       root0.changesCount
  * @param {*}       root0.onShowChanges
  * @param {boolean} root0.isSimpleMode
+ * @param {Object}  root0.voiceConversation Managed voice coordinator.
  */
 export default function ConvoHeader( {
 	sidebarCollapsed,
@@ -29,6 +30,7 @@ export default function ConvoHeader( {
 	changesCount,
 	onShowChanges,
 	isSimpleMode = false,
+	voiceConversation,
 } ) {
 	const { renameSession, setTtsEnabled } = useDispatch( STORE_NAME );
 	const { session, isRunning, ttsEnabled } = useSelect( ( sel ) => {
@@ -60,6 +62,15 @@ export default function ConvoHeader( {
 	const title = isSimpleMode
 		? branding.agentName || __( 'SD AI Agent', 'sd-ai-agent' )
 		: session?.title || __( 'New conversation', 'sd-ai-agent' );
+	let readAloudLabel = ttsEnabled
+		? __( 'Disable read aloud', 'superdav-ai-agent' )
+		: __( 'Read responses aloud', 'superdav-ai-agent' );
+	if ( voiceConversation.isSpeaking ) {
+		readAloudLabel = __( 'Stop reading aloud', 'superdav-ai-agent' );
+	}
+	const voiceModeLabel = voiceConversation.voiceModeEnabled
+		? __( 'Disable voice mode', 'superdav-ai-agent' )
+		: __( 'Enable voice mode', 'superdav-ai-agent' );
 
 	const startRename = useCallback( () => {
 		if ( ! session ) {
@@ -164,17 +175,40 @@ export default function ConvoHeader( {
 					<button
 						type="button"
 						className={ `sdaa-cr-icon-btn sdaa-tts-btn${
-							ttsEnabled ? ' is-active' : ''
+							ttsEnabled || voiceConversation.isSpeaking
+								? ' is-active'
+								: ''
 						}` }
-						onClick={ () => setTtsEnabled( ! ttsEnabled ) }
-						aria-label={
-							ttsEnabled
-								? __( 'Disable read aloud', 'sd-ai-agent' )
-								: __( 'Read responses aloud', 'sd-ai-agent' )
+						onClick={
+							voiceConversation.isSpeaking
+								? voiceConversation.stopSpeaking
+								: () => setTtsEnabled( ! ttsEnabled )
 						}
-						aria-pressed={ ttsEnabled }
+						aria-label={ readAloudLabel }
+						aria-pressed={
+							ttsEnabled || voiceConversation.isSpeaking
+						}
 					>
-						{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
+						{ ttsEnabled || voiceConversation.isSpeaking ? (
+							<Speaker />
+						) : (
+							<SpeakerMuted />
+						) }
+					</button>
+				) }
+				{ voiceConversation.isSupported && (
+					<button
+						type="button"
+						className={ `sdaa-cr-icon-btn sd-ai-agent-voice-mode-btn${
+							voiceConversation.voiceModeEnabled
+								? ' is-active'
+								: ''
+						}` }
+						onClick={ voiceConversation.toggleVoiceMode }
+						aria-label={ voiceModeLabel }
+						aria-pressed={ voiceConversation.voiceModeEnabled }
+					>
+						<Microphone />
 					</button>
 				) }
 				{ ! isSimpleMode && (

--- a/src/components/chat-redesign/ConvoHeader.js
+++ b/src/components/chat-redesign/ConvoHeader.js
@@ -10,7 +10,6 @@ import { Icon, moreHorizontal, sidebar as sidebarIcon } from '@wordpress/icons';
 
 import STORE_NAME from '../../store';
 import { getBranding } from '../../utils/branding';
-import { isTTSSupported } from '../use-text-to-speech';
 import SessionContextMenu from '../session-context-menu';
 import { AiIcon, Microphone, Speaker, SpeakerMuted } from './icons';
 
@@ -171,7 +170,7 @@ export default function ConvoHeader( {
 						</button>
 					</span>
 				) }
-				{ isTTSSupported && (
+				{ voiceConversation.isSpeechSupported && (
 					<button
 						type="button"
 						className={ `sdaa-cr-icon-btn sdaa-tts-btn${

--- a/src/components/chat-redesign/InputArea.js
+++ b/src/components/chat-redesign/InputArea.js
@@ -20,11 +20,15 @@ import AgentPicker from './AgentPicker';
 /**
  * Render the full-size chat composer.
  *
- * @param {Object}  root0
- * @param {boolean} root0.isSimpleMode Whether customer/simple UI mode is active.
+ * @param {Object}  root0                   Component properties.
+ * @param {boolean} root0.isSimpleMode      Whether customer/simple UI mode is active.
+ * @param {Object}  root0.voiceConversation Managed voice coordinator.
  * @return {JSX.Element} Main-chat composer.
  */
-export default function InputArea( { isSimpleMode = false } = {} ) {
+export default function InputArea( {
+	isSimpleMode = false,
+	voiceConversation,
+} = {} ) {
 	const composer = useChatComposer( {
 		isSimpleMode,
 		maxTextareaHeight: 200,
@@ -32,6 +36,7 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 			'Ask the agent to do something, or type / for commands…',
 			'superdav-ai-agent'
 		),
+		voiceConversation,
 	} );
 	const sendLabel = composer.sending
 		? __( 'Queue message', 'superdav-ai-agent' )
@@ -39,6 +44,11 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 
 	return (
 		<div className="sdaa-cr-input-area">
+			{ composer.speechPhase !== 'idle' && composer.speechStatus && (
+				<span className="sd-ai-agent-voice-status" aria-live="polite">
+					{ composer.speechStatus }
+				</span>
+			) }
 			{ ! isSimpleMode && composer.showSlash && (
 				<SlashCommandMenu
 					filter={ composer.text }
@@ -65,12 +75,12 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 						  ) }
 				</div>
 			) }
-			{ composer.attachmentError && (
+			{ ( composer.attachmentError || composer.speechError ) && (
 				<div
 					className="sd-ai-agent-composer-attachment-error"
 					role="alert"
 				>
-					{ composer.attachmentError }
+					{ composer.attachmentError || composer.speechError }
 				</div>
 			) }
 			<div className="sdaa-cr-input-inner">
@@ -187,6 +197,7 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 										composer.isListening ? ' is-active' : ''
 									}` }
 									onClick={ composer.toggleListening }
+									disabled={ composer.micDisabled }
 									aria-label={
 										composer.isListening
 											? __(

--- a/src/components/chat-redesign/InputArea.js
+++ b/src/components/chat-redesign/InputArea.js
@@ -75,12 +75,20 @@ export default function InputArea( {
 						  ) }
 				</div>
 			) }
-			{ ( composer.attachmentError || composer.speechError ) && (
+			{ composer.attachmentError && (
 				<div
 					className="sd-ai-agent-composer-attachment-error"
 					role="alert"
 				>
-					{ composer.attachmentError || composer.speechError }
+					{ composer.attachmentError }
+				</div>
+			) }
+			{ composer.speechError && (
+				<div
+					className="sd-ai-agent-composer-attachment-error"
+					role="alert"
+				>
+					{ composer.speechError }
 				</div>
 			) }
 			<div className="sdaa-cr-input-inner">

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -8,14 +8,13 @@
  */
 
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
 import ActionCard from '../action-card';
 import CompactConversationActionCard from '../compact-conversation-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
-import useTextToSpeech from '../use-text-to-speech';
 import MessageRows from '../chat-messages/message-rows';
 import {
 	getRunningJobPresentation,
@@ -24,15 +23,16 @@ import {
 import useCompactConversationAction from '../chat-messages/use-compact-conversation-action';
 import useMessageListScroll from '../chat-messages/use-message-list-scroll';
 import useRunningStatus from '../chat-messages/use-running-status';
-import { extractText } from './message-helpers';
 import { RunningMessage } from './message-items';
 
 /**
  * Render the main chat's message list and surface-specific actions.
  *
+ * @param {Object} root0                   Voice-aware component properties.
+ * @param {Object} root0.voiceConversation Managed voice coordinator.
  * @return {JSX.Element} Main chat message list.
  */
-export default function MessageList() {
+export default function MessageList( { voiceConversation } ) {
 	const {
 		messages,
 		sending,
@@ -40,10 +40,6 @@ export default function MessageList() {
 		liveToolCalls,
 		sessionJobs,
 		greeting,
-		ttsEnabled,
-		ttsVoiceURI,
-		ttsRate,
-		ttsPitch,
 		hasStreamError,
 		pendingActionCard,
 		providers,
@@ -63,10 +59,6 @@ export default function MessageList() {
 					'Ask the agent to make a change, write a post, or audit your site.',
 					'superdav-ai-agent'
 				),
-			ttsEnabled: store.isTtsEnabled(),
-			ttsVoiceURI: store.getTtsVoiceURI(),
-			ttsRate: store.getTtsRate(),
-			ttsPitch: store.getTtsPitch(),
 			hasStreamError: store.hasStreamError(),
 			pendingActionCard: store.getPendingActionCard(),
 			providers: store.getProviders(),
@@ -108,43 +100,6 @@ export default function MessageList() {
 	} );
 	const runningStatus = useRunningStatus( sending && running.isFallback );
 
-	const { speak, cancel } = useTextToSpeech( {
-		voiceURI: ttsVoiceURI,
-		rate: ttsRate,
-		pitch: ttsPitch,
-	} );
-	const lastSpokenIndexRef = useRef( -1 );
-
-	useEffect( () => {
-		if ( ! ttsEnabled || sending ) {
-			return;
-		}
-
-		const lastIndex = messages.length - 1;
-		const lastMessage = messages[ lastIndex ];
-		if (
-			lastIndex < 0 ||
-			lastMessage?.role !== 'model' ||
-			lastIndex === lastSpokenIndexRef.current
-		) {
-			return;
-		}
-
-		const text = extractText( lastMessage );
-		if ( ! text ) {
-			return;
-		}
-
-		lastSpokenIndexRef.current = lastIndex;
-		speak( text );
-	}, [ messages, ttsEnabled, sending, speak ] );
-
-	useEffect( () => {
-		if ( ! ttsEnabled ) {
-			cancel();
-		}
-	}, [ ttsEnabled, cancel ] );
-
 	const confirmJobFailureAction = () => {
 		if ( pendingActionCard?.type === 'resume_recoverable_job' ) {
 			resumeRecoverableJob();
@@ -161,7 +116,11 @@ export default function MessageList() {
 
 	return (
 		<>
-			<div className="sdaa-cr-messages" ref={ containerRef }>
+			<div
+				className="sdaa-cr-messages"
+				ref={ containerRef }
+				aria-live={ voiceConversation.isSpeaking ? 'off' : 'polite' }
+			>
 				<div className="sdaa-cr-messages-inner">
 					{ visible.length === 0 && ! sending && (
 						<div className="sdaa-cr-empty">{ greeting }</div>

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -119,7 +119,7 @@ export default function MessageList( { voiceConversation } ) {
 			<div
 				className="sdaa-cr-messages"
 				ref={ containerRef }
-				aria-live={ voiceConversation.isSpeaking ? 'off' : 'polite' }
+				aria-live={ voiceConversation?.isSpeaking ? 'off' : 'polite' }
 			>
 				<div className="sdaa-cr-messages-inner">
 					{ visible.length === 0 && ! sending && (

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1453,6 +1453,14 @@ input[type="text"].sdaa-cr-search-input {
 	position: relative;
 }
 
+.sd-ai-agent-voice-status {
+	display: block;
+	max-width: 780px;
+	margin: 0 auto 6px;
+	color: var(--sdaa-text-secondary);
+	font-size: 12px;
+}
+
 .sdaa-cr-input-inner {
 	max-width: 780px;
 	margin: 0 auto;

--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -59,7 +59,7 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 		}
 	} );
 	const [ showChanges, setShowChanges ] = useState( false );
-	const voiceConversation = useVoiceConversation();
+	const voiceConversation = useVoiceConversation( { surface: 'main' } );
 
 	const {
 		currentSessionId,

--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -15,6 +15,7 @@ import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import ActionCard from '../action-card';
 import useChangesCount from '../use-changes-count';
+import useVoiceConversation from '../use-voice-conversation';
 import { getChatUiMode, isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 import Sidebar from './Sidebar';
 import ConvoHeader from './ConvoHeader';
@@ -58,6 +59,7 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 		}
 	} );
 	const [ showChanges, setShowChanges ] = useState( false );
+	const voiceConversation = useVoiceConversation();
 
 	const {
 		currentSessionId,
@@ -245,6 +247,7 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 
 				<section className="sdaa-cr-convo">
 					<ConvoHeader
+						voiceConversation={ voiceConversation }
 						sidebarCollapsed={ sidebarCollapsed }
 						onExpandSidebar={ () => setSidebarCollapsed( false ) }
 						changesCount={ changesCount }
@@ -269,7 +272,7 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 					<ErrorBoundary
 						label={ __( 'Message list', 'superdav-ai-agent' ) }
 					>
-						<MessageList />
+						<MessageList voiceConversation={ voiceConversation } />
 					</ErrorBoundary>
 
 					{ pendingActionCard?.type === 'retry_client_tools' &&
@@ -310,7 +313,10 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 					<ErrorBoundary
 						label={ __( 'Message input', 'superdav-ai-agent' ) }
 					>
-						<InputArea isSimpleMode={ isSimpleMode } />
+						<InputArea
+							isSimpleMode={ isSimpleMode }
+							voiceConversation={ voiceConversation }
+						/>
 					</ErrorBoundary>
 				</section>
 			</div>

--- a/src/components/chat-widget/widget-header.js
+++ b/src/components/chat-widget/widget-header.js
@@ -19,7 +19,6 @@ import {
 
 import STORE_NAME from '../../store';
 import { getBranding } from '../../utils/branding';
-import { isTTSSupported } from '../use-text-to-speech';
 import {
 	AiIcon,
 	Microphone,
@@ -361,7 +360,7 @@ export default function WidgetHeader( {
 			) }
 
 			<div className="sdaa-w-head-actions">
-				{ ! isMinimized && isTTSSupported && (
+				{ ! isMinimized && voiceConversation.isSpeechSupported && (
 					<button
 						type="button"
 						className={ `sdaa-w-icon-btn${

--- a/src/components/chat-widget/widget-header.js
+++ b/src/components/chat-widget/widget-header.js
@@ -88,7 +88,7 @@ export default function WidgetHeader( {
 	onToggleMinimize,
 	onDragHandleMouseDown,
 	isSimpleMode = false,
-	voiceConversation,
+	voiceConversation = {},
 } ) {
 	const {
 		setFloatingOpen,
@@ -119,7 +119,7 @@ export default function WidgetHeader( {
 			currentSessionId: store.getCurrentSessionId(),
 			sessionJobs: store.getSessionJobs(),
 			activeModelName: model?.name || model?.id || '',
-			ttsEnabled: store.isTtsEnabled(),
+			ttsEnabled: store.isTtsEnabled?.() || false,
 		};
 	}, [] );
 
@@ -175,7 +175,7 @@ export default function WidgetHeader( {
 			: __( 'Ready', 'sd-ai-agent' );
 	} )();
 	const displayedStatusLabel =
-		voiceConversation.phase === 'idle'
+		( voiceConversation.phase || 'idle' ) === 'idle'
 			? statusLabel
 			: voiceConversation.statusLabel;
 	let readAloudLabel = ttsEnabled

--- a/src/components/chat-widget/widget-header.js
+++ b/src/components/chat-widget/widget-header.js
@@ -19,7 +19,13 @@ import {
 
 import STORE_NAME from '../../store';
 import { getBranding } from '../../utils/branding';
-import { AiIcon } from '../chat-redesign/icons';
+import { isTTSSupported } from '../use-text-to-speech';
+import {
+	AiIcon,
+	Microphone,
+	Speaker,
+	SpeakerMuted,
+} from '../chat-redesign/icons';
 
 /**
  *
@@ -76,35 +82,47 @@ function relativeTime( dateStr ) {
  * @param {*}       root0.onToggleMinimize
  * @param {*}       root0.onDragHandleMouseDown
  * @param {boolean} root0.isSimpleMode
+ * @param {Object}  root0.voiceConversation
  */
 export default function WidgetHeader( {
 	isMinimized,
 	onToggleMinimize,
 	onDragHandleMouseDown,
 	isSimpleMode = false,
+	voiceConversation,
 } ) {
-	const { setFloatingOpen, clearCurrentSession, openSession, fetchSessions } =
-		useDispatch( STORE_NAME );
+	const {
+		setFloatingOpen,
+		clearCurrentSession,
+		openSession,
+		fetchSessions,
+		setTtsEnabled,
+	} = useDispatch( STORE_NAME );
 
-	const { sessions, currentSessionId, sessionJobs, activeModelName } =
-		useSelect( ( sel ) => {
-			const store = sel( STORE_NAME );
-			const providers = store.getProviders() || [];
-			const providerId = store.getSelectedProviderId();
-			const modelId = store.getSelectedModelId();
-			const provider =
-				providers.find( ( p ) => p.id === providerId ) ||
-				providers[ 0 ];
-			const model =
-				provider?.models?.find( ( m ) => m.id === modelId ) ||
-				provider?.models?.[ 0 ];
-			return {
-				sessions: store.getSessions(),
-				currentSessionId: store.getCurrentSessionId(),
-				sessionJobs: store.getSessionJobs(),
-				activeModelName: model?.name || model?.id || '',
-			};
-		}, [] );
+	const {
+		sessions,
+		currentSessionId,
+		sessionJobs,
+		activeModelName,
+		ttsEnabled,
+	} = useSelect( ( sel ) => {
+		const store = sel( STORE_NAME );
+		const providers = store.getProviders() || [];
+		const providerId = store.getSelectedProviderId();
+		const modelId = store.getSelectedModelId();
+		const provider =
+			providers.find( ( p ) => p.id === providerId ) || providers[ 0 ];
+		const model =
+			provider?.models?.find( ( m ) => m.id === modelId ) ||
+			provider?.models?.[ 0 ];
+		return {
+			sessions: store.getSessions(),
+			currentSessionId: store.getCurrentSessionId(),
+			sessionJobs: store.getSessionJobs(),
+			activeModelName: model?.name || model?.id || '',
+			ttsEnabled: store.isTtsEnabled(),
+		};
+	}, [] );
 
 	const [ drawerOpen, setDrawerOpen ] = useState( false );
 	const drawerRef = useRef( null );
@@ -157,6 +175,19 @@ export default function WidgetHeader( {
 			? `${ __( 'Ready', 'sd-ai-agent' ) } · ${ activeModelName }`
 			: __( 'Ready', 'sd-ai-agent' );
 	} )();
+	const displayedStatusLabel =
+		voiceConversation.phase === 'idle'
+			? statusLabel
+			: voiceConversation.statusLabel;
+	let readAloudLabel = ttsEnabled
+		? __( 'Disable read aloud', 'superdav-ai-agent' )
+		: __( 'Read responses aloud', 'superdav-ai-agent' );
+	if ( voiceConversation.isSpeaking ) {
+		readAloudLabel = __( 'Stop reading aloud', 'superdav-ai-agent' );
+	}
+	const voiceModeLabel = voiceConversation.voiceModeEnabled
+		? __( 'Disable voice mode', 'superdav-ai-agent' )
+		: __( 'Enable voice mode', 'superdav-ai-agent' );
 
 	const handlePickSession = useCallback(
 		( id ) => {
@@ -242,7 +273,7 @@ export default function WidgetHeader( {
 						>
 							<span className="sdaa-w-head-status-dot" />
 							<span className="sdaa-w-head-status-text">
-								{ statusLabel }
+								{ displayedStatusLabel }
 							</span>
 						</span>
 					</span>
@@ -330,6 +361,48 @@ export default function WidgetHeader( {
 			) }
 
 			<div className="sdaa-w-head-actions">
+				{ ! isMinimized && isTTSSupported && (
+					<button
+						type="button"
+						className={ `sdaa-w-icon-btn${
+							ttsEnabled || voiceConversation.isSpeaking
+								? ' is-active'
+								: ''
+						}` }
+						onMouseDown={ ( event ) => event.stopPropagation() }
+						onClick={
+							voiceConversation.isSpeaking
+								? voiceConversation.stopSpeaking
+								: () => setTtsEnabled( ! ttsEnabled )
+						}
+						aria-label={ readAloudLabel }
+						aria-pressed={
+							ttsEnabled || voiceConversation.isSpeaking
+						}
+					>
+						{ ttsEnabled || voiceConversation.isSpeaking ? (
+							<Speaker />
+						) : (
+							<SpeakerMuted />
+						) }
+					</button>
+				) }
+				{ ! isMinimized && voiceConversation.isSupported && (
+					<button
+						type="button"
+						className={ `sdaa-w-icon-btn${
+							voiceConversation.voiceModeEnabled
+								? ' is-active'
+								: ''
+						}` }
+						onMouseDown={ ( event ) => event.stopPropagation() }
+						onClick={ voiceConversation.toggleVoiceMode }
+						aria-label={ voiceModeLabel }
+						aria-pressed={ voiceConversation.voiceModeEnabled }
+					>
+						<Microphone />
+					</button>
+				) }
 				<button
 					type="button"
 					className="sdaa-w-icon-btn"

--- a/src/components/chat-widget/widget-input.js
+++ b/src/components/chat-widget/widget-input.js
@@ -21,11 +21,15 @@ import ConnectedEditorSelectionStatus from './editor-selection-status';
 /**
  * Render the compact floating-widget composer.
  *
- * @param {Object}  root0
- * @param {boolean} root0.isSimpleMode Whether customer/simple UI mode is active.
+ * @param {Object}  root0                   Component properties.
+ * @param {boolean} root0.isSimpleMode      Whether customer/simple UI mode is active.
+ * @param {Object}  root0.voiceConversation Managed voice coordinator.
  * @return {JSX.Element} Widget composer.
  */
-export default function WidgetInput( { isSimpleMode = false } = {} ) {
+export default function WidgetInput( {
+	isSimpleMode = false,
+	voiceConversation,
+} = {} ) {
 	const composer = useChatComposer( {
 		isSimpleMode,
 		maxTextareaHeight: 140,
@@ -33,6 +37,7 @@ export default function WidgetInput( { isSimpleMode = false } = {} ) {
 			'Ask the agent or type / for commands…',
 			'superdav-ai-agent'
 		),
+		voiceConversation,
 	} );
 	const sendLabel = composer.sending
 		? __( 'Queue message', 'superdav-ai-agent' )
@@ -40,6 +45,11 @@ export default function WidgetInput( { isSimpleMode = false } = {} ) {
 
 	return (
 		<div className="sdaa-w-input">
+			{ composer.speechPhase !== 'idle' && composer.speechStatus && (
+				<span className="sd-ai-agent-voice-status" aria-live="polite">
+					{ composer.speechStatus }
+				</span>
+			) }
 			{ ! isSimpleMode && composer.showSlash && (
 				<SlashCommandMenu
 					filter={ composer.text }
@@ -66,12 +76,12 @@ export default function WidgetInput( { isSimpleMode = false } = {} ) {
 						  ) }
 				</div>
 			) }
-			{ composer.attachmentError && (
+			{ ( composer.attachmentError || composer.speechError ) && (
 				<div
 					className="sd-ai-agent-composer-attachment-error"
 					role="alert"
 				>
-					{ composer.attachmentError }
+					{ composer.attachmentError || composer.speechError }
 				</div>
 			) }
 			<ConnectedEditorSelectionStatus />
@@ -180,6 +190,7 @@ export default function WidgetInput( { isSimpleMode = false } = {} ) {
 									composer.isListening ? ' is-active' : ''
 								}` }
 								onClick={ composer.toggleListening }
+								disabled={ composer.micDisabled }
 								aria-label={
 									composer.isListening
 										? __(

--- a/src/components/chat-widget/widget-input.js
+++ b/src/components/chat-widget/widget-input.js
@@ -76,12 +76,20 @@ export default function WidgetInput( {
 						  ) }
 				</div>
 			) }
-			{ ( composer.attachmentError || composer.speechError ) && (
+			{ composer.attachmentError && (
 				<div
 					className="sd-ai-agent-composer-attachment-error"
 					role="alert"
 				>
-					{ composer.attachmentError || composer.speechError }
+					{ composer.attachmentError }
+				</div>
+			) }
+			{ composer.speechError && (
+				<div
+					className="sd-ai-agent-composer-attachment-error"
+					role="alert"
+				>
+					{ composer.speechError }
 				</div>
 			) }
 			<ConnectedEditorSelectionStatus />

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -89,9 +89,11 @@ function ClientToolRetryActionCard( { toolNames = [], onConfirm, onCancel } ) {
 /**
  * Render the floating widget's message list and surface-specific actions.
  *
+ * @param {Object} root0                   Voice-aware component properties.
+ * @param {Object} root0.voiceConversation Managed voice coordinator.
  * @return {JSX.Element} Floating widget message list.
  */
-export default function WidgetMessageList() {
+export default function WidgetMessageList( { voiceConversation } ) {
 	const {
 		messages,
 		sending,
@@ -177,7 +179,11 @@ export default function WidgetMessageList() {
 
 	return (
 		<>
-			<div className="sdaa-w-body" ref={ containerRef }>
+			<div
+				className="sdaa-w-body"
+				ref={ containerRef }
+				aria-live={ voiceConversation.isSpeaking ? 'off' : 'polite' }
+			>
 				<div className="sdaa-w-body-inner">
 					<MessageRows
 						items={ visible }

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -182,7 +182,7 @@ export default function WidgetMessageList( { voiceConversation } ) {
 			<div
 				className="sdaa-w-body"
 				ref={ containerRef }
-				aria-live={ voiceConversation.isSpeaking ? 'off' : 'polite' }
+				aria-live={ voiceConversation?.isSpeaking ? 'off' : 'polite' }
 			>
 				<div className="sdaa-w-body-inner">
 					<MessageRows

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -14,6 +14,7 @@ import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import ProposalPanel from '../proposal-panel';
 import useChangesCount from '../use-changes-count';
+import useVoiceConversation from '../use-voice-conversation';
 import ChangesDrawer from '../chat-redesign/ChangesDrawer';
 import { isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 // chat-redesign base styles (.sdaa-cr-*) are only needed by panel
@@ -66,6 +67,7 @@ export default function WidgetPanel( {
 	}, [] );
 
 	const [ showChanges, setShowChanges ] = useState( false );
+	const voiceConversation = useVoiceConversation();
 
 	// Auto-confirm pending tool calls when YOLO is on.
 	useEffect( () => {
@@ -187,6 +189,7 @@ export default function WidgetPanel( {
 				}
 			>
 				<WidgetHeader
+					voiceConversation={ voiceConversation }
 					isMinimized={ isMinimized }
 					onToggleMinimize={ toggleMinimize }
 					isSimpleMode={ isSimpleMode }
@@ -246,7 +249,9 @@ export default function WidgetPanel( {
 							{ showEmpty ? (
 								<WidgetEmpty />
 							) : (
-								<WidgetMessageList />
+								<WidgetMessageList
+									voiceConversation={ voiceConversation }
+								/>
 							) }
 						</ErrorBoundary>
 						{ ! isSimpleMode && showChanges && (
@@ -265,7 +270,10 @@ export default function WidgetPanel( {
 					<ErrorBoundary
 						label={ __( 'Message input', 'sd-ai-agent' ) }
 					>
-						<WidgetInput isSimpleMode={ isSimpleMode } />
+						<WidgetInput
+							isSimpleMode={ isSimpleMode }
+							voiceConversation={ voiceConversation }
+						/>
 					</ErrorBoundary>
 				) }
 

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -5,7 +5,13 @@
  * FloatingPanel so the surrounding feature set is unchanged.
  */
 
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	lazy,
+	Suspense,
+	useState,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _n } from '@wordpress/i18n';
 
@@ -14,7 +20,6 @@ import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import ProposalPanel from '../proposal-panel';
 import useChangesCount from '../use-changes-count';
-import useVoiceConversation from '../use-voice-conversation';
 import ChangesDrawer from '../chat-redesign/ChangesDrawer';
 import { isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 // chat-redesign base styles (.sdaa-cr-*) are only needed by panel
@@ -31,6 +36,24 @@ import useResize from './use-resize';
 
 const PANEL_POSITION_STORAGE_KEY = 'aiAgentWidgetPanelPosition';
 const PANEL_SIZE_STORAGE_KEY = 'aiAgentWidgetPanelSize';
+const WidgetVoiceController = lazy( () =>
+	import( './widget-voice-controller' )
+);
+const inactiveVoiceConversation = {
+	consumeTranscript: undefined,
+	error: '',
+	isListening: false,
+	isSpeaking: false,
+	isSpeechSupported: false,
+	isSupported: false,
+	pendingTranscript: null,
+	phase: 'idle',
+	statusLabel: '',
+	stopSpeaking: undefined,
+	toggleListening: undefined,
+	toggleVoiceMode: undefined,
+	voiceModeEnabled: false,
+};
 
 /**
  * @param {Object}      root0                        Component props.
@@ -67,7 +90,9 @@ export default function WidgetPanel( {
 	}, [] );
 
 	const [ showChanges, setShowChanges ] = useState( false );
-	const voiceConversation = useVoiceConversation();
+	const [ voiceConversation, setVoiceConversation ] = useState(
+		inactiveVoiceConversation
+	);
 
 	// Auto-confirm pending tool calls when YOLO is on.
 	useEffect( () => {
@@ -172,6 +197,9 @@ export default function WidgetPanel( {
 
 	return (
 		<>
+			<Suspense fallback={ null }>
+				<WidgetVoiceController onChange={ setVoiceConversation } />
+			</Suspense>
 			<div
 				className={ `sdaa-w-panel${
 					isMinimized ? ' is-minimized' : ''

--- a/src/components/chat-widget/widget-voice-controller.js
+++ b/src/components/chat-widget/widget-voice-controller.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+import useVoiceConversation from '../use-voice-conversation';
+
+/**
+ * Load the managed voice coordinator outside the budgeted widget panel chunk.
+ *
+ * @param {Object}   props          Component properties.
+ * @param {Function} props.onChange Receive the current coordinator state.
+ * @return {null} This controller has no presentation.
+ */
+export default function WidgetVoiceController( { onChange } ) {
+	const voice = useVoiceConversation( { surface: 'widget' } );
+
+	useEffect( () => {
+		onChange( voice );
+	}, [ onChange, voice ] );
+
+	return null;
+}

--- a/src/components/use-audio-recorder.js
+++ b/src/components/use-audio-recorder.js
@@ -11,6 +11,13 @@ const DEFAULT_CONSTRAINTS = {
 	},
 };
 
+const BROWSER_RECORDING_MIME_TYPES = [
+	'audio/webm;codecs=opus',
+	'audio/webm',
+	'audio/ogg;codecs=opus',
+	'audio/mp4',
+];
+
 const recorderError = ( error ) => {
 	if (
 		error?.name === 'NotAllowedError' ||
@@ -42,37 +49,48 @@ export default function useAudioRecorder( {
 } = {} ) {
 	const [ status, setStatus ] = useState( 'idle' );
 	const [ error, setError ] = useState( null );
-	const streamRef = useRef( null );
-	const recorderRef = useRef( null );
-	const chunksRef = useRef( [] );
-	const timeoutRef = useRef( null );
-	const limitReachedRef = useRef( false );
+	const activeRef = useRef( false );
+	const generationRef = useRef( 0 );
+	const turnRef = useRef( null );
 
-	const cleanup = useCallback( () => {
-		if ( timeoutRef.current ) {
-			clearTimeout( timeoutRef.current );
-			timeoutRef.current = null;
+	const cleanupTurn = useCallback( ( turn ) => {
+		if ( turn?.timeout ) {
+			clearTimeout( turn.timeout );
+			turn.timeout = null;
 		}
-		streamRef.current?.getTracks().forEach( ( track ) => track.stop() );
-		streamRef.current = null;
-		recorderRef.current = null;
+		turn?.stream?.getTracks().forEach( ( track ) => track.stop() );
+		if ( turnRef.current === turn ) {
+			turnRef.current = null;
+			activeRef.current = false;
+		}
 	}, [] );
 
 	const stop = useCallback( () => {
-		const recorder = recorderRef.current;
+		const recorder = turnRef.current?.recorder;
 		if ( recorder && recorder.state !== 'inactive' ) {
 			setStatus( 'stopping' );
 			recorder.stop();
 			return;
 		}
-		cleanup();
+		cleanupTurn( turnRef.current );
 		setStatus( 'idle' );
-	}, [ cleanup ] );
+	}, [ cleanupTurn ] );
 
 	const cancel = useCallback( () => {
-		chunksRef.current = [];
-		stop();
-	}, [ stop ] );
+		generationRef.current += 1;
+		activeRef.current = false;
+		const turn = turnRef.current;
+		if ( turn ) {
+			turn.cancelled = true;
+			turn.chunks = [];
+			if ( turn.recorder.state !== 'inactive' ) {
+				turn.recorder.stop();
+			} else {
+				cleanupTurn( turn );
+			}
+		}
+		setStatus( 'idle' );
+	}, [ cleanupTurn ] );
 
 	const start = useCallback(
 		async ( capabilityOverrides = {} ) => {
@@ -81,93 +99,144 @@ export default function useAudioRecorder( {
 			const byteLimit = capabilityOverrides.maxBytes ?? maxBytes;
 			const durationLimit =
 				capabilityOverrides.maxDurationMs ?? maxDurationMs;
-			if ( status !== 'idle' || typeof MediaRecorder === 'undefined' ) {
+			if ( activeRef.current || typeof MediaRecorder === 'undefined' ) {
 				setError( 'Audio recording is not supported by this browser.' );
 				setStatus( 'error' );
-				return;
+				return false;
 			}
-			const mimeType = supportedMimeTypes.find( ( candidate ) =>
-				MediaRecorder.isTypeSupported( candidate )
+			const candidates = supportedMimeTypes.some( ( candidate ) =>
+				candidate.toLowerCase().startsWith( 'audio/wav' )
+			)
+				? [ ...supportedMimeTypes, ...BROWSER_RECORDING_MIME_TYPES ]
+				: supportedMimeTypes;
+			const mimeType = candidates.find( ( candidate ) =>
+				MediaRecorder.isTypeSupported?.( candidate )
 			);
 			if ( ! mimeType ) {
 				setError( 'No supported audio format is available.' );
 				setStatus( 'error' );
-				return;
+				return false;
 			}
 
+			const generation = generationRef.current + 1;
+			generationRef.current = generation;
+			activeRef.current = true;
 			setError( null );
 			setStatus( 'requesting_permission' );
-			limitReachedRef.current = false;
-			chunksRef.current = [];
+			let stream = null;
 			try {
-				const stream =
+				stream =
 					await navigator.mediaDevices.getUserMedia(
 						DEFAULT_CONSTRAINTS
 					);
-				streamRef.current = stream;
+				if (
+					generation !== generationRef.current ||
+					! activeRef.current
+				) {
+					stream.getTracks().forEach( ( track ) => track.stop() );
+					return false;
+				}
 				const recorder = new MediaRecorder( stream, { mimeType } );
-				recorderRef.current = recorder;
+				const turn = {
+					cancelled: false,
+					chunks: [],
+					generation,
+					limitReached: false,
+					recorder,
+					stream,
+					timeout: null,
+					totalBytes: 0,
+				};
+				turnRef.current = turn;
 				recorder.ondataavailable = ( event ) => {
-					if ( ! event.data?.size ) {
+					if ( turn.cancelled || ! event.data?.size ) {
 						return;
 					}
-					chunksRef.current.push( event.data );
-					if (
-						byteLimit > 0 &&
-						chunksRef.current.reduce(
-							( total, chunk ) => total + chunk.size,
-							0
-						) >= byteLimit
-					) {
-						limitReachedRef.current = true;
-						stop();
+					turn.chunks.push( event.data );
+					turn.totalBytes += event.data.size;
+					if ( byteLimit > 0 && turn.totalBytes > byteLimit ) {
+						turn.limitReached = true;
+						if ( recorder.state !== 'inactive' ) {
+							recorder.stop();
+						}
 					}
 				};
 				recorder.onerror = () => {
-					setError( 'The audio recorder failed.' );
-					chunksRef.current = [];
-					cleanup();
-					setStatus( 'error' );
+					turn.cancelled = true;
+					turn.chunks = [];
+					cleanupTurn( turn );
+					if ( generation === generationRef.current ) {
+						setError( 'The audio recorder failed.' );
+						setStatus( 'error' );
+					}
 				};
 				recorder.onstop = () => {
-					const chunks = chunksRef.current;
-					chunksRef.current = [];
-					const blob = new Blob( chunks, { type: mimeType } );
-					cleanup();
-					if ( limitReachedRef.current ) {
+					const chunks = turn.chunks;
+					turn.chunks = [];
+					cleanupTurn( turn );
+					if (
+						turn.cancelled ||
+						generation !== generationRef.current
+					) {
+						return;
+					}
+					if ( turn.limitReached ) {
 						setError( 'The recording reached the service limit.' );
+						setStatus( 'error' );
+						return;
+					}
+					const blob = new Blob( chunks, {
+						type: recorder.mimeType || mimeType,
+					} );
+					if ( ! blob.size ) {
+						setError( 'The recording did not contain audio.' );
 						setStatus( 'error' );
 						return;
 					}
 					setStatus( 'idle' );
 					onComplete?.( { blob, mimeType } );
 				};
-				recorder.start();
+				recorder.start( 250 );
 				setStatus( 'recording' );
 				if ( durationLimit > 0 ) {
-					timeoutRef.current = setTimeout( () => {
-						limitReachedRef.current = true;
-						stop();
+					turn.timeout = setTimeout( () => {
+						turn.limitReached = true;
+						if ( recorder.state !== 'inactive' ) {
+							recorder.stop();
+						}
 					}, durationLimit );
 				}
+				return true;
 			} catch ( caughtError ) {
-				cleanup();
-				setError( recorderError( caughtError ) );
-				setStatus( 'error' );
+				stream?.getTracks().forEach( ( track ) => track.stop() );
+				if ( generation === generationRef.current ) {
+					activeRef.current = false;
+					setError( recorderError( caughtError ) );
+					setStatus( 'error' );
+				}
+				return false;
 			}
 		},
-		[
-			acceptedMimeTypes,
-			cleanup,
-			maxBytes,
-			maxDurationMs,
-			onComplete,
-			status,
-			stop,
-		]
+		[ acceptedMimeTypes, cleanupTurn, maxBytes, maxDurationMs, onComplete ]
 	);
 
-	useEffect( () => cleanup, [ cleanup ] );
+	useEffect(
+		() => () => {
+			generationRef.current += 1;
+			activeRef.current = false;
+			const turn = turnRef.current;
+			if ( turn ) {
+				turn.cancelled = true;
+				turn.chunks = [];
+				if ( turn.recorder.state !== 'inactive' ) {
+					turn.recorder.stop();
+				} else {
+					cleanupTurn( turn );
+				}
+			}
+		},
+		[ cleanupTurn ]
+	);
 
 	return { cancel, error, start, status, stop };
 }

--- a/src/components/use-audio-recorder.js
+++ b/src/components/use-audio-recorder.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 const DEFAULT_CONSTRAINTS = {
 	audio: {
@@ -23,12 +24,14 @@ const recorderError = ( error ) => {
 		error?.name === 'NotAllowedError' ||
 		error?.name === 'SecurityError'
 	) {
-		return 'Microphone permission was denied.';
+		return __( 'Microphone permission was denied.', 'superdav-ai-agent' );
 	}
 	if ( error?.name === 'NotFoundError' ) {
-		return 'No microphone is available.';
+		return __( 'No microphone is available.', 'superdav-ai-agent' );
 	}
-	return error?.message || 'Unable to record audio.';
+	return (
+		error?.message || __( 'Unable to record audio.', 'superdav-ai-agent' )
+	);
 };
 
 /**
@@ -100,7 +103,12 @@ export default function useAudioRecorder( {
 			const durationLimit =
 				capabilityOverrides.maxDurationMs ?? maxDurationMs;
 			if ( activeRef.current || typeof MediaRecorder === 'undefined' ) {
-				setError( 'Audio recording is not supported by this browser.' );
+				setError(
+					__(
+						'Audio recording is not supported by this browser.',
+						'superdav-ai-agent'
+					)
+				);
 				setStatus( 'error' );
 				return false;
 			}
@@ -113,7 +121,12 @@ export default function useAudioRecorder( {
 				MediaRecorder.isTypeSupported?.( candidate )
 			);
 			if ( ! mimeType ) {
-				setError( 'No supported audio format is available.' );
+				setError(
+					__(
+						'No supported audio format is available.',
+						'superdav-ai-agent'
+					)
+				);
 				setStatus( 'error' );
 				return false;
 			}
@@ -166,7 +179,12 @@ export default function useAudioRecorder( {
 					turn.chunks = [];
 					cleanupTurn( turn );
 					if ( generation === generationRef.current ) {
-						setError( 'The audio recorder failed.' );
+						setError(
+							__(
+								'The audio recorder failed.',
+								'superdav-ai-agent'
+							)
+						);
 						setStatus( 'error' );
 					}
 				};
@@ -181,7 +199,12 @@ export default function useAudioRecorder( {
 						return;
 					}
 					if ( turn.limitReached ) {
-						setError( 'The recording reached the service limit.' );
+						setError(
+							__(
+								'The recording reached the service limit.',
+								'superdav-ai-agent'
+							)
+						);
 						setStatus( 'error' );
 						return;
 					}
@@ -189,7 +212,12 @@ export default function useAudioRecorder( {
 						type: recorder.mimeType || mimeType,
 					} );
 					if ( ! blob.size ) {
-						setError( 'The recording did not contain audio.' );
+						setError(
+							__(
+								'The recording did not contain audio.',
+								'superdav-ai-agent'
+							)
+						);
 						setStatus( 'error' );
 						return;
 					}

--- a/src/components/use-audio-recorder.js
+++ b/src/components/use-audio-recorder.js
@@ -1,0 +1,173 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+const DEFAULT_CONSTRAINTS = {
+	audio: {
+		autoGainControl: true,
+		echoCancellation: true,
+		noiseSuppression: true,
+	},
+};
+
+const recorderError = ( error ) => {
+	if (
+		error?.name === 'NotAllowedError' ||
+		error?.name === 'SecurityError'
+	) {
+		return 'Microphone permission was denied.';
+	}
+	if ( error?.name === 'NotFoundError' ) {
+		return 'No microphone is available.';
+	}
+	return error?.message || 'Unable to record audio.';
+};
+
+/**
+ * Capture one bounded microphone recording without retaining audio after use.
+ *
+ * @param {Object}   options                   Configuration supplied by speech capabilities.
+ * @param {string[]} options.acceptedMimeTypes Service-supported recording MIME types.
+ * @param {number}   options.maxBytes          Maximum accepted recording size.
+ * @param {number}   options.maxDurationMs     Maximum accepted recording duration.
+ * @param {Function} options.onComplete        Called with the temporary recording.
+ * @return {Object} Recording state and controls.
+ */
+export default function useAudioRecorder( {
+	acceptedMimeTypes = [],
+	maxBytes = 0,
+	maxDurationMs = 0,
+	onComplete,
+} = {} ) {
+	const [ status, setStatus ] = useState( 'idle' );
+	const [ error, setError ] = useState( null );
+	const streamRef = useRef( null );
+	const recorderRef = useRef( null );
+	const chunksRef = useRef( [] );
+	const timeoutRef = useRef( null );
+	const limitReachedRef = useRef( false );
+
+	const cleanup = useCallback( () => {
+		if ( timeoutRef.current ) {
+			clearTimeout( timeoutRef.current );
+			timeoutRef.current = null;
+		}
+		streamRef.current?.getTracks().forEach( ( track ) => track.stop() );
+		streamRef.current = null;
+		recorderRef.current = null;
+	}, [] );
+
+	const stop = useCallback( () => {
+		const recorder = recorderRef.current;
+		if ( recorder && recorder.state !== 'inactive' ) {
+			setStatus( 'stopping' );
+			recorder.stop();
+			return;
+		}
+		cleanup();
+		setStatus( 'idle' );
+	}, [ cleanup ] );
+
+	const cancel = useCallback( () => {
+		chunksRef.current = [];
+		stop();
+	}, [ stop ] );
+
+	const start = useCallback(
+		async ( capabilityOverrides = {} ) => {
+			const supportedMimeTypes =
+				capabilityOverrides.acceptedMimeTypes || acceptedMimeTypes;
+			const byteLimit = capabilityOverrides.maxBytes ?? maxBytes;
+			const durationLimit =
+				capabilityOverrides.maxDurationMs ?? maxDurationMs;
+			if ( status !== 'idle' || typeof MediaRecorder === 'undefined' ) {
+				setError( 'Audio recording is not supported by this browser.' );
+				setStatus( 'error' );
+				return;
+			}
+			const mimeType = supportedMimeTypes.find( ( candidate ) =>
+				MediaRecorder.isTypeSupported( candidate )
+			);
+			if ( ! mimeType ) {
+				setError( 'No supported audio format is available.' );
+				setStatus( 'error' );
+				return;
+			}
+
+			setError( null );
+			setStatus( 'requesting_permission' );
+			limitReachedRef.current = false;
+			chunksRef.current = [];
+			try {
+				const stream =
+					await navigator.mediaDevices.getUserMedia(
+						DEFAULT_CONSTRAINTS
+					);
+				streamRef.current = stream;
+				const recorder = new MediaRecorder( stream, { mimeType } );
+				recorderRef.current = recorder;
+				recorder.ondataavailable = ( event ) => {
+					if ( ! event.data?.size ) {
+						return;
+					}
+					chunksRef.current.push( event.data );
+					if (
+						byteLimit > 0 &&
+						chunksRef.current.reduce(
+							( total, chunk ) => total + chunk.size,
+							0
+						) >= byteLimit
+					) {
+						limitReachedRef.current = true;
+						stop();
+					}
+				};
+				recorder.onerror = () => {
+					setError( 'The audio recorder failed.' );
+					chunksRef.current = [];
+					cleanup();
+					setStatus( 'error' );
+				};
+				recorder.onstop = () => {
+					const chunks = chunksRef.current;
+					chunksRef.current = [];
+					const blob = new Blob( chunks, { type: mimeType } );
+					cleanup();
+					if ( limitReachedRef.current ) {
+						setError( 'The recording reached the service limit.' );
+						setStatus( 'error' );
+						return;
+					}
+					setStatus( 'idle' );
+					onComplete?.( { blob, mimeType } );
+				};
+				recorder.start();
+				setStatus( 'recording' );
+				if ( durationLimit > 0 ) {
+					timeoutRef.current = setTimeout( () => {
+						limitReachedRef.current = true;
+						stop();
+					}, durationLimit );
+				}
+			} catch ( caughtError ) {
+				cleanup();
+				setError( recorderError( caughtError ) );
+				setStatus( 'error' );
+			}
+		},
+		[
+			acceptedMimeTypes,
+			cleanup,
+			maxBytes,
+			maxDurationMs,
+			onComplete,
+			status,
+			stop,
+		]
+	);
+
+	useEffect( () => cleanup, [ cleanup ] );
+
+	return { cancel, error, start, status, stop };
+}

--- a/src/components/use-speech-recognition.js
+++ b/src/components/use-speech-recognition.js
@@ -1,165 +1,160 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useCallback, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+import useAudioRecorder from './use-audio-recorder';
 
 /**
- * Whether the browser supports the Web Speech API SpeechRecognition interface.
+ * Whether the browser can capture audio for managed transcription.
  *
  * @type {boolean}
  */
 export const isSpeechRecognitionSupported =
-	typeof window !== 'undefined' &&
-	( 'SpeechRecognition' in window || 'webkitSpeechRecognition' in window );
+	typeof navigator !== 'undefined' &&
+	!! navigator.mediaDevices?.getUserMedia &&
+	typeof MediaRecorder !== 'undefined';
 
 /**
- * The SpeechRecognition constructor, if available.
+ * Record one user-initiated turn and send it to the authenticated speech API.
  *
- * @type {Function|null}
- */
-const getSpeechRecognition = () => {
-	if ( typeof window === 'undefined' ) {
-		return null;
-	}
-	return window.SpeechRecognition || window.webkitSpeechRecognition || null;
-};
-
-/**
- * Custom hook for push-to-talk speech recognition via the browser Web Speech API.
- *
- * Returns an object with:
- *   - isListening {boolean}  — true while the mic is active.
- *   - isSupported {boolean}  — false when the browser lacks SpeechRecognition.
- *   - transcript  {string}   — the latest interim/final transcript text.
- *   - error       {string|null} — last error message, or null.
- *   - startListening  {Function} — begin recording.
- *   - stopListening   {Function} — stop recording.
- *   - toggleListening {Function} — toggle start/stop.
- *   - resetTranscript {Function} — clear the transcript.
- *
- * @param {Object}   [options]                     - Configuration options.
- * @param {string}   [options.lang='']             - BCP-47 language tag (e.g. 'en-US').
- *                                                 Empty string uses the browser default.
- * @param {boolean}  [options.continuous=false]    - Keep listening after a pause.
- * @param {boolean}  [options.interimResults=true] - Emit interim (in-progress) results.
- * @param {Function} [options.onResult]            - Called with the transcript string on
- *                                                 each result event.
- * @param {Function} [options.onEnd]               - Called when recognition ends.
- * @return {Object} Speech recognition state and controls.
+ * @param {Object}   options          Configuration.
+ * @param {string}   options.lang     Initial BCP-47 language hint.
+ * @param {Function} options.onResult Called once with final text and language.
+ * @param {Function} options.onEnd    Called after a completed or failed turn.
+ * @return {Object} Speech recording state and controls.
  */
 export default function useSpeechRecognition( {
 	lang = '',
-	continuous = false,
-	interimResults = true,
 	onResult,
 	onEnd,
 } = {} ) {
-	const isSupported = isSpeechRecognitionSupported;
-
 	const [ isListening, setIsListening ] = useState( false );
 	const [ transcript, setTranscript ] = useState( '' );
 	const [ error, setError ] = useState( null );
+	const [ capabilities, setCapabilities ] = useState( null );
+	const requestRef = useRef( null );
+	const generationRef = useRef( 0 );
 
-	const recognitionRef = useRef( null );
-	// Track whether the stop was intentional (user action) vs automatic (end of speech).
-	const intentionalStopRef = useRef( false );
+	const transcribe = useCallback(
+		async ( { blob, mimeType } ) => {
+			const generation = generationRef.current;
+			const controller = new AbortController();
+			requestRef.current = controller;
+			const body = new FormData();
+			body.append(
+				'audio',
+				blob,
+				`recording.${ mimeType.split( '/' )[ 1 ] }`
+			);
+			if ( lang ) {
+				body.append( 'language', lang );
+			}
 
-	// Cleanup on unmount.
+			try {
+				const result = await apiFetch( {
+					body,
+					method: 'POST',
+					path: '/sd-ai-agent/v1/speech/transcriptions',
+					signal: controller.signal,
+				} );
+				if ( generation !== generationRef.current ) {
+					return;
+				}
+				const finalTranscript = result?.text?.trim();
+				if ( finalTranscript ) {
+					setTranscript( finalTranscript );
+					onResult?.( finalTranscript, result.language || '' );
+				}
+			} catch ( caughtError ) {
+				if (
+					caughtError?.name !== 'AbortError' &&
+					generation === generationRef.current
+				) {
+					setError(
+						caughtError?.message ||
+							'Unable to transcribe the recording.'
+					);
+				}
+			} finally {
+				if ( generation === generationRef.current ) {
+					setIsListening( false );
+					onEnd?.();
+				}
+			}
+		},
+		[ lang, onEnd, onResult ]
+	);
+
+	const {
+		cancel,
+		error: recorderError,
+		start,
+		status,
+		stop,
+	} = useAudioRecorder( {
+		acceptedMimeTypes: capabilities?.accepted_mime_types || [],
+		maxBytes: capabilities?.max_recording_bytes || 0,
+		maxDurationMs: capabilities?.max_recording_duration_ms || 0,
+		onComplete: transcribe,
+	} );
+
 	useEffect( () => {
 		return () => {
-			if ( recognitionRef.current ) {
-				intentionalStopRef.current = true;
-				recognitionRef.current.abort();
-			}
+			generationRef.current += 1;
+			requestRef.current?.abort();
+			cancel();
 		};
-	}, [] );
+	}, [ cancel ] );
 
-	const startListening = useCallback( () => {
-		if ( ! isSupported || isListening ) {
+	const startListening = useCallback( async () => {
+		if ( ! isSpeechRecognitionSupported || isListening ) {
 			return;
 		}
-
-		const SpeechRecognition = getSpeechRecognition();
-		if ( ! SpeechRecognition ) {
-			return;
-		}
-
 		setError( null );
 		setTranscript( '' );
-		intentionalStopRef.current = false;
-
-		const recognition = new SpeechRecognition();
-		recognition.lang = lang;
-		recognition.continuous = continuous;
-		recognition.interimResults = interimResults;
-
-		recognition.onstart = () => {
+		try {
+			const nextCapabilities =
+				capabilities ||
+				( await apiFetch( {
+					path: '/sd-ai-agent/v1/speech/capabilities',
+				} ) );
+			setCapabilities( nextCapabilities );
 			setIsListening( true );
-		};
-
-		recognition.onresult = ( event ) => {
-			let fullTranscript = '';
-			for ( let i = 0; i < event.results.length; i++ ) {
-				fullTranscript += event.results[ i ][ 0 ].transcript;
-			}
-			setTranscript( fullTranscript );
-			if ( onResult ) {
-				onResult( fullTranscript );
-			}
-		};
-
-		recognition.onerror = ( event ) => {
-			// 'aborted' fires when we call abort() intentionally — not a real error.
-			if ( event.error !== 'aborted' ) {
-				setError( event.error );
-			}
-			setIsListening( false );
-		};
-
-		recognition.onend = () => {
-			setIsListening( false );
-			if ( onEnd ) {
-				onEnd();
-			}
-		};
-
-		recognitionRef.current = recognition;
-		recognition.start();
-	}, [
-		isSupported,
-		isListening,
-		lang,
-		continuous,
-		interimResults,
-		onResult,
-		onEnd,
-	] );
+			start( {
+				acceptedMimeTypes: nextCapabilities.accepted_mime_types || [],
+				maxBytes: nextCapabilities.max_recording_bytes || 0,
+				maxDurationMs: nextCapabilities.max_recording_duration_ms || 0,
+			} );
+		} catch ( caughtError ) {
+			setError(
+				caughtError?.message || 'Speech services are unavailable.'
+			);
+		}
+	}, [ capabilities, isListening, start ] );
 
 	const stopListening = useCallback( () => {
-		if ( recognitionRef.current ) {
-			intentionalStopRef.current = true;
-			recognitionRef.current.stop();
-		}
+		stop();
 		setIsListening( false );
-	}, [] );
+	}, [ stop ] );
 
 	const toggleListening = useCallback( () => {
 		if ( isListening ) {
 			stopListening();
-		} else {
-			startListening();
+			return;
 		}
+		startListening();
 	}, [ isListening, startListening, stopListening ] );
 
-	const resetTranscript = useCallback( () => {
-		setTranscript( '' );
-	}, [] );
+	const resetTranscript = useCallback( () => setTranscript( '' ), [] );
 
 	return {
 		isListening,
-		isSupported,
+		isSupported: isSpeechRecognitionSupported,
 		transcript,
-		error,
+		error: error || recorderError,
+		status,
 		startListening,
 		stopListening,
 		toggleListening,

--- a/src/components/use-speech-recognition.js
+++ b/src/components/use-speech-recognition.js
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 import { loadSpeechCapabilities, recordingToWav } from '../utils/speech';
 import useAudioRecorder from './use-audio-recorder';
@@ -101,7 +102,10 @@ export default function useSpeechRecognition( {
 				) {
 					setError(
 						caughtError?.message ||
-							'Unable to transcribe the recording.'
+							__(
+								'Unable to transcribe the recording.',
+								'superdav-ai-agent'
+							)
 					);
 				}
 			} finally {
@@ -129,6 +133,37 @@ export default function useSpeechRecognition( {
 			( capabilities?.transcription?.max_duration_seconds || 0 ) * 1000,
 		onComplete: transcribe,
 	} );
+	const transcriptionCapabilities = capabilities?.transcription;
+	const hasManagedTranscription = Boolean(
+		isSpeechRecognitionSupported &&
+			capabilities?.available &&
+			Array.isArray(
+				transcriptionCapabilities?.accepted_input_mime_types
+			) &&
+			transcriptionCapabilities.accepted_input_mime_types.includes(
+				'audio/wav'
+			) &&
+			Number( transcriptionCapabilities.max_bytes ) > 44 &&
+			Number( transcriptionCapabilities.max_duration_seconds ) > 0
+	);
+
+	useEffect( () => {
+		if ( ! isSpeechRecognitionSupported ) {
+			return undefined;
+		}
+		let active = true;
+		loadSpeechCapabilities()
+			.then( ( result ) => {
+				if ( active ) {
+					capabilitiesRef.current = result;
+					setCapabilities( result );
+				}
+			} )
+			.catch( () => undefined );
+		return () => {
+			active = false;
+		};
+	}, [] );
 
 	useEffect( () => {
 		return () => {
@@ -189,19 +224,26 @@ export default function useSpeechRecognition( {
 				transcription.max_bytes > 44
 					? Math.floor( ( transcription.max_bytes - 44 ) / 32 )
 					: 0;
+			const durationLimits = [
+				( transcription.max_duration_seconds || 0 ) * 1000,
+				wavDurationLimit,
+			].filter( ( limit ) => limit > 0 );
 			return await start( {
 				acceptedMimeTypes:
 					transcription.accepted_input_mime_types || [],
 				maxBytes: transcription.max_bytes || 0,
-				maxDurationMs: Math.min(
-					( transcription.max_duration_seconds || 0 ) * 1000,
-					wavDurationLimit
-				),
+				maxDurationMs: durationLimits.length
+					? Math.min( ...durationLimits )
+					: 0,
 			} );
 		} catch ( caughtError ) {
 			if ( generation === generationRef.current ) {
 				setError(
-					caughtError?.message || 'Speech services are unavailable.'
+					caughtError?.message ||
+						__(
+							'Speech services are unavailable.',
+							'superdav-ai-agent'
+						)
 				);
 			}
 			return false;
@@ -254,7 +296,7 @@ export default function useSpeechRecognition( {
 		detectedLanguage,
 		isListening,
 		isTranscribing,
-		isSupported: isSpeechRecognitionSupported,
+		isSupported: hasManagedTranscription,
 		transcript,
 		error: error || recorderError,
 		status,

--- a/src/components/use-speech-recognition.js
+++ b/src/components/use-speech-recognition.js
@@ -4,6 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
+import { loadSpeechCapabilities, recordingToWav } from '../utils/speech';
 import useAudioRecorder from './use-audio-recorder';
 
 /**
@@ -19,40 +20,62 @@ export const isSpeechRecognitionSupported =
 /**
  * Record one user-initiated turn and send it to the authenticated speech API.
  *
- * @param {Object}   options          Configuration.
- * @param {string}   options.lang     Initial BCP-47 language hint.
- * @param {Function} options.onResult Called once with final text and language.
- * @param {Function} options.onEnd    Called after a completed or failed turn.
+ * @param {Object}   options            Configuration.
+ * @param {string}   options.lang       Initial BCP-47 language hint.
+ * @param {string}   options.sessionKey Active conversation identity.
+ * @param {Function} options.onResult   Called once with final text and language.
+ * @param {Function} options.onEnd      Called after a completed or failed turn.
  * @return {Object} Speech recording state and controls.
  */
 export default function useSpeechRecognition( {
 	lang = '',
+	sessionKey = '',
 	onResult,
 	onEnd,
 } = {} ) {
-	const [ isListening, setIsListening ] = useState( false );
 	const [ transcript, setTranscript ] = useState( '' );
 	const [ error, setError ] = useState( null );
 	const [ capabilities, setCapabilities ] = useState( null );
+	const [ detectedLanguage, setDetectedLanguage ] = useState( '' );
+	const [ isLoadingCapabilities, setIsLoadingCapabilities ] =
+		useState( false );
+	const [ isTranscribing, setIsTranscribing ] = useState( false );
+	const capabilitiesRef = useRef( null );
+	const detectedLanguageRef = useRef( '' );
 	const requestRef = useRef( null );
 	const generationRef = useRef( 0 );
+	const sessionRef = useRef( sessionKey );
 
 	const transcribe = useCallback(
-		async ( { blob, mimeType } ) => {
+		async ( { blob } ) => {
 			const generation = generationRef.current;
 			const controller = new AbortController();
 			requestRef.current = controller;
-			const body = new FormData();
-			body.append(
-				'audio',
-				blob,
-				`recording.${ mimeType.split( '/' )[ 1 ] }`
-			);
-			if ( lang ) {
-				body.append( 'language', lang );
-			}
+			setIsTranscribing( true );
 
 			try {
+				const currentCapabilities = capabilitiesRef.current;
+				const transcription = currentCapabilities?.transcription;
+				const wav = await recordingToWav(
+					blob,
+					transcription?.max_bytes || 0
+				);
+				if ( generation !== generationRef.current ) {
+					return;
+				}
+				const body = new FormData();
+				body.append( 'audio', wav, 'recording.wav' );
+				const language =
+					detectedLanguageRef.current ||
+					lang ||
+					currentCapabilities?.locales?.initial_locale ||
+					( typeof navigator !== 'undefined'
+						? navigator.language
+						: '' );
+				if ( language ) {
+					body.append( 'language', language );
+				}
+
 				const result = await apiFetch( {
 					body,
 					method: 'POST',
@@ -65,7 +88,11 @@ export default function useSpeechRecognition( {
 				const finalTranscript = result?.text?.trim();
 				if ( finalTranscript ) {
 					setTranscript( finalTranscript );
-					onResult?.( finalTranscript, result.language || '' );
+					if ( result.language ) {
+						detectedLanguageRef.current = result.language;
+						setDetectedLanguage( result.language );
+					}
+					onResult?.( finalTranscript, result.language || language );
 				}
 			} catch ( caughtError ) {
 				if (
@@ -79,7 +106,8 @@ export default function useSpeechRecognition( {
 				}
 			} finally {
 				if ( generation === generationRef.current ) {
-					setIsListening( false );
+					requestRef.current = null;
+					setIsTranscribing( false );
 					onEnd?.();
 				}
 			}
@@ -91,12 +119,14 @@ export default function useSpeechRecognition( {
 		cancel,
 		error: recorderError,
 		start,
-		status,
+		status: recorderStatus,
 		stop,
 	} = useAudioRecorder( {
-		acceptedMimeTypes: capabilities?.accepted_mime_types || [],
-		maxBytes: capabilities?.max_recording_bytes || 0,
-		maxDurationMs: capabilities?.max_recording_duration_ms || 0,
+		acceptedMimeTypes:
+			capabilities?.transcription?.accepted_input_mime_types || [],
+		maxBytes: capabilities?.transcription?.max_bytes || 0,
+		maxDurationMs:
+			( capabilities?.transcription?.max_duration_seconds || 0 ) * 1000,
 		onComplete: transcribe,
 	} );
 
@@ -108,49 +138,122 @@ export default function useSpeechRecognition( {
 		};
 	}, [ cancel ] );
 
-	const startListening = useCallback( async () => {
-		if ( ! isSpeechRecognitionSupported || isListening ) {
+	const cancelListening = useCallback( () => {
+		generationRef.current += 1;
+		requestRef.current?.abort();
+		requestRef.current = null;
+		cancel();
+		setIsLoadingCapabilities( false );
+		setIsTranscribing( false );
+	}, [ cancel ] );
+
+	useEffect( () => {
+		if ( sessionRef.current === sessionKey ) {
 			return;
 		}
+		sessionRef.current = sessionKey;
+		cancelListening();
+		detectedLanguageRef.current = '';
+		setDetectedLanguage( '' );
+		setTranscript( '' );
+		setError( null );
+	}, [ cancelListening, sessionKey ] );
+
+	const startListening = useCallback( async () => {
+		if (
+			! isSpeechRecognitionSupported ||
+			isLoadingCapabilities ||
+			isTranscribing ||
+			[ 'requesting_permission', 'recording', 'stopping' ].includes(
+				recorderStatus
+			)
+		) {
+			return false;
+		}
+		const generation = generationRef.current + 1;
+		generationRef.current = generation;
+		requestRef.current?.abort();
 		setError( null );
 		setTranscript( '' );
+		setIsLoadingCapabilities( true );
 		try {
 			const nextCapabilities =
-				capabilities ||
-				( await apiFetch( {
-					path: '/sd-ai-agent/v1/speech/capabilities',
-				} ) );
+				capabilities || ( await loadSpeechCapabilities() );
+			if ( generation !== generationRef.current ) {
+				return false;
+			}
+			capabilitiesRef.current = nextCapabilities;
 			setCapabilities( nextCapabilities );
-			setIsListening( true );
-			start( {
-				acceptedMimeTypes: nextCapabilities.accepted_mime_types || [],
-				maxBytes: nextCapabilities.max_recording_bytes || 0,
-				maxDurationMs: nextCapabilities.max_recording_duration_ms || 0,
+			const transcription = nextCapabilities.transcription;
+			const wavDurationLimit =
+				transcription.max_bytes > 44
+					? Math.floor( ( transcription.max_bytes - 44 ) / 32 )
+					: 0;
+			return await start( {
+				acceptedMimeTypes:
+					transcription.accepted_input_mime_types || [],
+				maxBytes: transcription.max_bytes || 0,
+				maxDurationMs: Math.min(
+					( transcription.max_duration_seconds || 0 ) * 1000,
+					wavDurationLimit
+				),
 			} );
 		} catch ( caughtError ) {
-			setError(
-				caughtError?.message || 'Speech services are unavailable.'
-			);
+			if ( generation === generationRef.current ) {
+				setError(
+					caughtError?.message || 'Speech services are unavailable.'
+				);
+			}
+			return false;
+		} finally {
+			if ( generation === generationRef.current ) {
+				setIsLoadingCapabilities( false );
+			}
 		}
-	}, [ capabilities, isListening, start ] );
+	}, [
+		capabilities,
+		isLoadingCapabilities,
+		isTranscribing,
+		recorderStatus,
+		start,
+	] );
 
 	const stopListening = useCallback( () => {
 		stop();
-		setIsListening( false );
 	}, [ stop ] );
 
 	const toggleListening = useCallback( () => {
-		if ( isListening ) {
+		if (
+			[ 'requesting_permission', 'recording', 'stopping' ].includes(
+				recorderStatus
+			)
+		) {
 			stopListening();
 			return;
 		}
 		startListening();
-	}, [ isListening, startListening, stopListening ] );
+	}, [ recorderStatus, startListening, stopListening ] );
 
 	const resetTranscript = useCallback( () => setTranscript( '' ), [] );
+	let status = recorderStatus;
+	if ( isLoadingCapabilities ) {
+		status = 'loading_capabilities';
+	}
+	if ( isTranscribing ) {
+		status = 'transcribing';
+	}
+	const isListening = [
+		'requesting_permission',
+		'recording',
+		'stopping',
+	].includes( recorderStatus );
 
 	return {
+		capabilities,
+		cancelListening,
+		detectedLanguage,
 		isListening,
+		isTranscribing,
 		isSupported: isSpeechRecognitionSupported,
 		transcript,
 		error: error || recorderError,

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -4,114 +4,277 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
-import { chunkSpeechText, toSpeakableText } from '../utils/speech';
+import {
+	base64ToBlob,
+	chunkSpeechText,
+	loadSpeechCapabilities,
+	toSpeakableText,
+} from '../utils/speech';
 
-export const isTTSSupported = typeof Audio !== 'undefined';
+/** Whether managed audio playback is available in this browser. */
+export const isTTSSupported =
+	typeof Audio !== 'undefined' &&
+	typeof URL !== 'undefined' &&
+	typeof URL.createObjectURL === 'function';
 
 /**
+ * Load managed voices in the legacy selector shape used by settings.
  *
+ * @return {Object[]} Managed voice options.
  */
 export function useAvailableVoices() {
-	return [];
+	const [ voices, setVoices ] = useState( [] );
+	useEffect( () => {
+		let active = true;
+		loadSpeechCapabilities()
+			.then( ( capabilities ) => {
+				if ( ! active ) {
+					return;
+				}
+				setVoices(
+					capabilities.text_to_speech.voices.map( ( voice ) => ( {
+						lang: voice.locales[ 0 ] || '',
+						name: voice.name,
+						voiceURI: voice.id,
+					} ) )
+				);
+			} )
+			.catch( () => {
+				if ( active ) {
+					setVoices( [] );
+				}
+			} );
+		return () => {
+			active = false;
+		};
+	}, [] );
+	return voices;
 }
 
 /**
- * Queue managed speech audio without relying on the browser speech APIs.
+ * Speak text through the authenticated managed synthesis route.
  *
- * @param {Object} options               Speech preferences and service limits.
- * @param {string} options.voiceId       Selected service voice ID.
- * @param {number} options.rate          Selected service speech speed.
- * @param {string} options.lang          Current session language hint.
- * @param {number} options.maxTextLength Service maximum text size per request.
- * @return {Object} Playback state and controls.
+ * @param {Object}   options           Configuration.
+ * @param {string}   options.lang      Initial BCP-47 language hint.
+ * @param {Function} options.onEnd     Called after playback finishes.
+ * @param {Function} options.onError   Called after synthesis/playback fails.
+ * @param {Function} options.onStart   Called when managed playback starts.
+ * @param {number}   options.rate      Requested playback speed.
+ * @param {string}   options.sessionId Optional managed session identifier.
+ * @param {string}   options.voice     Preferred managed voice identifier.
+ * @param {string}   options.voiceURI  Legacy preferred voice identifier.
+ * @return {Object} Managed speech controls and state.
  */
 export default function useTextToSpeech( {
-	voiceId = 'auto',
-	rate = 1,
 	lang = '',
-	maxTextLength = 1200,
+	onEnd,
+	onError,
+	onStart,
+	rate = 1,
+	sessionId = '',
+	voice = '',
+	voiceURI = '',
 } = {} ) {
-	const [ isSpeaking, setIsSpeaking ] = useState( false );
+	const [ capabilities, setCapabilities ] = useState( null );
 	const [ error, setError ] = useState( null );
+	const [ isSpeaking, setIsSpeaking ] = useState( false );
+	const abortRef = useRef( null );
 	const audioRef = useRef( null );
-	const controllerRef = useRef( null );
 	const generationRef = useRef( 0 );
+	const objectUrlRef = useRef( '' );
+	const playbackResolveRef = useRef( null );
+
+	const releaseAudio = useCallback( ( settlePlayback = true ) => {
+		if ( audioRef.current ) {
+			audioRef.current.onended = null;
+			audioRef.current.onerror = null;
+			audioRef.current.pause();
+			audioRef.current.removeAttribute( 'src' );
+			audioRef.current = null;
+		}
+		if ( objectUrlRef.current ) {
+			URL.revokeObjectURL( objectUrlRef.current );
+			objectUrlRef.current = '';
+		}
+		if ( settlePlayback && playbackResolveRef.current ) {
+			playbackResolveRef.current();
+		}
+		playbackResolveRef.current = null;
+	}, [] );
 
 	const cancel = useCallback( () => {
 		generationRef.current += 1;
-		controllerRef.current?.abort();
-		const audio = audioRef.current;
-		if ( audio ) {
-			audio.pause();
-			URL.revokeObjectURL( audio.src );
-		}
-		audioRef.current = null;
+		abortRef.current?.abort();
+		abortRef.current = null;
+		releaseAudio();
 		setIsSpeaking( false );
-	}, [] );
+	}, [ releaseAudio ] );
 
 	useEffect( () => cancel, [ cancel ] );
 
+	const playBlob = useCallback(
+		( blob, generation ) =>
+			new Promise( ( resolve, reject ) => {
+				if ( generation !== generationRef.current ) {
+					resolve();
+					return;
+				}
+				const objectUrl = URL.createObjectURL( blob );
+				const audio = new Audio( objectUrl );
+				playbackResolveRef.current = resolve;
+				objectUrlRef.current = objectUrl;
+				audioRef.current = audio;
+				audio.onended = () => {
+					releaseAudio( false );
+					resolve();
+				};
+				audio.onerror = () => {
+					releaseAudio( false );
+					reject( new Error( 'Unable to play synthesized speech.' ) );
+				};
+				audio.play().catch( ( caughtError ) => {
+					releaseAudio( false );
+					reject( caughtError );
+				} );
+			} ),
+		[ releaseAudio ]
+	);
+
 	const speak = useCallback(
-		async ( text ) => {
-			cancel();
-			const chunks = chunkSpeechText(
-				toSpeakableText( text || '' ),
-				maxTextLength
-			);
-			if ( ! chunks.length || ! isTTSSupported ) {
-				return;
+		async ( text, turnOptions = {} ) => {
+			const speechText = toSpeakableText( String( text || '' ) );
+			if ( ! isTTSSupported || ! speechText ) {
+				return false;
 			}
+
+			cancel();
 			const generation = generationRef.current;
 			setError( null );
 			setIsSpeaking( true );
+
 			try {
+				const nextCapabilities =
+					capabilities || ( await loadSpeechCapabilities() );
+				if ( generation !== generationRef.current ) {
+					return false;
+				}
+				setCapabilities( nextCapabilities );
+				const synthesis = nextCapabilities.text_to_speech;
+				const requestedLanguage =
+					turnOptions.lang ||
+					lang ||
+					nextCapabilities.locales?.initial_locale ||
+					'';
+				const preferredVoice = turnOptions.voice || voice || voiceURI;
+				const selectedVoice =
+					synthesis.voices.find(
+						( candidate ) => candidate.id === preferredVoice
+					) ||
+					synthesis.voices.find( ( candidate ) =>
+						candidate.locales.includes( requestedLanguage )
+					) ||
+					synthesis.voices[ 0 ];
+				const language = selectedVoice.locales.includes(
+					requestedLanguage
+				)
+					? requestedLanguage
+					: '';
+				const requestedSpeed = Number( turnOptions.rate ?? rate );
+				const minimumSpeed = synthesis.speed.minimum;
+				const maximumSpeed = synthesis.speed.maximum;
+				let speed = 1;
+				if ( Number.isFinite( requestedSpeed ) ) {
+					speed = requestedSpeed;
+				}
+				speed = Math.min(
+					maximumSpeed,
+					Math.max( minimumSpeed, speed )
+				);
+				const mimeType = synthesis.output_mime_types[ 0 ];
+				const chunks = chunkSpeechText(
+					speechText,
+					synthesis.max_input_characters
+				);
+				let playbackStarted = false;
+
 				for ( const chunk of chunks ) {
+					if ( generation !== generationRef.current ) {
+						return false;
+					}
 					const controller = new AbortController();
-					controllerRef.current = controller;
+					abortRef.current = controller;
 					const result = await apiFetch( {
 						data: {
-							language: lang,
-							speed: rate,
+							language: language || undefined,
+							mime_type: mimeType,
+							session_id:
+								turnOptions.sessionId || sessionId || undefined,
+							speed,
 							text: chunk,
-							voice_id: voiceId,
+							voice: selectedVoice.id,
 						},
 						method: 'POST',
 						path: '/sd-ai-agent/v1/speech/synthesis',
 						signal: controller.signal,
 					} );
 					if ( generation !== generationRef.current ) {
-						return;
+						return false;
 					}
-					const bytes = Uint8Array.from(
-						atob( result.audio ),
-						( character ) => character.charCodeAt( 0 )
-					);
-					const url = URL.createObjectURL(
-						new Blob( [ bytes ], { type: result.mime_type } )
-					);
-					const audio = new Audio( url );
-					audioRef.current = audio;
-					await audio.play();
-					await new Promise( ( resolve, reject ) => {
-						audio.onended = resolve;
-						audio.onerror = reject;
-					} );
-					URL.revokeObjectURL( url );
+					const blob = base64ToBlob( result.audio, result.mime_type );
+					if ( blob.size > synthesis.max_response_bytes ) {
+						throw new Error(
+							'The synthesized audio is too large.'
+						);
+					}
+					if ( ! playbackStarted ) {
+						playbackStarted = true;
+						onStart?.();
+					}
+					await playBlob( blob, generation );
 				}
+				return true;
 			} catch ( caughtError ) {
-				if ( generation === generationRef.current ) {
-					setError(
-						caughtError?.message || 'Unable to play speech audio.'
-					);
+				if (
+					caughtError?.name !== 'AbortError' &&
+					generation === generationRef.current
+				) {
+					const message =
+						caughtError?.message || 'Unable to synthesize speech.';
+					setError( message );
+					onError?.( message );
 				}
+				return false;
 			} finally {
 				if ( generation === generationRef.current ) {
+					abortRef.current = null;
+					releaseAudio();
 					setIsSpeaking( false );
+					onEnd?.();
 				}
 			}
 		},
-		[ cancel, lang, maxTextLength, rate, voiceId ]
+		[
+			cancel,
+			capabilities,
+			lang,
+			onEnd,
+			onError,
+			onStart,
+			playBlob,
+			rate,
+			releaseAudio,
+			sessionId,
+			voice,
+			voiceURI,
+		]
 	);
 
-	return { cancel, error, isSpeaking, isSupported: isTTSSupported, speak };
+	return {
+		cancel,
+		capabilities,
+		error,
+		isSpeaking,
+		isSupported: isTTSSupported,
+		speak,
+	};
 }

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -1,175 +1,117 @@
 /**
- * Text-to-speech hook using the Web Speech API (SpeechSynthesis).
- *
- * Provides a simple interface to speak text aloud, cancel speech,
- * and query browser support. Voice, rate, and pitch are configurable.
- *
- * @module use-text-to-speech
- */
-
-/**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+import { chunkSpeechText, toSpeakableText } from '../utils/speech';
+
+export const isTTSSupported = typeof Audio !== 'undefined';
 
 /**
- * Whether the browser supports the Web Speech API SpeechSynthesis interface.
  *
- * @type {boolean}
- */
-export const isTTSSupported =
-	typeof window !== 'undefined' && 'speechSynthesis' in window;
-
-/**
- * Return the list of available SpeechSynthesis voices.
- * Voices load asynchronously in some browsers (Chrome), so this hook
- * subscribes to the `voiceschanged` event and re-reads the list.
- *
- * @return {Object[]} Available voices (may be empty until loaded).
  */
 export function useAvailableVoices() {
-	const [ voices, setVoices ] = useState( () =>
-		isTTSSupported ? window.speechSynthesis.getVoices() : []
-	);
-
-	useEffect( () => {
-		if ( ! isTTSSupported ) {
-			return;
-		}
-
-		const update = () => setVoices( window.speechSynthesis.getVoices() );
-
-		// Chrome fires voiceschanged; Firefox populates synchronously.
-		window.speechSynthesis.addEventListener( 'voiceschanged', update );
-		update();
-
-		return () => {
-			window.speechSynthesis.removeEventListener(
-				'voiceschanged',
-				update
-			);
-		};
-	}, [] );
-
-	return voices;
+	return [];
 }
 
 /**
- * Strip markdown syntax from text before speaking it.
- * Removes code fences, inline code, headers, bold/italic markers, links,
- * and leading list/blockquote characters so the spoken output is clean prose.
+ * Queue managed speech audio without relying on the browser speech APIs.
  *
- * @param {string} text Raw markdown text.
- * @return {string} Plain text suitable for speech synthesis.
- */
-function stripMarkdown( text ) {
-	return (
-		text
-			// Fenced code blocks — replace with a brief spoken label.
-			.replace( /```[\s\S]*?```/g, ' code block. ' )
-			// Inline code.
-			.replace( /`[^`]+`/g, ( m ) => m.slice( 1, -1 ) )
-			// ATX headings.
-			.replace( /^#{1,6}\s+/gm, '' )
-			// Bold / italic.
-			.replace( /\*{1,3}([^*]+)\*{1,3}/g, '$1' )
-			.replace( /_{1,3}([^_]+)_{1,3}/g, '$1' )
-			// Links — keep the label.
-			.replace( /\[([^\]]+)\]\([^)]+\)/g, '$1' )
-			// Images.
-			.replace( /!\[[^\]]*\]\([^)]+\)/g, '' )
-			// Blockquote markers.
-			.replace( /^>\s*/gm, '' )
-			// List markers.
-			.replace( /^[\s]*[-*+]\s+/gm, '' )
-			.replace( /^[\s]*\d+\.\s+/gm, '' )
-			// Horizontal rules.
-			.replace( /^[-*_]{3,}\s*$/gm, '' )
-			// Collapse multiple blank lines.
-			.replace( /\n{3,}/g, '\n\n' )
-			.trim()
-	);
-}
-
-/**
- * Hook that provides text-to-speech functionality via SpeechSynthesis.
- *
- * @param {Object} options               - Configuration options.
- * @param {string} [options.voiceURI=''] - URI of the voice to use (empty = browser default).
- * @param {number} [options.rate=1]      - Speech rate (0.1–10, default 1).
- * @param {number} [options.pitch=1]     - Speech pitch (0–2, default 1).
- * @return {{
- *   isSpeaking: boolean,
- *   speak: (text: string) => void,
- *   cancel: () => void,
- *   isSupported: boolean,
- * }} TTS controls.
+ * @param {Object} options               Speech preferences and service limits.
+ * @param {string} options.voiceId       Selected service voice ID.
+ * @param {number} options.rate          Selected service speech speed.
+ * @param {string} options.lang          Current session language hint.
+ * @param {number} options.maxTextLength Service maximum text size per request.
+ * @return {Object} Playback state and controls.
  */
 export default function useTextToSpeech( {
-	voiceURI = '',
+	voiceId = 'auto',
 	rate = 1,
-	pitch = 1,
+	lang = '',
+	maxTextLength = 1200,
 } = {} ) {
 	const [ isSpeaking, setIsSpeaking ] = useState( false );
-	const utteranceRef = useRef( null );
-
-	// Cancel any in-progress speech when the component unmounts.
-	useEffect( () => {
-		return () => {
-			if ( isTTSSupported ) {
-				window.speechSynthesis.cancel();
-			}
-		};
-	}, [] );
-
-	const speak = useCallback(
-		( text ) => {
-			if ( ! isTTSSupported || ! text ) {
-				return;
-			}
-
-			// Cancel any current speech before starting new.
-			window.speechSynthesis.cancel();
-
-			const plain = stripMarkdown( text );
-			if ( ! plain ) {
-				return;
-			}
-
-			const utterance = new SpeechSynthesisUtterance( plain );
-			utterance.rate = rate;
-			utterance.pitch = pitch;
-
-			// Resolve voice by URI if specified.
-			if ( voiceURI ) {
-				const voices = window.speechSynthesis.getVoices();
-				const match = voices.find( ( v ) => v.voiceURI === voiceURI );
-				if ( match ) {
-					utterance.voice = match;
-				}
-			}
-
-			utterance.onstart = () => setIsSpeaking( true );
-			utterance.onend = () => setIsSpeaking( false );
-			utterance.onerror = () => setIsSpeaking( false );
-
-			utteranceRef.current = utterance;
-			window.speechSynthesis.speak( utterance );
-		},
-		[ voiceURI, rate, pitch ]
-	);
+	const [ error, setError ] = useState( null );
+	const audioRef = useRef( null );
+	const controllerRef = useRef( null );
+	const generationRef = useRef( 0 );
 
 	const cancel = useCallback( () => {
-		if ( isTTSSupported ) {
-			window.speechSynthesis.cancel();
-			setIsSpeaking( false );
+		generationRef.current += 1;
+		controllerRef.current?.abort();
+		const audio = audioRef.current;
+		if ( audio ) {
+			audio.pause();
+			URL.revokeObjectURL( audio.src );
 		}
+		audioRef.current = null;
+		setIsSpeaking( false );
 	}, [] );
 
-	return {
-		isSpeaking,
-		speak,
-		cancel,
-		isSupported: isTTSSupported,
-	};
+	useEffect( () => cancel, [ cancel ] );
+
+	const speak = useCallback(
+		async ( text ) => {
+			cancel();
+			const chunks = chunkSpeechText(
+				toSpeakableText( text || '' ),
+				maxTextLength
+			);
+			if ( ! chunks.length || ! isTTSSupported ) {
+				return;
+			}
+			const generation = generationRef.current;
+			setError( null );
+			setIsSpeaking( true );
+			try {
+				for ( const chunk of chunks ) {
+					const controller = new AbortController();
+					controllerRef.current = controller;
+					const result = await apiFetch( {
+						data: {
+							language: lang,
+							speed: rate,
+							text: chunk,
+							voice_id: voiceId,
+						},
+						method: 'POST',
+						path: '/sd-ai-agent/v1/speech/synthesis',
+						signal: controller.signal,
+					} );
+					if ( generation !== generationRef.current ) {
+						return;
+					}
+					const bytes = Uint8Array.from(
+						atob( result.audio ),
+						( character ) => character.charCodeAt( 0 )
+					);
+					const url = URL.createObjectURL(
+						new Blob( [ bytes ], { type: result.mime_type } )
+					);
+					const audio = new Audio( url );
+					audioRef.current = audio;
+					await audio.play();
+					await new Promise( ( resolve, reject ) => {
+						audio.onended = resolve;
+						audio.onerror = reject;
+					} );
+					URL.revokeObjectURL( url );
+				}
+			} catch ( caughtError ) {
+				if ( generation === generationRef.current ) {
+					setError(
+						caughtError?.message || 'Unable to play speech audio.'
+					);
+				}
+			} finally {
+				if ( generation === generationRef.current ) {
+					setIsSpeaking( false );
+				}
+			}
+		},
+		[ cancel, lang, maxTextLength, rate, voiceId ]
+	);
+
+	return { cancel, error, isSpeaking, isSupported: isTTSSupported, speak };
 }

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -16,6 +16,32 @@ export const isTTSSupported =
 	typeof Audio !== 'undefined' &&
 	typeof URL !== 'undefined' &&
 	typeof URL.createObjectURL === 'function';
+const isBrowserFallbackSupported =
+	typeof globalThis.speechSynthesis !== 'undefined' &&
+	typeof globalThis.SpeechSynthesisUtterance !== 'undefined';
+
+/**
+ * Load the managed speech contract for preference controls.
+ *
+ * @return {Object|null} Managed speech capabilities.
+ */
+export function useSpeechCapabilities() {
+	const [ capabilities, setCapabilities ] = useState( null );
+	useEffect( () => {
+		let active = true;
+		loadSpeechCapabilities()
+			.then( ( result ) => {
+				if ( active ) {
+					setCapabilities( result );
+				}
+			} )
+			.catch( () => undefined );
+		return () => {
+			active = false;
+		};
+	}, [] );
+	return capabilities;
+}
 
 /**
  * Load managed voices in the legacy selector shape used by settings.
@@ -23,49 +49,33 @@ export const isTTSSupported =
  * @return {Object[]} Managed voice options.
  */
 export function useAvailableVoices() {
-	const [ voices, setVoices ] = useState( [] );
-	useEffect( () => {
-		let active = true;
-		loadSpeechCapabilities()
-			.then( ( capabilities ) => {
-				if ( ! active ) {
-					return;
-				}
-				setVoices(
-					capabilities.text_to_speech.voices.map( ( voice ) => ( {
-						lang: voice.locales[ 0 ] || '',
-						name: voice.name,
-						voiceURI: voice.id,
-					} ) )
-				);
-			} )
-			.catch( () => {
-				if ( active ) {
-					setVoices( [] );
-				}
-			} );
-		return () => {
-			active = false;
-		};
-	}, [] );
-	return voices;
+	const capabilities = useSpeechCapabilities();
+	return (
+		capabilities?.text_to_speech?.voices.map( ( voice ) => ( {
+			lang: voice.locales[ 0 ] || '',
+			name: voice.name,
+			voiceURI: voice.id,
+		} ) ) || []
+	);
 }
 
 /**
  * Speak text through the authenticated managed synthesis route.
  *
- * @param {Object}   options           Configuration.
- * @param {string}   options.lang      Initial BCP-47 language hint.
- * @param {Function} options.onEnd     Called after playback finishes.
- * @param {Function} options.onError   Called after synthesis/playback fails.
- * @param {Function} options.onStart   Called when managed playback starts.
- * @param {number}   options.rate      Requested playback speed.
- * @param {string}   options.sessionId Optional managed session identifier.
- * @param {string}   options.voice     Preferred managed voice identifier.
- * @param {string}   options.voiceURI  Legacy preferred voice identifier.
+ * @param {Object}   options                      Configuration.
+ * @param {boolean}  options.allowBrowserFallback Allow explicit browser fallback.
+ * @param {string}   options.lang                 Initial BCP-47 language hint.
+ * @param {Function} options.onEnd                Called after playback finishes.
+ * @param {Function} options.onError              Called after synthesis/playback fails.
+ * @param {Function} options.onStart              Called when managed playback starts.
+ * @param {number}   options.rate                 Requested playback speed.
+ * @param {string}   options.sessionId            Optional managed session identifier.
+ * @param {string}   options.voice                Preferred managed voice identifier.
+ * @param {string}   options.voiceURI             Legacy preferred voice identifier.
  * @return {Object} Managed speech controls and state.
  */
 export default function useTextToSpeech( {
+	allowBrowserFallback = false,
 	lang = '',
 	onEnd,
 	onError,
@@ -81,6 +91,8 @@ export default function useTextToSpeech( {
 	const abortRef = useRef( null );
 	const audioRef = useRef( null );
 	const generationRef = useRef( 0 );
+	const nativeRef = useRef( null );
+	const nativeResolveRef = useRef( null );
 	const objectUrlRef = useRef( '' );
 	const playbackResolveRef = useRef( null );
 
@@ -102,13 +114,27 @@ export default function useTextToSpeech( {
 		playbackResolveRef.current = null;
 	}, [] );
 
+	const releaseNative = useCallback( ( settlePlayback = true ) => {
+		if ( nativeRef.current ) {
+			nativeRef.current.onend = null;
+			nativeRef.current.onerror = null;
+			globalThis.speechSynthesis.cancel();
+			nativeRef.current = null;
+		}
+		if ( settlePlayback && nativeResolveRef.current ) {
+			nativeResolveRef.current();
+		}
+		nativeResolveRef.current = null;
+	}, [] );
+
 	const cancel = useCallback( () => {
 		generationRef.current += 1;
 		abortRef.current?.abort();
 		abortRef.current = null;
 		releaseAudio();
+		releaseNative();
 		setIsSpeaking( false );
-	}, [ releaseAudio ] );
+	}, [ releaseAudio, releaseNative ] );
 
 	useEffect( () => cancel, [ cancel ] );
 
@@ -140,6 +166,33 @@ export default function useTextToSpeech( {
 		[ releaseAudio ]
 	);
 
+	const playBrowserFallback = useCallback(
+		( text, generation, language, speed ) =>
+			new Promise( ( resolve, reject ) => {
+				if ( generation !== generationRef.current ) {
+					resolve();
+					return;
+				}
+				const utterance = new globalThis.SpeechSynthesisUtterance(
+					text
+				);
+				utterance.lang = language;
+				utterance.rate = Math.min( 10, Math.max( 0.1, speed ) );
+				nativeRef.current = utterance;
+				nativeResolveRef.current = resolve;
+				utterance.onend = () => {
+					releaseNative( false );
+					resolve();
+				};
+				utterance.onerror = () => {
+					releaseNative( false );
+					reject( new Error( 'Unable to play browser speech.' ) );
+				};
+				globalThis.speechSynthesis.speak( utterance );
+			} ),
+		[ releaseNative ]
+	);
+
 	const speak = useCallback(
 		async ( text, turnOptions = {} ) => {
 			const speechText = toSpeakableText( String( text || '' ) );
@@ -149,6 +202,13 @@ export default function useTextToSpeech( {
 
 			cancel();
 			const generation = generationRef.current;
+			const fallbackLanguage =
+				turnOptions.lang ||
+				lang ||
+				globalThis.navigator?.language ||
+				'';
+			const fallbackSpeed = Number( turnOptions.rate ?? rate ) || 1;
+			let playbackStarted = false;
 			setError( null );
 			setIsSpeaking( true );
 
@@ -195,8 +255,6 @@ export default function useTextToSpeech( {
 					speechText,
 					synthesis.max_input_characters
 				);
-				let playbackStarted = false;
-
 				for ( const chunk of chunks ) {
 					if ( generation !== generationRef.current ) {
 						return false;
@@ -234,12 +292,34 @@ export default function useTextToSpeech( {
 				}
 				return true;
 			} catch ( caughtError ) {
+				let failure = caughtError;
 				if (
+					allowBrowserFallback &&
+					isBrowserFallbackSupported &&
+					! playbackStarted &&
 					caughtError?.name !== 'AbortError' &&
 					generation === generationRef.current
 				) {
+					try {
+						playbackStarted = true;
+						onStart?.();
+						await playBrowserFallback(
+							speechText,
+							generation,
+							fallbackLanguage,
+							fallbackSpeed
+						);
+						return true;
+					} catch ( fallbackError ) {
+						failure = fallbackError;
+					}
+				}
+				if (
+					failure?.name !== 'AbortError' &&
+					generation === generationRef.current
+				) {
 					const message =
-						caughtError?.message || 'Unable to synthesize speech.';
+						failure?.message || 'Unable to synthesize speech.';
 					setError( message );
 					onError?.( message );
 				}
@@ -248,12 +328,14 @@ export default function useTextToSpeech( {
 				if ( generation === generationRef.current ) {
 					abortRef.current = null;
 					releaseAudio();
+					releaseNative();
 					setIsSpeaking( false );
 					onEnd?.();
 				}
 			}
 		},
 		[
+			allowBrowserFallback,
 			cancel,
 			capabilities,
 			lang,
@@ -261,8 +343,10 @@ export default function useTextToSpeech( {
 			onError,
 			onStart,
 			playBlob,
+			playBrowserFallback,
 			rate,
 			releaseAudio,
+			releaseNative,
 			sessionId,
 			voice,
 			voiceURI,

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 import {
 	base64ToBlob,
@@ -133,6 +134,23 @@ export default function useTextToSpeech( {
 		setIsSpeaking( false );
 	}, [ releaseAudio, releaseNative ] );
 
+	useEffect( () => {
+		if ( ! isTTSSupported ) {
+			return undefined;
+		}
+		let active = true;
+		loadSpeechCapabilities()
+			.then( ( result ) => {
+				if ( active ) {
+					setCapabilities( result );
+				}
+			} )
+			.catch( () => undefined );
+		return () => {
+			active = false;
+		};
+	}, [] );
+
 	useEffect( () => cancel, [ cancel ] );
 
 	const playBlob = useCallback(
@@ -153,7 +171,14 @@ export default function useTextToSpeech( {
 				};
 				audio.onerror = () => {
 					releaseAudio( false );
-					reject( new Error( 'Unable to play synthesized speech.' ) );
+					reject(
+						new Error(
+							__(
+								'Unable to play synthesized speech.',
+								'superdav-ai-agent'
+							)
+						)
+					);
 				};
 				audio.play().catch( ( caughtError ) => {
 					releaseAudio( false );
@@ -183,7 +208,14 @@ export default function useTextToSpeech( {
 				};
 				utterance.onerror = () => {
 					releaseNative( false );
-					reject( new Error( 'Unable to play browser speech.' ) );
+					reject(
+						new Error(
+							__(
+								'Unable to play browser speech.',
+								'superdav-ai-agent'
+							)
+						)
+					);
 				};
 				globalThis.speechSynthesis.speak( utterance );
 			} ),
@@ -215,7 +247,12 @@ export default function useTextToSpeech( {
 
 			try {
 				if ( ! isTTSSupported ) {
-					throw new Error( 'Managed audio playback is unavailable.' );
+					throw new Error(
+						__(
+							'Managed audio playback is unavailable.',
+							'superdav-ai-agent'
+						)
+					);
 				}
 				const nextCapabilities =
 					capabilities || ( await loadSpeechCapabilities() );
@@ -285,7 +322,10 @@ export default function useTextToSpeech( {
 					const blob = base64ToBlob( result.audio, result.mime_type );
 					if ( blob.size > synthesis.max_response_bytes ) {
 						throw new Error(
-							'The synthesized audio is too large.'
+							__(
+								'The synthesized audio is too large.',
+								'superdav-ai-agent'
+							)
 						);
 					}
 					if ( ! playbackStarted ) {
@@ -323,7 +363,11 @@ export default function useTextToSpeech( {
 					generation === generationRef.current
 				) {
 					const message =
-						failure?.message || 'Unable to synthesize speech.';
+						failure?.message ||
+						__(
+							'Unable to synthesize speech.',
+							'superdav-ai-agent'
+						);
 					setError( message );
 					onError?.( message );
 				}
@@ -357,13 +401,25 @@ export default function useTextToSpeech( {
 		]
 	);
 
+	const synthesisCapabilities = capabilities?.text_to_speech;
+	const hasManagedSynthesis = Boolean(
+		isTTSSupported &&
+			capabilities?.available &&
+			Array.isArray( synthesisCapabilities?.voices ) &&
+			synthesisCapabilities.voices.length > 0 &&
+			Array.isArray( synthesisCapabilities.output_mime_types ) &&
+			synthesisCapabilities.output_mime_types.length > 0 &&
+			Number( synthesisCapabilities.max_input_characters ) > 0 &&
+			Number( synthesisCapabilities.max_response_bytes ) > 0
+	);
+
 	return {
 		cancel,
 		capabilities,
 		error,
 		isSpeaking,
 		isSupported:
-			isTTSSupported ||
+			hasManagedSynthesis ||
 			( allowBrowserFallback && isBrowserFallbackSupported ),
 		speak,
 	};

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -7,18 +7,15 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	base64ToBlob,
 	chunkSpeechText,
+	isBrowserSpeechSynthesisSupported,
+	isManagedAudioPlaybackSupported,
 	loadSpeechCapabilities,
 	toSpeakableText,
 } from '../utils/speech';
 
 /** Whether managed audio playback is available in this browser. */
-export const isTTSSupported =
-	typeof Audio !== 'undefined' &&
-	typeof URL !== 'undefined' &&
-	typeof URL.createObjectURL === 'function';
-const isBrowserFallbackSupported =
-	typeof globalThis.speechSynthesis !== 'undefined' &&
-	typeof globalThis.SpeechSynthesisUtterance !== 'undefined';
+export const isTTSSupported = isManagedAudioPlaybackSupported;
+export const isBrowserFallbackSupported = isBrowserSpeechSynthesisSupported;
 
 /**
  * Load the managed speech contract for preference controls.
@@ -196,7 +193,11 @@ export default function useTextToSpeech( {
 	const speak = useCallback(
 		async ( text, turnOptions = {} ) => {
 			const speechText = toSpeakableText( String( text || '' ) );
-			if ( ! isTTSSupported || ! speechText ) {
+			if (
+				! speechText ||
+				( ! isTTSSupported &&
+					( ! allowBrowserFallback || ! isBrowserFallbackSupported ) )
+			) {
 				return false;
 			}
 
@@ -213,6 +214,9 @@ export default function useTextToSpeech( {
 			setIsSpeaking( true );
 
 			try {
+				if ( ! isTTSSupported ) {
+					throw new Error( 'Managed audio playback is unavailable.' );
+				}
 				const nextCapabilities =
 					capabilities || ( await loadSpeechCapabilities() );
 				if ( generation !== generationRef.current ) {
@@ -358,7 +362,9 @@ export default function useTextToSpeech( {
 		capabilities,
 		error,
 		isSpeaking,
-		isSupported: isTTSSupported,
+		isSupported:
+			isTTSSupported ||
+			( allowBrowserFallback && isBrowserFallbackSupported ),
 		speak,
 	};
 }

--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -16,7 +16,7 @@ import { extractText } from './chat-redesign/message-helpers';
 import useSpeechRecognition from './use-speech-recognition';
 import useTextToSpeech from './use-text-to-speech';
 
-let playbackOwner = null;
+let activePlayback = null;
 
 const latestModelResponse = ( messages ) => {
 	for ( let index = messages.length - 1; index >= 0; index-- ) {
@@ -147,8 +147,8 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 	} );
 
 	const stopSpeaking = useCallback( () => {
-		if ( playbackOwner === ownerRef.current ) {
-			playbackOwner = null;
+		if ( activePlayback?.owner === ownerRef.current ) {
+			activePlayback = null;
 		}
 		cancelSpeech();
 		setPhase( 'idle' );
@@ -156,24 +156,35 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 
 	const readAloud = useCallback(
 		async ( text, options = {} ) => {
-			if ( playbackOwner && playbackOwner !== ownerRef.current ) {
+			if ( activePlayback && activePlayback.owner !== ownerRef.current ) {
 				setPhase( 'idle' );
 				return false;
 			}
-			playbackOwner = ownerRef.current;
+			const owner = ownerRef.current;
+			activePlayback = {
+				cancel: () => {
+					cancelSpeech();
+					setPhase( 'idle' );
+				},
+				owner,
+			};
 			setPhase( 'speaking' );
 			const completed = await speak( text, options );
-			if ( playbackOwner === ownerRef.current ) {
-				playbackOwner = null;
+			if ( activePlayback?.owner === owner ) {
+				activePlayback = null;
 				setPhase( completed ? 'idle' : 'error' );
 			}
 			return completed;
 		},
-		[ speak ]
+		[ cancelSpeech, speak ]
 	);
 
 	const startListening = useCallback( async () => {
-		if ( isSpeaking ) {
+		if ( activePlayback && activePlayback.owner !== ownerRef.current ) {
+			const cancelOwnerPlayback = activePlayback.cancel;
+			activePlayback = null;
+			cancelOwnerPlayback();
+		} else if ( activePlayback || isSpeaking ) {
 			stopSpeaking();
 		}
 		setPhase( 'loading_capabilities' );
@@ -307,8 +318,8 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 			);
 			window.removeEventListener( 'pagehide', stopForPageChange );
 			stopForPageChange();
-			if ( playbackOwner === owner ) {
-				playbackOwner = null;
+			if ( activePlayback?.owner === owner ) {
+				activePlayback = null;
 			}
 		};
 	}, [ cancelRecognition, stopSpeaking ] );

--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -81,14 +81,14 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 	} = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
 		return {
-			currentSessionId: store.getCurrentSessionId(),
-			messages: store.getCurrentSessionMessages(),
-			readAloudEnabled: store.isTtsEnabled(),
-			sending: store.isSending(),
+			currentSessionId: store.getCurrentSessionId?.() || null,
+			messages: store.getCurrentSessionMessages?.() || [],
+			readAloudEnabled: store.isTtsEnabled?.() || false,
+			sending: store.isSending?.() || false,
 			speechFallbackEnabled: store.isSpeechFallbackEnabled?.() || false,
-			speed: store.getTtsRate(),
+			speed: store.getTtsRate?.() || 1,
 			streamError: store.hasStreamError?.() || false,
-			voiceId: store.getTtsVoiceURI(),
+			voiceId: store.getTtsVoiceURI?.() || '',
 			voiceModeEnabled: store.isVoiceConversationEnabled?.() || false,
 		};
 	}, [] );

--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -93,6 +93,7 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 		};
 	}, [] );
 	const voiceModeRef = useRef( voiceModeEnabled );
+	const previousSessionIdRef = useRef( currentSessionId );
 
 	useEffect( () => {
 		voiceModeRef.current = voiceModeEnabled;
@@ -291,8 +292,17 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 	}, [ recognitionError, speechError ] );
 
 	useEffect( () => {
+		const previousSessionId = previousSessionIdRef.current;
+		previousSessionIdRef.current = currentSessionId;
+		const createdSessionForPendingTurn = Boolean(
+			! previousSessionId && currentSessionId && sending
+		);
 		cancelRecognition();
 		stopSpeaking();
+		if ( createdSessionForPendingTurn ) {
+			awaitingResponseRef.current = true;
+			return;
+		}
 		voiceTurnRef.current = false;
 		awaitingResponseRef.current = false;
 		responseBaselineRef.current = latestModelResponse( messages ).identity;

--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -11,6 +17,20 @@ import useSpeechRecognition from './use-speech-recognition';
 import useTextToSpeech from './use-text-to-speech';
 
 let playbackOwner = null;
+
+const latestModelResponse = ( messages ) => {
+	for ( let index = messages.length - 1; index >= 0; index-- ) {
+		const message = messages[ index ];
+		if ( message?.role === 'model' ) {
+			const text = extractText( message );
+			return {
+				identity: `${ index }:${ message.id || '' }:${ text }`,
+				text,
+			};
+		}
+	}
+	return { identity: '', text: '' };
+};
 
 const STATUS_LABELS = {
 	error: __( 'Voice turn stopped', 'superdav-ai-agent' ),
@@ -35,11 +55,14 @@ const STATUS_LABELS = {
  * Microphone capture starts only from startListening(), which UI controls must
  * call directly from a user gesture. Completing playback never reopens it.
  *
+ * @param {Object} options         Coordinator options.
+ * @param {string} options.surface Surface identity: main or widget.
  * @return {Object} Voice state and controls for one chat surface.
  */
-export default function useVoiceConversation() {
+export default function useVoiceConversation( { surface = 'main' } = {} ) {
+	const awaitingResponseRef = useRef( false );
+	const responseBaselineRef = useRef( '' );
 	const ownerRef = useRef( Symbol( 'voice-conversation' ) );
-	const previousSendingRef = useRef( false );
 	const voiceTurnRef = useRef( false );
 	const [ pendingTranscript, setPendingTranscript ] = useState( null );
 	const [ phase, setPhase ] = useState( 'idle' );
@@ -52,6 +75,7 @@ export default function useVoiceConversation() {
 		sending,
 		speechFallbackEnabled,
 		speed,
+		streamError,
 		voiceId,
 		voiceModeEnabled,
 	} = useSelect( ( select ) => {
@@ -61,10 +85,11 @@ export default function useVoiceConversation() {
 			messages: store.getCurrentSessionMessages(),
 			readAloudEnabled: store.isTtsEnabled(),
 			sending: store.isSending(),
-			speechFallbackEnabled: store.isSpeechFallbackEnabled(),
+			speechFallbackEnabled: store.isSpeechFallbackEnabled?.() || false,
 			speed: store.getTtsRate(),
+			streamError: store.hasStreamError?.() || false,
 			voiceId: store.getTtsVoiceURI(),
-			voiceModeEnabled: store.isVoiceConversationEnabled(),
+			voiceModeEnabled: store.isVoiceConversationEnabled?.() || false,
 		};
 	}, [] );
 	const voiceModeRef = useRef( voiceModeEnabled );
@@ -180,7 +205,7 @@ export default function useVoiceConversation() {
 
 	const toggleVoiceMode = useCallback( () => {
 		const enabled = ! voiceModeEnabled;
-		setVoiceConversationEnabled( enabled );
+		setVoiceConversationEnabled?.( enabled );
 		if ( ! enabled ) {
 			voiceTurnRef.current = false;
 			cancelRecognition();
@@ -195,28 +220,48 @@ export default function useVoiceConversation() {
 
 	useEffect( () => {
 		if ( sending ) {
-			previousSendingRef.current = true;
-			if ( voiceTurnRef.current ) {
+			if ( ! awaitingResponseRef.current ) {
+				responseBaselineRef.current =
+					latestModelResponse( messages ).identity;
+				awaitingResponseRef.current = true;
+			}
+			if ( voiceTurnRef.current || readAloudEnabled ) {
 				setPhase( 'thinking' );
 			}
 			return;
 		}
-		if ( ! previousSendingRef.current ) {
+		if ( ! awaitingResponseRef.current ) {
 			return;
 		}
-		previousSendingRef.current = false;
-		const latestResponse = [ ...messages ]
-			.reverse()
-			.find( ( message ) => message?.role === 'model' );
-		const text = latestResponse ? extractText( latestResponse ) : '';
+		const latestResponse = latestModelResponse( messages );
+		if (
+			! latestResponse.text ||
+			latestResponse.identity === responseBaselineRef.current
+		) {
+			setPhase( 'thinking' );
+			return;
+		}
+		awaitingResponseRef.current = false;
 		const shouldSpeak = voiceTurnRef.current || readAloudEnabled;
 		voiceTurnRef.current = false;
-		if ( shouldSpeak && text ) {
-			readAloud( text );
+		const mainSurfacePresent =
+			typeof document !== 'undefined' &&
+			document.querySelector( '.sdaa-cr' );
+		const observesPlayback = surface !== 'widget' || ! mainSurfacePresent;
+		if ( shouldSpeak && observesPlayback ) {
+			readAloud( latestResponse.text );
 		} else {
 			setPhase( 'idle' );
 		}
-	}, [ messages, readAloud, readAloudEnabled, sending ] );
+	}, [ messages, readAloud, readAloudEnabled, sending, surface ] );
+
+	useEffect( () => {
+		if ( streamError ) {
+			awaitingResponseRef.current = false;
+			voiceTurnRef.current = false;
+			setPhase( 'error' );
+		}
+	}, [ streamError ] );
 
 	useEffect( () => {
 		if ( isTranscribing ) {
@@ -238,7 +283,8 @@ export default function useVoiceConversation() {
 		cancelRecognition();
 		stopSpeaking();
 		voiceTurnRef.current = false;
-		previousSendingRef.current = sending;
+		awaitingResponseRef.current = false;
+		responseBaselineRef.current = latestModelResponse( messages ).identity;
 	}, [ currentSessionId ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect( () => {
@@ -267,21 +313,42 @@ export default function useVoiceConversation() {
 		};
 	}, [ cancelRecognition, stopSpeaking ] );
 
-	return {
-		consumeTranscript,
-		error: recognitionError || speechError,
-		isListening,
-		isSpeaking,
-		isSupported: recognitionSupported && speechSupported,
-		pendingTranscript,
-		phase,
-		readAloud,
-		startListening,
-		statusLabel: STATUS_LABELS[ phase ] || STATUS_LABELS.idle,
-		stopListening,
-		stopSpeaking,
-		toggleListening,
-		toggleVoiceMode,
-		voiceModeEnabled,
-	};
+	return useMemo(
+		() => ( {
+			consumeTranscript,
+			error: recognitionError || speechError,
+			isListening,
+			isSpeaking,
+			isSpeechSupported: speechSupported,
+			isSupported: recognitionSupported && speechSupported,
+			pendingTranscript,
+			phase,
+			readAloud,
+			startListening,
+			statusLabel: STATUS_LABELS[ phase ] || STATUS_LABELS.idle,
+			stopListening,
+			stopSpeaking,
+			toggleListening,
+			toggleVoiceMode,
+			voiceModeEnabled,
+		} ),
+		[
+			consumeTranscript,
+			isListening,
+			isSpeaking,
+			pendingTranscript,
+			phase,
+			readAloud,
+			recognitionError,
+			recognitionSupported,
+			speechError,
+			speechSupported,
+			startListening,
+			stopListening,
+			stopSpeaking,
+			toggleListening,
+			toggleVoiceMode,
+			voiceModeEnabled,
+		]
+	);
 }

--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -1,0 +1,287 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+import STORE_NAME from '../store';
+import { extractText } from './chat-redesign/message-helpers';
+import useSpeechRecognition from './use-speech-recognition';
+import useTextToSpeech from './use-text-to-speech';
+
+let playbackOwner = null;
+
+const STATUS_LABELS = {
+	error: __( 'Voice turn stopped', 'superdav-ai-agent' ),
+	idle: __( 'Voice ready', 'superdav-ai-agent' ),
+	listening: __( 'Listening', 'superdav-ai-agent' ),
+	loading_capabilities: __( 'Preparing voice', 'superdav-ai-agent' ),
+	recording: __( 'Listening', 'superdav-ai-agent' ),
+	requesting_permission: __(
+		'Waiting for microphone permission',
+		'superdav-ai-agent'
+	),
+	sending: __( 'Sending voice message', 'superdav-ai-agent' ),
+	speaking: __( 'Reading response aloud', 'superdav-ai-agent' ),
+	stopping: __( 'Finishing recording', 'superdav-ai-agent' ),
+	thinking: __( 'Waiting for response', 'superdav-ai-agent' ),
+	transcribing: __( 'Transcribing', 'superdav-ai-agent' ),
+};
+
+/**
+ * Coordinate one turn-based managed voice conversation surface.
+ *
+ * Microphone capture starts only from startListening(), which UI controls must
+ * call directly from a user gesture. Completing playback never reopens it.
+ *
+ * @return {Object} Voice state and controls for one chat surface.
+ */
+export default function useVoiceConversation() {
+	const ownerRef = useRef( Symbol( 'voice-conversation' ) );
+	const previousSendingRef = useRef( false );
+	const voiceTurnRef = useRef( false );
+	const [ pendingTranscript, setPendingTranscript ] = useState( null );
+	const [ phase, setPhase ] = useState( 'idle' );
+	const { sendMessage, setVoiceConversationEnabled } =
+		useDispatch( STORE_NAME );
+	const {
+		currentSessionId,
+		messages,
+		readAloudEnabled,
+		sending,
+		speechFallbackEnabled,
+		speed,
+		voiceId,
+		voiceModeEnabled,
+	} = useSelect( ( select ) => {
+		const store = select( STORE_NAME );
+		return {
+			currentSessionId: store.getCurrentSessionId(),
+			messages: store.getCurrentSessionMessages(),
+			readAloudEnabled: store.isTtsEnabled(),
+			sending: store.isSending(),
+			speechFallbackEnabled: store.isSpeechFallbackEnabled(),
+			speed: store.getTtsRate(),
+			voiceId: store.getTtsVoiceURI(),
+			voiceModeEnabled: store.isVoiceConversationEnabled(),
+		};
+	}, [] );
+	const voiceModeRef = useRef( voiceModeEnabled );
+
+	useEffect( () => {
+		voiceModeRef.current = voiceModeEnabled;
+	}, [ voiceModeEnabled ] );
+
+	const handleTranscript = useCallback(
+		( text ) => {
+			if ( voiceModeRef.current ) {
+				voiceTurnRef.current = true;
+				setPhase( 'sending' );
+				sendMessage( text, [] );
+				return;
+			}
+			setPendingTranscript( {
+				id: globalThis.crypto?.randomUUID?.() || Date.now(),
+				text,
+			} );
+		},
+		[ sendMessage ]
+	);
+
+	const {
+		cancelListening: cancelRecognition,
+		detectedLanguage,
+		error: recognitionError,
+		isListening,
+		isSupported: recognitionSupported,
+		isTranscribing,
+		startListening: startRecognition,
+		status: recognitionStatus,
+		stopListening: stopRecognition,
+	} = useSpeechRecognition( {
+		lang: globalThis.sdAiAgentData?.speechLocales?.initial_locale || '',
+		onResult: handleTranscript,
+		sessionKey: currentSessionId || '',
+	} );
+	const {
+		cancel: cancelSpeech,
+		error: speechError,
+		isSpeaking,
+		isSupported: speechSupported,
+		speak,
+	} = useTextToSpeech( {
+		allowBrowserFallback: speechFallbackEnabled,
+		lang:
+			detectedLanguage ||
+			globalThis.sdAiAgentData?.speechLocales?.initial_locale ||
+			'',
+		rate: speed,
+		sessionId: currentSessionId || '',
+		voice: voiceId,
+	} );
+
+	const stopSpeaking = useCallback( () => {
+		if ( playbackOwner === ownerRef.current ) {
+			playbackOwner = null;
+		}
+		cancelSpeech();
+		setPhase( 'idle' );
+	}, [ cancelSpeech ] );
+
+	const readAloud = useCallback(
+		async ( text, options = {} ) => {
+			if ( playbackOwner && playbackOwner !== ownerRef.current ) {
+				setPhase( 'idle' );
+				return false;
+			}
+			playbackOwner = ownerRef.current;
+			setPhase( 'speaking' );
+			const completed = await speak( text, options );
+			if ( playbackOwner === ownerRef.current ) {
+				playbackOwner = null;
+				setPhase( completed ? 'idle' : 'error' );
+			}
+			return completed;
+		},
+		[ speak ]
+	);
+
+	const startListening = useCallback( async () => {
+		if ( isSpeaking ) {
+			stopSpeaking();
+		}
+		setPhase( 'loading_capabilities' );
+		const started = await startRecognition();
+		if ( ! started ) {
+			setPhase( 'error' );
+		}
+		return started;
+	}, [ isSpeaking, startRecognition, stopSpeaking ] );
+
+	const stopListening = useCallback( () => {
+		stopRecognition();
+		setPhase( 'transcribing' );
+	}, [ stopRecognition ] );
+
+	const toggleListening = useCallback( () => {
+		if ( isListening ) {
+			stopListening();
+			return;
+		}
+		startListening();
+	}, [ isListening, startListening, stopListening ] );
+
+	const consumeTranscript = useCallback( ( id ) => {
+		setPendingTranscript( ( current ) =>
+			current?.id === id ? null : current
+		);
+	}, [] );
+
+	const toggleVoiceMode = useCallback( () => {
+		const enabled = ! voiceModeEnabled;
+		setVoiceConversationEnabled( enabled );
+		if ( ! enabled ) {
+			voiceTurnRef.current = false;
+			cancelRecognition();
+			stopSpeaking();
+		}
+	}, [
+		cancelRecognition,
+		setVoiceConversationEnabled,
+		stopSpeaking,
+		voiceModeEnabled,
+	] );
+
+	useEffect( () => {
+		if ( sending ) {
+			previousSendingRef.current = true;
+			if ( voiceTurnRef.current ) {
+				setPhase( 'thinking' );
+			}
+			return;
+		}
+		if ( ! previousSendingRef.current ) {
+			return;
+		}
+		previousSendingRef.current = false;
+		const latestResponse = [ ...messages ]
+			.reverse()
+			.find( ( message ) => message?.role === 'model' );
+		const text = latestResponse ? extractText( latestResponse ) : '';
+		const shouldSpeak = voiceTurnRef.current || readAloudEnabled;
+		voiceTurnRef.current = false;
+		if ( shouldSpeak && text ) {
+			readAloud( text );
+		} else {
+			setPhase( 'idle' );
+		}
+	}, [ messages, readAloud, readAloudEnabled, sending ] );
+
+	useEffect( () => {
+		if ( isTranscribing ) {
+			setPhase( 'transcribing' );
+			return;
+		}
+		if ( isListening ) {
+			setPhase( recognitionStatus );
+		}
+	}, [ isListening, isTranscribing, recognitionStatus ] );
+
+	useEffect( () => {
+		if ( recognitionError || speechError ) {
+			setPhase( 'error' );
+		}
+	}, [ recognitionError, speechError ] );
+
+	useEffect( () => {
+		cancelRecognition();
+		stopSpeaking();
+		voiceTurnRef.current = false;
+		previousSendingRef.current = sending;
+	}, [ currentSessionId ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect( () => {
+		const owner = ownerRef.current;
+		const stopForPageChange = () => {
+			cancelRecognition();
+			stopSpeaking();
+		};
+		const handleVisibility = () => {
+			if ( document.hidden ) {
+				stopForPageChange();
+			}
+		};
+		document.addEventListener( 'visibilitychange', handleVisibility );
+		window.addEventListener( 'pagehide', stopForPageChange );
+		return () => {
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibility
+			);
+			window.removeEventListener( 'pagehide', stopForPageChange );
+			stopForPageChange();
+			if ( playbackOwner === owner ) {
+				playbackOwner = null;
+			}
+		};
+	}, [ cancelRecognition, stopSpeaking ] );
+
+	return {
+		consumeTranscript,
+		error: recognitionError || speechError,
+		isListening,
+		isSpeaking,
+		isSupported: recognitionSupported && speechSupported,
+		pendingTranscript,
+		phase,
+		readAloud,
+		startListening,
+		statusLabel: STATUS_LABELS[ phase ] || STATUS_LABELS.idle,
+		stopListening,
+		stopSpeaking,
+		toggleListening,
+		toggleVoiceMode,
+		voiceModeEnabled,
+	};
+}

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -23,6 +23,7 @@ import {
 	isBrowserFallbackSupported,
 	isTTSSupported,
 } from '../components/use-text-to-speech';
+import { isSpeechRecognitionSupported } from '../components/use-speech-recognition';
 import { isSoundSupported } from '../utils/sound-manager';
 
 /**
@@ -125,6 +126,34 @@ export default function SettingsApp() {
 		speechCapabilities?.text_to_speech?.speed?.minimum ?? 0.5;
 	const maximumSpeechSpeed =
 		speechCapabilities?.text_to_speech?.speed?.maximum ?? 2;
+	const transcriptionCapabilities = speechCapabilities?.transcription;
+	const canUseVoiceConversation = Boolean(
+		isSpeechRecognitionSupported &&
+			speechCapabilities?.available &&
+			Array.isArray(
+				transcriptionCapabilities?.accepted_input_mime_types
+			) &&
+			transcriptionCapabilities.accepted_input_mime_types.includes(
+				'audio/wav'
+			) &&
+			Number( transcriptionCapabilities.max_bytes ) > 44 &&
+			Number( transcriptionCapabilities.max_duration_seconds ) > 0
+	);
+
+	useEffect( () => {
+		if (
+			voiceConversationEnabled &&
+			( ! isSpeechRecognitionSupported ||
+				( speechCapabilities && ! canUseVoiceConversation ) )
+		) {
+			setVoiceConversationEnabled( false );
+		}
+	}, [
+		canUseVoiceConversation,
+		setVoiceConversationEnabled,
+		speechCapabilities,
+		voiceConversationEnabled,
+	] );
 
 	const { createNotice, removeNotice } = useDispatch( 'core/notices' );
 	const snackbarNotices = useSelect( ( select ) =>
@@ -1552,33 +1581,43 @@ export default function SettingsApp() {
 															/>
 														</td>
 													</tr>
-													<tr>
-														<th scope="row">
-															{ __(
-																'Voice mode',
-																'superdav-ai-agent'
-															) }
-														</th>
-														<td>
-															<ToggleControl
-																label={ __(
-																	'Send each recorded turn and read the response aloud',
+													{ canUseVoiceConversation && (
+														<tr>
+															<th scope="row">
+																{ __(
+																	'Voice mode',
 																	'superdav-ai-agent'
 																) }
-																checked={
-																	voiceConversationEnabled
-																}
-																onChange={
-																	setVoiceConversationEnabled
-																}
-																help={ __(
-																	'Microphone access still starts only when you press the microphone button.',
-																	'superdav-ai-agent'
-																) }
-																__nextHasNoMarginBottom
-															/>
-														</td>
-													</tr>
+															</th>
+															<td>
+																<ToggleControl
+																	label={ __(
+																		'Send each recorded turn and read the response aloud',
+																		'superdav-ai-agent'
+																	) }
+																	checked={
+																		voiceConversationEnabled
+																	}
+																	onChange={ (
+																		enabled
+																	) => {
+																		if (
+																			canUseVoiceConversation
+																		) {
+																			setVoiceConversationEnabled(
+																				enabled
+																			);
+																		}
+																	} }
+																	help={ __(
+																		'Microphone access still starts only when you press the microphone button.',
+																		'superdav-ai-agent'
+																	) }
+																	__nextHasNoMarginBottom
+																/>
+															</td>
+														</tr>
+													) }
 													<tr>
 														<th scope="row">
 															{ __(

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -20,6 +20,7 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	useAvailableVoices,
 	useSpeechCapabilities,
+	isBrowserFallbackSupported,
 	isTTSSupported,
 } from '../components/use-text-to-speech';
 import { isSoundSupported } from '../utils/sound-manager';
@@ -1434,29 +1435,31 @@ export default function SettingsApp() {
 												'superdav-ai-agent'
 											) }
 										</h3>
-										{ ! isTTSSupported && (
-											<p className="description">
-												{ __(
-													'Text-to-speech is not supported in this browser.',
-													'sd-ai-agent'
-												) }
-											</p>
-										) }
-										{ isTTSSupported && (
+										{ ! isTTSSupported &&
+											! isBrowserFallbackSupported && (
+												<p className="description">
+													{ __(
+														'Text-to-speech is not supported in this browser.',
+														'superdav-ai-agent'
+													) }
+												</p>
+											) }
+										{ ( isTTSSupported ||
+											isBrowserFallbackSupported ) && (
 											<table className="form-table sdaa-form-table">
 												<tbody>
 													<tr>
 														<th scope="row">
 															{ __(
 																'Text-to-Speech',
-																'sd-ai-agent'
+																'superdav-ai-agent'
 															) }
 														</th>
 														<td>
 															<ToggleControl
 																label={ __(
 																	'Read AI responses aloud automatically',
-																	'sd-ai-agent'
+																	'superdav-ai-agent'
 																) }
 																checked={
 																	ttsEnabled
@@ -1478,7 +1481,7 @@ export default function SettingsApp() {
 																<label htmlFor="sd-tts-voice">
 																	{ __(
 																		'Voice',
-																		'sd-ai-agent'
+																		'superdav-ai-agent'
 																	) }
 																</label>
 															</th>
@@ -1510,7 +1513,7 @@ export default function SettingsApp() {
 																	}
 																	help={ __(
 																		'Select the voice used for speech synthesis.',
-																		'sd-ai-agent'
+																		'superdav-ai-agent'
 																	) }
 																	__nextHasNoMarginBottom
 																/>
@@ -1522,7 +1525,7 @@ export default function SettingsApp() {
 															<label htmlFor="sd-tts-rate">
 																{ __(
 																	'Speech Rate',
-																	'sd-ai-agent'
+																	'superdav-ai-agent'
 																) }
 															</label>
 														</th>
@@ -1544,7 +1547,7 @@ export default function SettingsApp() {
 																step={ 0.1 }
 																help={ __(
 																	'Speed of speech. 1 is normal speed.',
-																	'sd-ai-agent'
+																	'superdav-ai-agent'
 																) }
 															/>
 														</td>

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	useAvailableVoices,
+	useSpeechCapabilities,
 	isTTSSupported,
 } from '../components/use-text-to-speech';
 import { isSoundSupported } from '../utils/sound-manager';
@@ -77,7 +78,8 @@ export default function SettingsApp() {
 		setTtsEnabled,
 		setTtsVoiceURI,
 		setTtsRate,
-		setTtsPitch,
+		setVoiceConversationEnabled,
+		setSpeechFallbackEnabled,
 		setSoundSuccessEnabled,
 		setSoundErrorEnabled,
 		setSoundThinkingEnabled,
@@ -90,7 +92,8 @@ export default function SettingsApp() {
 		ttsEnabled,
 		ttsVoiceURI,
 		ttsRate,
-		ttsPitch,
+		voiceConversationEnabled,
+		speechFallbackEnabled,
 		soundSuccessEnabled,
 		soundErrorEnabled,
 		soundThinkingEnabled,
@@ -103,7 +106,10 @@ export default function SettingsApp() {
 			ttsEnabled: select( STORE_NAME ).isTtsEnabled(),
 			ttsVoiceURI: select( STORE_NAME ).getTtsVoiceURI(),
 			ttsRate: select( STORE_NAME ).getTtsRate(),
-			ttsPitch: select( STORE_NAME ).getTtsPitch(),
+			voiceConversationEnabled:
+				select( STORE_NAME ).isVoiceConversationEnabled(),
+			speechFallbackEnabled:
+				select( STORE_NAME ).isSpeechFallbackEnabled(),
 			soundSuccessEnabled: select( STORE_NAME ).isSoundSuccessEnabled(),
 			soundErrorEnabled: select( STORE_NAME ).isSoundErrorEnabled(),
 			soundThinkingEnabled: select( STORE_NAME ).isSoundThinkingEnabled(),
@@ -113,6 +119,11 @@ export default function SettingsApp() {
 
 	// Available TTS voices (loaded asynchronously in some browsers).
 	const ttsVoices = useAvailableVoices();
+	const speechCapabilities = useSpeechCapabilities();
+	const minimumSpeechSpeed =
+		speechCapabilities?.text_to_speech?.speed?.minimum ?? 0.5;
+	const maximumSpeechSpeed =
+		speechCapabilities?.text_to_speech?.speed?.maximum ?? 2;
 
 	const { createNotice, removeNotice } = useDispatch( 'core/notices' );
 	const snackbarNotices = useSelect( ( select ) =>
@@ -1419,8 +1430,8 @@ export default function SettingsApp() {
 
 										<h3 className="sdaa-settings-section-title">
 											{ __(
-												'Text-to-Speech',
-												'sd-ai-agent'
+												'Managed voice',
+												'superdav-ai-agent'
 											) }
 										</h3>
 										{ ! isTTSSupported && (
@@ -1480,8 +1491,8 @@ export default function SettingsApp() {
 																	options={ [
 																		{
 																			label: __(
-																				'(Browser default)',
-																				'sd-ai-agent'
+																				'(Service default)',
+																				'superdav-ai-agent'
 																			),
 																			value: '',
 																		},
@@ -1524,8 +1535,12 @@ export default function SettingsApp() {
 																onChange={
 																	setTtsRate
 																}
-																min={ 0.5 }
-																max={ 2 }
+																min={
+																	minimumSpeechSpeed
+																}
+																max={
+																	maximumSpeechSpeed
+																}
 																step={ 0.1 }
 																help={ __(
 																	'Speed of speech. 1 is normal speed.',
@@ -1536,29 +1551,51 @@ export default function SettingsApp() {
 													</tr>
 													<tr>
 														<th scope="row">
-															<label htmlFor="sd-tts-pitch">
-																{ __(
-																	'Pitch',
-																	'sd-ai-agent'
-																) }
-															</label>
+															{ __(
+																'Voice mode',
+																'superdav-ai-agent'
+															) }
 														</th>
 														<td>
-															<RangeControl
-																id="sd-tts-pitch"
-																value={
-																	ttsPitch
+															<ToggleControl
+																label={ __(
+																	'Send each recorded turn and read the response aloud',
+																	'superdav-ai-agent'
+																) }
+																checked={
+																	voiceConversationEnabled
 																}
 																onChange={
-																	setTtsPitch
+																	setVoiceConversationEnabled
 																}
-																min={ 0 }
-																max={ 2 }
-																step={ 0.1 }
 																help={ __(
-																	'Pitch of speech. 1 is normal pitch.',
-																	'sd-ai-agent'
+																	'Microphone access still starts only when you press the microphone button.',
+																	'superdav-ai-agent'
 																) }
+																__nextHasNoMarginBottom
+															/>
+														</td>
+													</tr>
+													<tr>
+														<th scope="row">
+															{ __(
+																'Fallback',
+																'superdav-ai-agent'
+															) }
+														</th>
+														<td>
+															<ToggleControl
+																label={ __(
+																	'Allow browser speech when the managed service is unavailable',
+																	'superdav-ai-agent'
+																) }
+																checked={
+																	speechFallbackEnabled
+																}
+																onChange={
+																	setSpeechFallbackEnabled
+																}
+																__nextHasNoMarginBottom
 															/>
 														</td>
 													</tr>

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -5,6 +5,27 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
+const CURRENT_USER_ID = globalThis.sdAiAgentData?.currentUserId || 0;
+const speechStorageKey = ( preference ) =>
+	`sdAiAgent:${ CURRENT_USER_ID }:speech:${ preference }`;
+
+const readSpeechPreference = ( preference, legacyKey, fallback = '' ) => {
+	const key = speechStorageKey( preference );
+	let value = localStorage.getItem( key );
+	if ( value === null && legacyKey ) {
+		value = localStorage.getItem( legacyKey );
+		if ( value !== null ) {
+			localStorage.setItem( key, value );
+			localStorage.removeItem( legacyKey );
+		}
+	}
+	return value ?? fallback;
+};
+
+const writeSpeechPreference = ( preference, value ) => {
+	localStorage.setItem( speechStorageKey( preference ), String( value ) );
+};
+
 export const initialState = {
 	floatingOpen: false,
 	floatingMinimized: false,
@@ -29,11 +50,18 @@ export const initialState = {
 	// appearing while the agent is actively exploring the site.
 	isBootstrapSession: false,
 
-	// Text-to-speech (t084) — persisted to localStorage.
-	ttsEnabled: localStorage.getItem( 'sdAiAgentTtsEnabled' ) === 'true',
-	ttsVoiceURI: localStorage.getItem( 'sdAiAgentTtsVoiceURI' ) || '',
-	ttsRate: parseFloat( localStorage.getItem( 'sdAiAgentTtsRate' ) || '1' ),
-	ttsPitch: parseFloat( localStorage.getItem( 'sdAiAgentTtsPitch' ) || '1' ),
+	// Managed speech preferences are isolated by authenticated WordPress user.
+	ttsEnabled:
+		readSpeechPreference( 'readAloud', 'sdAiAgentTtsEnabled' ) === 'true',
+	ttsVoiceURI: readSpeechPreference( 'voiceId', 'sdAiAgentTtsVoiceURI' ),
+	ttsRate: parseFloat(
+		readSpeechPreference( 'speed', 'sdAiAgentTtsRate', '1' )
+	),
+	ttsPitch: parseFloat(
+		readSpeechPreference( 'legacyPitch', 'sdAiAgentTtsPitch', '1' )
+	),
+	voiceConversationEnabled: readSpeechPreference( 'voiceMode' ) === 'true',
+	speechFallbackEnabled: readSpeechPreference( 'browserFallback' ) === 'true',
 
 	// Sound notifications — persisted to localStorage.
 	soundSuccessEnabled:
@@ -100,10 +128,7 @@ export const actions = {
 	 * @return {Object} Redux action.
 	 */
 	setTtsEnabled( enabled ) {
-		localStorage.setItem(
-			'sdAiAgentTtsEnabled',
-			enabled ? 'true' : 'false'
-		);
+		writeSpeechPreference( 'readAloud', enabled ? 'true' : 'false' );
 		return { type: 'SET_TTS_ENABLED', enabled };
 	},
 
@@ -114,7 +139,7 @@ export const actions = {
 	 * @return {Object} Redux action.
 	 */
 	setTtsVoiceURI( voiceURI ) {
-		localStorage.setItem( 'sdAiAgentTtsVoiceURI', voiceURI );
+		writeSpeechPreference( 'voiceId', voiceURI );
 		return { type: 'SET_TTS_VOICE_URI', voiceURI };
 	},
 
@@ -125,7 +150,7 @@ export const actions = {
 	 * @return {Object} Redux action.
 	 */
 	setTtsRate( rate ) {
-		localStorage.setItem( 'sdAiAgentTtsRate', String( rate ) );
+		writeSpeechPreference( 'speed', rate );
 		return { type: 'SET_TTS_RATE', rate };
 	},
 
@@ -136,8 +161,18 @@ export const actions = {
 	 * @return {Object} Redux action.
 	 */
 	setTtsPitch( pitch ) {
-		localStorage.setItem( 'sdAiAgentTtsPitch', String( pitch ) );
+		writeSpeechPreference( 'legacyPitch', pitch );
 		return { type: 'SET_TTS_PITCH', pitch };
+	},
+
+	setVoiceConversationEnabled( enabled ) {
+		writeSpeechPreference( 'voiceMode', enabled ? 'true' : 'false' );
+		return { type: 'SET_VOICE_CONVERSATION_ENABLED', enabled };
+	},
+
+	setSpeechFallbackEnabled( enabled ) {
+		writeSpeechPreference( 'browserFallback', enabled ? 'true' : 'false' );
+		return { type: 'SET_SPEECH_FALLBACK_ENABLED', enabled };
 	},
 
 	// ─── Sound notifications ──────────────────────────────────────
@@ -355,6 +390,14 @@ export const selectors = {
 		return state.ttsPitch;
 	},
 
+	isVoiceConversationEnabled( state ) {
+		return state.voiceConversationEnabled;
+	},
+
+	isSpeechFallbackEnabled( state ) {
+		return state.speechFallbackEnabled;
+	},
+
 	// Sound notifications
 
 	/**
@@ -409,6 +452,10 @@ export function reducer( state, action ) {
 			return { ...state, ttsRate: action.rate };
 		case 'SET_TTS_PITCH':
 			return { ...state, ttsPitch: action.pitch };
+		case 'SET_VOICE_CONVERSATION_ENABLED':
+			return { ...state, voiceConversationEnabled: action.enabled };
+		case 'SET_SPEECH_FALLBACK_ENABLED':
+			return { ...state, speechFallbackEnabled: action.enabled };
 		case 'SET_SOUND_SUCCESS_ENABLED':
 			return { ...state, soundSuccessEnabled: action.enabled };
 		case 'SET_SOUND_ERROR_ENABLED':

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -5,20 +5,13 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
-const CURRENT_USER_ID = globalThis.sdAiAgentData?.currentUserId || 0;
+const currentUserId = globalThis.sdAiAgentData?.currentUserId || 0;
 const speechStorageKey = ( preference ) =>
-	`sdAiAgent:${ CURRENT_USER_ID }:speech:${ preference }`;
+	`sdAiAgent:${ currentUserId }:speech:${ preference }`;
 
-const readSpeechPreference = ( preference, legacyKey, fallback = '' ) => {
+const readSpeechPreference = ( preference, fallback = '' ) => {
 	const key = speechStorageKey( preference );
-	let value = localStorage.getItem( key );
-	if ( value === null && legacyKey ) {
-		value = localStorage.getItem( legacyKey );
-		if ( value !== null ) {
-			localStorage.setItem( key, value );
-			localStorage.removeItem( legacyKey );
-		}
-	}
+	const value = localStorage.getItem( key );
 	return value ?? fallback;
 };
 
@@ -51,15 +44,10 @@ export const initialState = {
 	isBootstrapSession: false,
 
 	// Managed speech preferences are isolated by authenticated WordPress user.
-	ttsEnabled:
-		readSpeechPreference( 'readAloud', 'sdAiAgentTtsEnabled' ) === 'true',
-	ttsVoiceURI: readSpeechPreference( 'voiceId', 'sdAiAgentTtsVoiceURI' ),
-	ttsRate: parseFloat(
-		readSpeechPreference( 'speed', 'sdAiAgentTtsRate', '1' )
-	),
-	ttsPitch: parseFloat(
-		readSpeechPreference( 'legacyPitch', 'sdAiAgentTtsPitch', '1' )
-	),
+	ttsEnabled: readSpeechPreference( 'readAloud' ) === 'true',
+	ttsVoiceURI: readSpeechPreference( 'voiceId' ),
+	ttsRate: parseFloat( readSpeechPreference( 'speed', '1' ) ),
+	ttsPitch: parseFloat( readSpeechPreference( 'legacyPitch', '1' ) ),
 	voiceConversationEnabled: readSpeechPreference( 'voiceMode' ) === 'true',
 	speechFallbackEnabled: readSpeechPreference( 'browserFallback' ) === 'true',
 

--- a/src/utils/__tests__/speech.test.js
+++ b/src/utils/__tests__/speech.test.js
@@ -1,0 +1,112 @@
+/**
+ * Focused managed-speech utility tests.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+import {
+	base64ToBlob,
+	chunkSpeechText,
+	encodeAudioBufferToWav,
+	loadSpeechCapabilities,
+	recordingToWav,
+	resetSpeechCapabilities,
+	toSpeakableText,
+} from '../speech';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'managed speech utilities', () => {
+	afterEach( () => {
+		resetSpeechCapabilities();
+		jest.clearAllMocks();
+	} );
+
+	test( 'loads and caches the authenticated capability contract', async () => {
+		const capabilities = {
+			available: true,
+			text_to_speech: { voices: [] },
+			transcription: { accepted_input_mime_types: [ 'audio/wav' ] },
+		};
+		apiFetch.mockResolvedValue( capabilities );
+
+		await expect( loadSpeechCapabilities() ).resolves.toBe( capabilities );
+		await expect( loadSpeechCapabilities() ).resolves.toBe( capabilities );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/speech/capabilities',
+		} );
+	} );
+
+	test( 'rejects incomplete capability responses', async () => {
+		apiFetch.mockResolvedValue( { available: true } );
+
+		await expect( loadSpeechCapabilities() ).rejects.toThrow(
+			'Speech services are unavailable.'
+		);
+	} );
+
+	test( 'cleans Markdown and chunks Unicode text at service bounds', () => {
+		expect(
+			toSpeakableText(
+				'# Heading\nA [link](https://example.com). `code`\n```secret```'
+			)
+		).toBe( 'Heading A link. code' );
+
+		const chunks = chunkSpeechText( '😀😀. Next sentence.', 6 );
+		expect( chunks ).toEqual( [ '😀😀.', 'Next s', 'entenc', 'e.' ] );
+		expect(
+			chunks.every( ( chunk ) => Array.from( chunk ).length <= 6 )
+		).toBe( true );
+	} );
+
+	test( 'decodes inline audio into a temporary blob', () => {
+		const blob = base64ToBlob( 'UklGRg==', 'audio/wav' );
+
+		expect( blob.type ).toBe( 'audio/wav' );
+		expect( blob.size ).toBe( 4 );
+	} );
+
+	test( 'encodes mono 16-bit WAV and enforces the output byte limit', () => {
+		const audioBuffer = {
+			duration: 0.001,
+			getChannelData: () => new Float32Array( 48 ),
+			length: 48,
+			numberOfChannels: 1,
+			sampleRate: 48000,
+		};
+		const wav = encodeAudioBufferToWav( audioBuffer, 100 );
+
+		expect( wav.type ).toBe( 'audio/wav' );
+		expect( wav.size ).toBe( 76 );
+		expect( () => encodeAudioBufferToWav( audioBuffer, 75 ) ).toThrow(
+			'The recording reached the service limit.'
+		);
+	} );
+
+	test( 'normalizes recordings already labelled as WAV', async () => {
+		const audioBuffer = {
+			duration: 0.001,
+			getChannelData: () => new Float32Array( 48 ),
+			length: 48,
+			numberOfChannels: 1,
+			sampleRate: 48000,
+		};
+		const decodeAudioData = jest.fn().mockResolvedValue( audioBuffer );
+		const close = jest.fn().mockResolvedValue( undefined );
+		const OriginalAudioContext = global.AudioContext;
+		global.AudioContext = jest.fn( () => ( { close, decodeAudioData } ) );
+		const recording = {
+			arrayBuffer: jest.fn().mockResolvedValue( new ArrayBuffer( 4 ) ),
+			type: 'audio/wav',
+		};
+
+		const wav = await recordingToWav( recording, 100 );
+
+		expect( decodeAudioData ).toHaveBeenCalledTimes( 1 );
+		expect( wav.type ).toBe( 'audio/wav' );
+		expect( wav.size ).toBe( 76 );
+		expect( close ).toHaveBeenCalledTimes( 1 );
+		global.AudioContext = OriginalAudioContext;
+	} );
+} );

--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -1,0 +1,44 @@
+/**
+ * Convert Markdown response content into bounded speech-ready text.
+ *
+ * @param {string} text Raw response content.
+ * @return {string} Plain text without code payloads.
+ */
+export const toSpeakableText = ( text ) =>
+	text
+		.replace( /```[\s\S]*?```/g, '' )
+		.replace( /`([^`]+)`/g, '$1' )
+		.replace( /!\[[^\]]*\]\([^)]+\)/g, '' )
+		.replace( /\[([^\]]+)\]\([^)]+\)/g, '$1' )
+		.replace( /^[#>*\-+]\s*/gm, '' )
+		.replace( /\*{1,3}([^*]+)\*{1,3}/g, '$1' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+
+/**
+ * Split a string at sentence/word boundaries without splitting Unicode units.
+ *
+ * @param {string} text  Input text.
+ * @param {number} limit Maximum code points per chunk.
+ * @return {string[]} Bounded chunks.
+ */
+export const chunkSpeechText = ( text, limit ) => {
+	const characters = Array.from( text );
+	const chunks = [];
+	let remaining = characters;
+	while ( remaining.length ) {
+		let end = Math.min( limit, remaining.length );
+		if ( end < remaining.length ) {
+			const boundary = remaining
+				.slice( 0, end )
+				.join( '' )
+				.search( /[.!?]\s[^.!?]*$/ );
+			if ( boundary > 0 ) {
+				end = boundary + 2;
+			}
+		}
+		chunks.push( remaining.slice( 0, end ).join( '' ).trim() );
+		remaining = remaining.slice( end );
+	}
+	return chunks.filter( Boolean );
+};

--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -1,4 +1,45 @@
 /**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+let capabilitiesRequest = null;
+
+/**
+ * Load the authenticated speech contract once for the current page lifecycle.
+ *
+ * @param {Object}  options       Request options.
+ * @param {boolean} options.force Force a fresh capability request.
+ * @return {Promise<Object>} Validated speech capabilities.
+ */
+export const loadSpeechCapabilities = async ( { force = false } = {} ) => {
+	if ( force || ! capabilitiesRequest ) {
+		capabilitiesRequest = apiFetch( {
+			path: '/sd-ai-agent/v1/speech/capabilities',
+		} ).catch( ( error ) => {
+			capabilitiesRequest = null;
+			throw error;
+		} );
+	}
+
+	const capabilities = await capabilitiesRequest;
+	if (
+		! capabilities?.available ||
+		! capabilities.transcription ||
+		! capabilities.text_to_speech
+	) {
+		throw new Error( 'Speech services are unavailable.' );
+	}
+
+	return capabilities;
+};
+
+/** Clear page-local capability state, primarily after authentication changes. */
+export const resetSpeechCapabilities = () => {
+	capabilitiesRequest = null;
+};
+
+/**
  * Convert Markdown response content into bounded speech-ready text.
  *
  * @param {string} text Raw response content.
@@ -23,6 +64,9 @@ export const toSpeakableText = ( text ) =>
  * @return {string[]} Bounded chunks.
  */
 export const chunkSpeechText = ( text, limit ) => {
+	if ( ! Number.isFinite( limit ) || limit < 1 ) {
+		return [];
+	}
 	const characters = Array.from( text );
 	const chunks = [];
 	let remaining = characters;
@@ -41,4 +85,127 @@ export const chunkSpeechText = ( text, limit ) => {
 		remaining = remaining.slice( end );
 	}
 	return chunks.filter( Boolean );
+};
+
+/**
+ * Decode a managed inline-audio response without persisting it.
+ *
+ * @param {string} value    Base64-encoded audio.
+ * @param {string} mimeType Validated response MIME type.
+ * @return {Blob} Temporary audio payload.
+ */
+export const base64ToBlob = ( value, mimeType ) => {
+	if ( typeof value !== 'string' || ! value ) {
+		throw new Error( 'The speech service returned invalid audio.' );
+	}
+	const decoded = globalThis.atob( value );
+	const bytes = new Uint8Array( decoded.length );
+	for ( let index = 0; index < decoded.length; index++ ) {
+		bytes[ index ] = decoded.charCodeAt( index );
+	}
+	return new Blob( [ bytes ], { type: mimeType } );
+};
+
+const writeAscii = ( view, offset, value ) => {
+	for ( let index = 0; index < value.length; index++ ) {
+		view.setUint8( offset + index, value.charCodeAt( index ) );
+	}
+};
+
+/**
+ * Encode decoded browser audio as bounded 16 kHz mono PCM WAV.
+ *
+ * @param {AudioBuffer} audioBuffer Decoded browser audio.
+ * @param {number}      maxBytes    Maximum encoded size.
+ * @return {Blob} PCM WAV recording.
+ */
+export const encodeAudioBufferToWav = ( audioBuffer, maxBytes = 0 ) => {
+	const targetRate = Math.min( 16000, audioBuffer.sampleRate );
+	const frameCount = Math.max(
+		1,
+		Math.floor( audioBuffer.duration * targetRate )
+	);
+	const byteLength = 44 + frameCount * 2;
+	if ( maxBytes > 0 && byteLength > maxBytes ) {
+		throw new Error( 'The recording reached the service limit.' );
+	}
+
+	const output = new ArrayBuffer( byteLength );
+	const view = new DataView( output );
+	writeAscii( view, 0, 'RIFF' );
+	view.setUint32( 4, byteLength - 8, true );
+	writeAscii( view, 8, 'WAVE' );
+	writeAscii( view, 12, 'fmt ' );
+	view.setUint32( 16, 16, true );
+	view.setUint16( 20, 1, true );
+	view.setUint16( 22, 1, true );
+	view.setUint32( 24, targetRate, true );
+	view.setUint32( 28, targetRate * 2, true );
+	view.setUint16( 32, 2, true );
+	view.setUint16( 34, 16, true );
+	writeAscii( view, 36, 'data' );
+	view.setUint32( 40, frameCount * 2, true );
+
+	const channels = Array.from(
+		{ length: audioBuffer.numberOfChannels },
+		( _, channel ) => audioBuffer.getChannelData( channel )
+	);
+	const sourceRate = audioBuffer.sampleRate;
+	for ( let frame = 0; frame < frameCount; frame++ ) {
+		const sourcePosition = ( frame * sourceRate ) / targetRate;
+		const lower = Math.min(
+			audioBuffer.length - 1,
+			Math.floor( sourcePosition )
+		);
+		const upper = Math.min( audioBuffer.length - 1, lower + 1 );
+		const fraction = sourcePosition - lower;
+		let sample = 0;
+		channels.forEach( ( channel ) => {
+			sample +=
+				channel[ lower ] +
+				( channel[ upper ] - channel[ lower ] ) * fraction;
+		} );
+		sample = Math.max( -1, Math.min( 1, sample / channels.length ) );
+		view.setInt16(
+			44 + frame * 2,
+			sample < 0 ? sample * 0x8000 : sample * 0x7fff,
+			true
+		);
+	}
+
+	return new Blob( [ output ], { type: 'audio/wav' } );
+};
+
+/**
+ * Convert a browser MediaRecorder payload to the service's strict WAV format.
+ *
+ * @param {Blob}   recording Recording captured by MediaRecorder.
+ * @param {number} maxBytes  Maximum encoded request size.
+ * @return {Promise<Blob>} Strict PCM WAV payload.
+ */
+export const recordingToWav = async ( recording, maxBytes = 0 ) => {
+	if ( recording.type.toLowerCase().startsWith( 'audio/wav' ) ) {
+		if ( maxBytes > 0 && recording.size > maxBytes ) {
+			throw new Error( 'The recording reached the service limit.' );
+		}
+		return recording;
+	}
+
+	const AudioContextClass =
+		globalThis.AudioContext || globalThis.webkitAudioContext;
+	if ( ! AudioContextClass ) {
+		throw new Error(
+			'This browser cannot prepare audio for transcription.'
+		);
+	}
+
+	const context = new AudioContextClass();
+	try {
+		const decoded = await context.decodeAudioData(
+			await recording.arrayBuffer()
+		);
+		return encodeAudioBufferToWav( decoded, maxBytes );
+	} finally {
+		await context.close?.();
+	}
 };

--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -5,6 +5,15 @@ import apiFetch from '@wordpress/api-fetch';
 
 let capabilitiesRequest = null;
 
+export const isManagedAudioPlaybackSupported =
+	typeof Audio !== 'undefined' &&
+	typeof URL !== 'undefined' &&
+	typeof URL.createObjectURL === 'function';
+
+export const isBrowserSpeechSynthesisSupported =
+	typeof globalThis.speechSynthesis !== 'undefined' &&
+	typeof globalThis.SpeechSynthesisUtterance !== 'undefined';
+
 /**
  * Load the authenticated speech contract once for the current page lifecycle.
  *
@@ -73,12 +82,14 @@ export const chunkSpeechText = ( text, limit ) => {
 	while ( remaining.length ) {
 		let end = Math.min( limit, remaining.length );
 		if ( end < remaining.length ) {
-			const boundary = remaining
-				.slice( 0, end )
-				.join( '' )
-				.search( /[.!?]\s[^.!?]*$/ );
-			if ( boundary > 0 ) {
-				end = boundary + 2;
+			for ( let index = end - 2; index > 0; index-- ) {
+				if (
+					/[.!?]/.test( remaining[ index ] ) &&
+					/\s/.test( remaining[ index + 1 ] )
+				) {
+					end = index + 2;
+					break;
+				}
 			}
 		}
 		chunks.push( remaining.slice( 0, end ).join( '' ).trim() );
@@ -184,13 +195,6 @@ export const encodeAudioBufferToWav = ( audioBuffer, maxBytes = 0 ) => {
  * @return {Promise<Blob>} Strict PCM WAV payload.
  */
 export const recordingToWav = async ( recording, maxBytes = 0 ) => {
-	if ( recording.type.toLowerCase().startsWith( 'audio/wav' ) ) {
-		if ( maxBytes > 0 && recording.size > maxBytes ) {
-			throw new Error( 'The recording reached the service limit.' );
-		}
-		return recording;
-	}
-
 	const AudioContextClass =
 		globalThis.AudioContext || globalThis.webkitAudioContext;
 	if ( ! AudioContextClass ) {

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -615,12 +615,22 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		}
 		await expect( ttsBtn ).toHaveClass( /is-active/ );
 
-		await interceptStream( page );
+		await interceptStream( page, { processingPolls: 1 } );
+		const assistantBubbleLocator = page.locator( '.sdaa-cr-msg-assistant' );
+		const initialBubbleCount = await assistantBubbleLocator.count();
 		const input = page
 			.locator( '.sdaa-cr .sdaa-cr-input-textarea' )
 			.first();
 		await input.fill( 'Read this response' );
 		await input.press( 'Enter' );
+		await page.waitForFunction(
+			( count ) =>
+				document.querySelectorAll( '.sdaa-cr-msg-assistant' ).length >
+				count,
+			initialBubbleCount,
+			{ timeout: 30_000 }
+		);
+		await expect( input ).toBeEnabled( { timeout: 15_000 } );
 		await expect( ttsBtn ).toHaveAttribute(
 			'aria-label',
 			'Stop reading aloud',

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -178,7 +178,9 @@ async function injectTtsMock( page ) {
  */
 async function interceptStream( page, options = {} ) {
 	const { processingPolls = 0 } = options;
+	const syntheticJobId = 'e2e-tts-job-1';
 	let jobPollCount = 0;
+	let jobCompleted = false;
 
 	// Track the session_id created by the store before POST /run fires.
 	let capturedSessionId = null;
@@ -189,52 +191,61 @@ async function interceptStream( page, options = {} ) {
 	// Use a predicate function instead of a regex because wp-env uses plain
 	// permalinks (?rest_route=%2F...) where slashes are URL-encoded.
 	await page.route(
-		( url ) => decodeURIComponent( url.toString() ).includes( 'sd-ai-agent/v1/run' ),
+		( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				'sd-ai-agent/v1/run'
+			),
 		async ( route ) => {
-		try {
-			const postBody = route.request().postDataJSON();
-			if ( postBody?.session_id ) {
-				capturedSessionId = postBody.session_id;
+			try {
+				const postBody = route.request().postDataJSON();
+				if ( postBody?.session_id ) {
+					capturedSessionId = postBody.session_id;
+				}
+			} catch {
+				// Ignore parse failures — capturedSessionId stays null, triggering
+				// the local-append fallback path in pollJob.
 			}
-		} catch {
-			// Ignore parse failures — capturedSessionId stays null, triggering
-			// the local-append fallback path in pollJob.
+			await route.fulfill( {
+				status: 202,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					job_id: syntheticJobId,
+					status: 'processing',
+				} ),
+			} );
 		}
-		await route.fulfill( {
-			status: 202,
-			contentType: 'application/json',
-			body: JSON.stringify( {
-				job_id: 'e2e-tts-job-1',
-				status: 'processing',
-			} ),
-		} );
-	} );
+	);
 
-	// Intercept GET /job/:id — return 'processing' for the first
-	// `processingPolls` polls, then 'complete' with session_id so the store
-	// reloads the session (intercepted below to include the AI reply).
+	// Intercept only our synthetic job. A restored job from another test may be
+	// polling concurrently; hijacking it can inject this test's response before
+	// the new turn completes and make that response the speech baseline.
 	await page.route(
-		( url ) => decodeURIComponent( url.toString() ).includes( 'sd-ai-agent/v1/job/' ),
+		( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				`sd-ai-agent/v1/job/${ syntheticJobId }`
+			),
 		async ( route ) => {
-		jobPollCount += 1;
-		if ( jobPollCount <= processingPolls ) {
+			jobPollCount += 1;
+			if ( jobPollCount <= processingPolls ) {
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( { status: 'processing' } ),
+				} );
+				return;
+			}
+			jobCompleted = true;
 			await route.fulfill( {
 				status: 200,
 				contentType: 'application/json',
-				body: JSON.stringify( { status: 'processing' } ),
+				body: JSON.stringify( {
+					status: 'complete',
+					session_id: capturedSessionId,
+					reply: 'Hello from the AI!',
+				} ),
 			} );
-			return;
 		}
-		await route.fulfill( {
-			status: 200,
-			contentType: 'application/json',
-			body: JSON.stringify( {
-				status: 'complete',
-				session_id: capturedSessionId,
-				reply: 'Hello from the AI!',
-			} ),
-		} );
-	} );
+	);
 
 	// Intercept GET /sessions/:id — return a synthetic session that already
 	// contains both the user message and the AI reply. Without this, the store
@@ -252,7 +263,16 @@ async function interceptStream( page, options = {} ) {
 			);
 		},
 		async ( route ) => {
-			if ( capturedSessionId === null ) {
+			// Let the real session load proceed until the synthetic job reports
+			// complete. Returning the model reply during initial session creation
+			// makes it predate the completion transition that triggers read-aloud.
+			const decodedUrl = decodeURIComponent( route.request().url() );
+			const targetsCapturedSession =
+				capturedSessionId !== null &&
+				decodedUrl.includes(
+					`sd-ai-agent/v1/sessions/${ capturedSessionId }`
+				);
+			if ( ! targetsCapturedSession || ! jobCompleted ) {
 				await route.continue();
 				return;
 			}

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -1,13 +1,12 @@
 /**
- * E2E tests for the text-to-speech (TTS) feature.
+ * E2E tests for managed text-to-speech.
  *
  * Tests the TTS toggle button in the chat header, the TTS settings tab,
  * and the auto-speak behaviour on AI responses.
  *
- * The Web Speech API (SpeechSynthesis) is not available in headless Chromium,
- * so each test injects a minimal mock via page.addInitScript() before
- * navigating. The mock records calls to speak() and cancel() so tests can
- * assert on TTS behaviour without requiring real audio output.
+ * Tests intercept the authenticated capabilities and synthesis routes and use
+ * a controlled HTMLAudioElement fake. Browser Web Speech is not the primary
+ * path under test.
  *
  * Run: pnpm run test:e2e:playwright
  */
@@ -24,17 +23,7 @@ const {
 // ---------------------------------------------------------------------------
 
 /**
- * Inject a minimal SpeechSynthesis mock into the page before navigation.
- *
- * The mock exposes:
- *   - window.speechSynthesis.speak(utterance)  — records the utterance text
- *   - window.speechSynthesis.cancel()          — records a cancel call
- *   - window.__ttsMockCalls                    — array of recorded calls
- *   - window.__ttsMockVoices                   — voices returned by getVoices()
- *
- * Calling speak() fires utterance.onstart synchronously so the React hook
- * transitions isSpeaking → true immediately, then fires utterance.onend
- * after a short delay so the hook transitions back to false.
+ * Intercept managed speech routes and inject a controlled Audio fake.
  *
  * @param {import('@playwright/test').Page} page - Playwright page object.
  */
@@ -42,77 +31,37 @@ async function injectTtsMock( page ) {
 	await page.addInitScript( () => {
 		const calls = [];
 		window.__ttsMockCalls = calls;
+		window.Audio = class {
+			constructor( source ) {
+				this.source = source;
+				this.timer = null;
+			}
 
-		const mockVoice = {
-			name: 'Mock Voice',
-			lang: 'en-US',
-			voiceURI: 'mock-voice-uri',
-			localService: true,
-			default: true,
+			play() {
+				calls.push( { type: 'play', source: this.source } );
+				this.timer = setTimeout( () => this.onended?.(), 5000 );
+				return Promise.resolve();
+			}
+
+			pause() {
+				calls.push( { type: 'pause' } );
+				clearTimeout( this.timer );
+			}
+
+			removeAttribute() {}
 		};
-		window.__ttsMockVoices = [ mockVoice ];
 
-		const synthesis = {
-			speaking: false,
-			pending: false,
-			paused: false,
-			_voicesChangedListeners: [],
-			getVoices() {
-				return window.__ttsMockVoices;
-			},
-			speak( utterance ) {
-				calls.push( { type: 'speak', text: utterance.text } );
-				synthesis.speaking = true;
-				if ( typeof utterance.onstart === 'function' ) {
-					utterance.onstart();
-				}
-				// Simulate speech ending after a short delay.
-				setTimeout( () => {
-					synthesis.speaking = false;
-					if ( typeof utterance.onend === 'function' ) {
-						utterance.onend();
-					}
-				}, 50 );
-			},
-			cancel() {
-				calls.push( { type: 'cancel' } );
-				synthesis.speaking = false;
-			},
-			pause() {},
-			resume() {},
-			addEventListener( event, listener ) {
-				if ( event === 'voiceschanged' ) {
-					synthesis._voicesChangedListeners.push( listener );
-				}
-			},
-			removeEventListener( event, listener ) {
-				if ( event === 'voiceschanged' ) {
-					synthesis._voicesChangedListeners =
-						synthesis._voicesChangedListeners.filter(
-							( l ) => l !== listener
-						);
-				}
-			},
+		const revokeObjectUrl = URL.revokeObjectURL.bind( URL );
+		URL.revokeObjectURL = ( url ) => {
+			calls.push( { type: 'revoke', url } );
+			revokeObjectUrl( url );
 		};
 
 		Object.defineProperty( window, 'speechSynthesis', {
-			value: synthesis,
-			writable: false,
+			value: undefined,
+			writable: true,
 			configurable: true,
 		} );
-
-		// SpeechSynthesisUtterance mock.
-		window.SpeechSynthesisUtterance = class {
-			constructor( text ) {
-				this.text = text;
-				this.rate = 1;
-				this.pitch = 1;
-				this.voice = null;
-				this.onstart = null;
-				this.onend = null;
-				this.onerror = null;
-			}
-		};
 
 		// Stub the WP 7.0 abilities API so ensureClientAbilitiesRegistered()
 		// (called by the store's streamMessage thunk before POST /run) resolves
@@ -148,6 +97,59 @@ async function injectTtsMock( page ) {
 			enumerable: true,
 		} );
 	} );
+
+	await page.route(
+		( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				'sd-ai-agent/v1/speech/capabilities'
+			),
+		async ( route ) => {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					available: true,
+					locales: { initial_locale: 'en-US' },
+					text_to_speech: {
+						max_input_characters: 1200,
+						max_response_bytes: 1024,
+						output_formats: [ 'mp3' ],
+						output_mime_types: [ 'audio/mpeg' ],
+						speed: { minimum: 0.5, maximum: 2 },
+						voices: [
+							{
+								id: 'managed-voice',
+								name: 'Managed Voice',
+								locales: [ 'en-US' ],
+							},
+						],
+					},
+					transcription: {
+						accepted_input_mime_types: [ 'audio/wav' ],
+						max_bytes: 1024,
+						max_duration_seconds: 10,
+					},
+				} ),
+			} );
+		}
+	);
+	await page.route(
+		( url ) =>
+			decodeURIComponent( url.toString() ).includes(
+				'sd-ai-agent/v1/speech/synthesis'
+			),
+		async ( route ) => {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					audio: 'UklGRg==',
+					mime_type: 'audio/mpeg',
+					request_id: 'e2e-speech',
+				} ),
+			} );
+		}
+	);
 }
 
 /**
@@ -401,13 +403,11 @@ test.describe( 'TTS Settings Tab', () => {
 			.waitFor( { state: 'hidden', timeout: 15_000 } );
 	} );
 
-	test( 'Text-to-Speech settings are present in the General tab', async ( {
+	test( 'Managed voice settings are present in the General tab', async ( {
 		page,
 	} ) => {
-		// TTS settings are rendered under a "Text-to-Speech" section heading
-		// inside the General tab — there is no dedicated TTS tab.
 		const ttsHeading = page.getByRole( 'heading', {
-			name: /text-to-speech/i,
+			name: /managed voice/i,
 		} );
 		await expect( ttsHeading ).toBeVisible();
 	} );
@@ -461,7 +461,7 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		await goToAgentPage( page );
 	} );
 
-	test( 'speechSynthesis.speak is called when TTS is enabled and AI responds', async ( {
+	test( 'managed audio plays when read-aloud is enabled and AI responds', async ( {
 		page,
 	} ) => {
 		// Enable TTS via the header toggle. The admin page uses ChatRedesign
@@ -539,14 +539,14 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 					const calls = await page.evaluate(
 						() => window.__ttsMockCalls
 					);
-					return calls.filter( ( c ) => c.type === 'speak' ).length;
+					return calls.filter( ( c ) => c.type === 'play' ).length;
 				},
 				{ timeout: 20_000 }
 			)
 			.toBeGreaterThanOrEqual( 1 );
 	} );
 
-	test( 'speechSynthesis.speak is NOT called when TTS is disabled', async ( {
+	test( 'managed audio does not play when read-aloud is disabled', async ( {
 		page,
 	} ) => {
 		// Ensure TTS is disabled. Scope to the ChatRedesign root (.sdaa-cr).
@@ -595,14 +595,13 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 
 		// Verify that speak() was NOT called.
 		const calls = await page.evaluate( () => window.__ttsMockCalls );
-		const speakCalls = calls.filter( ( c ) => c.type === 'speak' );
+		const speakCalls = calls.filter( ( c ) => c.type === 'play' );
 		expect( speakCalls.length ).toBe( 0 );
 	} );
 
-	test( 'disabling TTS mid-conversation calls speechSynthesis.cancel', async ( {
+	test( 'the active read-aloud control stops audio and revokes its URL', async ( {
 		page,
 	} ) => {
-		// Enable TTS. Scope to the ChatRedesign root (.sdaa-cr).
 		const ttsBtn = page
 			.locator( '.sdaa-cr .sdaa-tts-btn' )
 			.first();
@@ -616,13 +615,21 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		}
 		await expect( ttsBtn ).toHaveClass( /is-active/ );
 
-		// Disable TTS — the store effect calls cancel() when ttsEnabled → false.
+		await interceptStream( page );
+		const input = page
+			.locator( '.sdaa-cr .sdaa-cr-input-textarea' )
+			.first();
+		await input.fill( 'Read this response' );
+		await input.press( 'Enter' );
+		await expect( ttsBtn ).toHaveAttribute(
+			'aria-label',
+			'Stop reading aloud',
+			{ timeout: 30_000 }
+		);
 		await ttsBtn.click();
-		await expect( ttsBtn ).not.toHaveClass( /is-active/ );
 
-		// Verify cancel() was called.
 		const calls = await page.evaluate( () => window.__ttsMockCalls );
-		const cancelCalls = calls.filter( ( c ) => c.type === 'cancel' );
-		expect( cancelCalls.length ).toBeGreaterThanOrEqual( 1 );
+		expect( calls.some( ( call ) => call.type === 'pause' ) ).toBe( true );
+		expect( calls.some( ( call ) => call.type === 'revoke' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## Summary

- Replace browser-primary speech with authenticated, capability-driven transcription and synthesis through the private `sd-ai-agent/v1/speech/*` gateway.
- Add bounded `MediaRecorder` capture, strict mono PCM WAV normalization, managed audio chunking/playback, cancellation, object URL cleanup, and explicit opt-in browser fallback.
- Add a shared turn coordinator for push-to-talk and voice mode across the main chat and floating widget, including response identity tracking, barge-in, session/page cleanup, and deterministic playback ownership.
- Scope speech preferences to the current WordPress user, expose managed voice/speed settings, preserve accessible status behavior, and document the interaction contract in `DESIGN.md`.
- Add focused recorder, speech utility, synthesis, coordinator, and managed Playwright coverage while keeping the widget panel within its entry budget.

## Security and lifecycle

- Browser clients never receive the site-scoped Superdav credential.
- Audio and text use authenticated private REST routes; captured audio is retained only for one transcription request, while accepted transcripts follow the normal chat-message lifecycle.
- Recording, transcription, synthesis, playback, media tracks, requests, and object URLs are stopped or released on cancellation, failure, session changes, page hiding, and unmount.
- Microphone capture starts only from a fresh user gesture and never restarts automatically after playback.
- Browser-native synthesis fallback remains disabled unless the current user explicitly enables it.

## Worker self-verification
- PHPUnit: Tests: 4343, Assertions: 19981, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Additional verification

- Focused Jest: the managed voice coordinator suite passed all 6 tests, including first-turn session creation.
- Full Jest: 61 suites and 595 tests passed; two existing baseline failures remain in `src/store/__tests__/index.test.js` (`getSessions` test double) and `src/components/chat-redesign/__tests__/customer-simple-mode.test.js` (`combineReducers` mock).
- Playwright trace analysis found that the test harness exposed the synthetic model reply before job completion and that first-turn session creation reset response tracking. The harness now isolates its synthetic job and delays the reply until completion; the coordinator preserves pending first-turn playback while still cancelling genuine session switches.

## Bundle budget rationale

Managed recording, WAV normalization, synthesis, playback, and turn coordination require 13.6 KiB minified and 1.6 KiB gzip above the previous aggregate deferred-JavaScript ratchet. The widget coordinator remains lazy-loaded and both entry budgets stay unchanged. The deferred ratchet increases only from 1700/525 KiB to 1720/528 KiB; the verified bundle measures 1713.6 KiB minified and 526.6 KiB gzip.

Resolves #2647

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 22h 14m and 4,576,378 tokens on this with the user in an interactive session. Overall, 15h 43m since this issue was created.
