### PR TITLE
GH#2645: Add managed text-to-speech AI Client model

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
@@ -65,6 +65,9 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 				: $item['id'];
 
 			$capabilities = self::supported_capabilities( $item );
+			if ( null === $capabilities ) {
+				continue;
+			}
 
 			$models[] = new ModelMetadata(
 				$item['id'],
@@ -85,11 +88,31 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 	 * @return list<SupportedOption>
 	 */
 	private static function supported_options( array $capabilities ): array {
+		if ( self::has_capability( $capabilities, CapabilityEnum::textToSpeechConversion() ) ) {
+			return self::text_to_speech_supported_options();
+		}
+
 		if ( self::has_capability( $capabilities, CapabilityEnum::imageGeneration() ) ) {
 			return self::image_supported_options();
 		}
 
 		return self::text_supported_options();
+	}
+
+	/**
+	 * Managed text-to-speech options matching the service capability contract.
+	 *
+	 * @return list<SupportedOption>
+	 */
+	private static function text_to_speech_supported_options(): array {
+		return array(
+			new SupportedOption( OptionEnum::inputModalities(), array( array( ModalityEnum::text() ) ) ),
+			new SupportedOption( OptionEnum::outputModalities(), array( array( ModalityEnum::audio() ) ) ),
+			new SupportedOption( OptionEnum::outputFileType(), array( FileTypeEnum::inline() ) ),
+			new SupportedOption( OptionEnum::outputMimeType(), array_keys( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT ) ),
+			new SupportedOption( OptionEnum::outputSpeechVoice(), SuperdavAiTextToSpeechConversionModel::SUPPORTED_VOICES ),
+			new SupportedOption( OptionEnum::customOptions() ),
+		);
 	}
 
 	/**
@@ -168,15 +191,17 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 	 * Parse provider-advertised capability flags into SDK capability enums.
 	 *
 	 * @param array<string, mixed> $item Model item from `/v1/models`.
-	 * @return list<CapabilityEnum>
+	 * @return list<CapabilityEnum>|null Known capabilities, or null for explicitly unsupported models.
 	 */
-	private static function supported_capabilities( array $item ): array {
-		$values = array();
+	private static function supported_capabilities( array $item ): ?array {
+		$values                    = array();
+		$has_explicit_capabilities = false;
 
 		foreach ( array( 'capabilities', 'supported_capabilities' ) as $key ) {
 			if ( ! isset( $item[ $key ] ) || ! is_array( $item[ $key ] ) ) {
 				continue;
 			}
+			$has_explicit_capabilities = true;
 			foreach ( $item[ $key ] as $capability_key => $capability_value ) {
 				if ( is_string( $capability_key ) && true === $capability_value ) {
 					$values[] = $capability_key;
@@ -189,12 +214,22 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 		}
 
 		foreach ( $item as $key => $value ) {
-			if ( is_string( $key ) && str_starts_with( $key, 'supports_' ) && true === $value ) {
-				$values[] = substr( $key, strlen( 'supports_' ) );
+			if ( ! is_string( $key ) || ! str_starts_with( $key, 'supports_' ) ) {
+				continue;
+			}
+
+			$capability = str_replace( '-', '_', strtolower( substr( $key, strlen( 'supports_' ) ) ) );
+			if ( 'tool_calling' === $capability ) {
+				continue;
+			}
+
+			$has_explicit_capabilities = true;
+			if ( true === $value ) {
+				$values[] = $capability;
 			}
 		}
 
-		if ( array() === $values ) {
+		if ( ! $has_explicit_capabilities ) {
 			return array( CapabilityEnum::textGeneration() );
 		}
 
@@ -206,6 +241,6 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 			}
 		}
 
-		return array() === $capabilities ? array( CapabilityEnum::textGeneration() ) : $capabilities;
+		return array() === $capabilities ? null : $capabilities;
 	}
 }

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -141,6 +141,10 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	 */
 	protected static function createModel( ModelMetadata $model_metadata, ProviderMetadata $provider_metadata ): ModelInterface {
 		foreach ( $model_metadata->getSupportedCapabilities() as $capability ) {
+			if ( $capability->equals( CapabilityEnum::textToSpeechConversion() ) ) {
+				return new SuperdavAiTextToSpeechConversionModel( $model_metadata, $provider_metadata );
+			}
+
 			if ( $capability->equals( CapabilityEnum::imageGeneration() ) ) {
 				return new SuperdavAiImageGenerationModel( $model_metadata, $provider_metadata );
 			}
@@ -216,7 +220,7 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 			ProviderTypeEnum::cloud(),
 			null,
 			RequestAuthenticationMethod::apiKey(),
-			'OpenAI-compatible AI service hosted for SD AI Agent.'
+			'OpenAI-compatible text, image, and speech synthesis service hosted for SD AI Agent.'
 		);
 	}
 

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextToSpeechConversionModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextToSpeechConversionModel.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Infrastructure\AiClient\Superdav;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\Http\Util\ResponseUtil;
+use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WordPress\AiClient\Results\DTO\Candidate;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Text-to-speech conversion model for the managed Superdav service.
+ */
+final class SuperdavAiTextToSpeechConversionModel extends AbstractApiBasedModel implements TextToSpeechConversionModelInterface {
+
+	public const DEFAULT_VOICE        = 'alloy';
+	public const DEFAULT_MIME_TYPE    = 'audio/mpeg';
+	public const MAX_INPUT_CHARACTERS = 4096;
+	public const MAX_RESPONSE_BYTES   = 20 * 1024 * 1024;
+	public const MIN_SPEED            = 0.25;
+	public const MAX_SPEED            = 4.0;
+
+	/** @var list<string> */
+	public const SUPPORTED_VOICES = array( self::DEFAULT_VOICE );
+
+	/** @var list<string> */
+	public const SUPPORTED_LANGUAGES = array( 'en-US' );
+
+	/** @var array<string, string> */
+	public const MIME_TYPE_TO_RESPONSE_FORMAT = array(
+		'audio/mpeg' => 'mp3',
+		'audio/ogg'  => 'opus',
+		'audio/aac'  => 'aac',
+		'audio/flac' => 'flac',
+		'audio/wav'  => 'wav',
+		'audio/l16'  => 'pcm',
+	);
+
+	/**
+	 * Convert text messages into one inline audio file.
+	 *
+	 * @param array<int, Message> $prompt Prompt messages.
+	 * @phpstan-param list<Message> $prompt
+	 * @return GenerativeAiResult Speech result.
+	 */
+	public function convertTextToSpeechResult( array $prompt ): GenerativeAiResult {
+		$mime_type = $this->prepare_output_mime_type();
+		$request   = $this->createRequest(
+			HttpMethodEnum::POST(),
+			'audio/speech',
+			array( 'Content-Type' => 'application/json' ),
+			$this->prepare_convert_params( $prompt, $mime_type )
+		);
+		$request   = $this->getRequestAuthentication()->authenticateRequest( $request );
+		$response  = $this->getHttpTransporter()->send( $request );
+
+		ResponseUtil::throwIfNotSuccessful( $response );
+
+		return $this->parse_response_to_generative_ai_result( $response, $mime_type );
+	}
+
+	/**
+	 * Create an authenticated-service request with SDK transport options.
+	 *
+	 * @param HttpMethodEnum                     $method  HTTP method.
+	 * @param string                             $path    Service path.
+	 * @param array<string, string|list<string>> $headers Request headers.
+	 * @param string|array<string, mixed>|null   $data    Request data.
+	 * @return Request
+	 */
+	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
+		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
+	}
+
+	/**
+	 * Prepare the allowlisted service request parameters.
+	 *
+	 * @param array<int, Message> $prompt    Prompt messages.
+	 * @param string              $mime_type Requested output MIME type.
+	 * @phpstan-param list<Message> $prompt
+	 * @return array<string, mixed>
+	 */
+	private function prepare_convert_params( array $prompt, string $mime_type ): array {
+		$instructions = $this->getConfig()->getSystemInstruction();
+		if ( is_string( $instructions ) && '' !== trim( $instructions ) ) {
+			throw new InvalidArgumentException( 'Instructions are not supported for managed text-to-speech conversion.' );
+		}
+
+		$params = array(
+			'model'           => $this->metadata()->getId(),
+			'input'           => $this->prepare_prompt_text( $prompt ),
+			'voice'           => $this->prepare_voice(),
+			'response_format' => self::MIME_TYPE_TO_RESPONSE_FORMAT[ $mime_type ],
+		);
+
+		foreach ( $this->getConfig()->getCustomOptions() as $key => $value ) {
+			if ( array_key_exists( $key, $params ) ) {
+				throw new InvalidArgumentException( sprintf( 'The custom option "%s" conflicts with a required text-to-speech parameter.', esc_html( (string) $key ) ) );
+			}
+
+			switch ( $key ) {
+				case 'speed':
+					if ( ( ! is_int( $value ) && ! is_float( $value ) ) || ! is_finite( (float) $value ) || $value < self::MIN_SPEED || $value > self::MAX_SPEED ) {
+						throw new InvalidArgumentException( 'The custom option "speed" must be a finite number from 0.25 through 4.' );
+					}
+					$params['speed'] = $value;
+					break;
+
+				case 'language':
+					if ( ! is_string( $value ) || ! in_array( $value, self::SUPPORTED_LANGUAGES, true ) ) {
+						throw new InvalidArgumentException( 'The custom option "language" is not supported by the managed text-to-speech service.' );
+					}
+					$params['language'] = $value;
+					break;
+
+				default:
+					throw new InvalidArgumentException( sprintf( 'The custom option "%s" is not supported for managed text-to-speech conversion.', esc_html( (string) $key ) ) );
+			}
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Join only text parts and enforce the service input ceiling.
+	 *
+	 * @param array<int, Message> $prompt Prompt messages.
+	 * @phpstan-param list<Message> $prompt
+	 * @return string
+	 */
+	private function prepare_prompt_text( array $prompt ): string {
+		$text_parts = array();
+		foreach ( $prompt as $message ) {
+			foreach ( $message->getParts() as $part ) {
+				if ( ! $part instanceof MessagePart || ! $part->getType()->isText() ) {
+					continue;
+				}
+				$text = $part->getText();
+				if ( is_string( $text ) ) {
+					$text_parts[] = $text;
+				}
+			}
+		}
+
+		$input = implode( "\n", $text_parts );
+		if ( '' === trim( $input ) ) {
+			throw new InvalidArgumentException( 'The prompt must contain text to convert to speech.' );
+		}
+
+		if ( self::unicode_length( $input ) > self::MAX_INPUT_CHARACTERS ) {
+			throw new InvalidArgumentException( 'The text-to-speech prompt exceeds the 4096-character service limit.' );
+		}
+
+		return $input;
+	}
+
+	/** Resolve and validate the configured voice. */
+	private function prepare_voice(): string {
+		$voice = $this->getConfig()->getOutputSpeechVoice();
+		$voice = null === $voice || '' === trim( $voice ) ? self::DEFAULT_VOICE : trim( $voice );
+
+		if ( ! in_array( $voice, self::SUPPORTED_VOICES, true ) ) {
+			throw new InvalidArgumentException( 'The configured output speech voice is not supported by the managed service.' );
+		}
+
+		return $voice;
+	}
+
+	/** Resolve and validate the configured output MIME type. */
+	private function prepare_output_mime_type(): string {
+		$mime_type = $this->getConfig()->getOutputMimeType();
+		$mime_type = null === $mime_type || '' === trim( $mime_type ) ? self::DEFAULT_MIME_TYPE : strtolower( trim( $mime_type ) );
+
+		if ( ! isset( self::MIME_TYPE_TO_RESPONSE_FORMAT[ $mime_type ] ) ) {
+			throw new InvalidArgumentException( 'The configured output MIME type is not supported for managed text-to-speech conversion.' );
+		}
+
+		return $mime_type;
+	}
+
+	/**
+	 * Convert validated binary audio into an inline SDK result.
+	 */
+	private function parse_response_to_generative_ai_result( Response $response, string $requested_mime_type ): GenerativeAiResult {
+		$body = $response->getBody();
+		if ( null === $body || '' === $body ) {
+			throw ResponseException::fromMissingData( 'SD AI', 'body' );
+		}
+		if ( strlen( $body ) > self::MAX_RESPONSE_BYTES ) {
+			throw ResponseException::fromInvalidData( 'SD AI', 'body', 'The audio response exceeds the supported size limit.' );
+		}
+
+		$content_type       = $response->getHeaderAsString( 'content-type' );
+		$response_mime_type = is_string( $content_type )
+			? strtolower( trim( explode( ';', $content_type, 2 )[0] ) )
+			: '';
+		if ( ! isset( self::MIME_TYPE_TO_RESPONSE_FORMAT[ $response_mime_type ] ) ) {
+			throw ResponseException::fromInvalidData( 'SD AI', 'content-type', 'The audio response MIME type is unsupported.' );
+		}
+		if ( $response_mime_type !== $requested_mime_type ) {
+			throw ResponseException::fromInvalidData( 'SD AI', 'content-type', 'The audio response MIME type does not match the requested format.' );
+		}
+
+		$file      = new File( base64_encode( $body ), $response_mime_type ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Binary audio must be represented as an inline SDK file.
+		$message   = new Message( MessageRoleEnum::model(), array( new MessagePart( $file ) ) );
+		$candidate = new Candidate( $message, FinishReasonEnum::stop() );
+
+		return new GenerativeAiResult(
+			'superdav-tts-' . wp_generate_uuid4(),
+			array( $candidate ),
+			new TokenUsage( 0, 0, 0 ),
+			$this->providerMetadata(),
+			$this->metadata()
+		);
+	}
+
+	/** Count Unicode code points without silently accepting invalid UTF-8. */
+	private static function unicode_length( string $value ): int {
+		if ( 1 !== preg_match( '//u', $value ) ) {
+			throw new InvalidArgumentException( 'The text-to-speech prompt must be valid UTF-8 text.' );
+		}
+
+		if ( function_exists( 'mb_strlen' ) ) {
+			return mb_strlen( $value, 'UTF-8' );
+		}
+
+		$count = preg_match_all( '/./us', $value );
+		if ( false === $count ) {
+			throw new InvalidArgumentException( 'The text-to-speech prompt must be valid UTF-8 text.' );
+		}
+
+		return $count;
+	}
+}

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -53,6 +53,9 @@ namespace WordPress\AiClient\Messages\Enums {
 		/** @return bool */
 		public function isUser(): bool { return false; }
 
+		/** @return self */
+		public static function model(): self { return new self(); }
+
 		/**
 		 * Allow casting to string.
 		 *
@@ -530,6 +533,18 @@ namespace WordPress\AiClient\Providers\Models\DTO {
 
 		/** @param array<string, mixed> $customOptions Custom provider options. */
 		public function setCustomOptions( array $customOptions ): void {}
+
+		/** @return string|null */
+		public function getOutputMimeType(): ?string { return null; }
+
+		/** @param string $outputMimeType Output MIME type. */
+		public function setOutputMimeType( string $outputMimeType ): void {}
+
+		/** @return string|null */
+		public function getOutputSpeechVoice(): ?string { return null; }
+
+		/** @param string $outputSpeechVoice Output speech voice. */
+		public function setOutputSpeechVoice( string $outputSpeechVoice ): void {}
 	}
 }
 
@@ -654,6 +669,17 @@ namespace WordPress\AiClient\Providers\Models\TextGeneration\Contracts {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts {
+
+	interface TextToSpeechConversionModelInterface {
+		/**
+		 * @param list<\WordPress\AiClient\Messages\DTO\Message> $prompt Prompt messages.
+		 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult
+		 */
+		public function convertTextToSpeechResult( array $prompt ): \WordPress\AiClient\Results\DTO\GenerativeAiResult;
+	}
+}
+
 namespace WordPress\AiClient\Providers\Http\Contracts {
 
 	interface HttpTransporterInterface {
@@ -717,6 +743,12 @@ namespace WordPress\AiClient\Providers\Http\DTO {
 	class Response {
 		/** @return array<string, mixed>|null */
 		public function getData(): ?array { return null; }
+
+		/** @return string|null */
+		public function getBody(): ?string { return null; }
+
+		/** @return string|null */
+		public function getHeaderAsString( string $name ): ?string { return null; }
 	}
 
 	class ApiKeyRequestAuthentication implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
@@ -750,6 +782,9 @@ namespace WordPress\AiClient\Providers\Http\Exception {
 	class ResponseException extends \Exception {
 		/** @return self */
 		public static function fromMissingData( string $apiName, string $fieldName ): self { return new self(); }
+
+		/** @return self */
+		public static function fromInvalidData( string $apiName, string $fieldName, string $message ): self { return new self(); }
 	}
 }
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiTextToSpeechConversionModelTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiTextToSpeechConversionModelTest.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Tests for the managed Superdav text-to-speech model.
+ *
+ * @package SdAiAgent\Tests\Infrastructure\AiClient\Superdav
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Infrastructure\AiClient\Superdav;
+
+use SdAiAgent\Core\ModelCapabilityRegistry;
+use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiImageGenerationModel;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextGenerationModel;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextToSpeechConversionModel;
+use WP_UnitTestCase;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+
+/**
+ * Covers metadata, request validation, forwarding, and binary result mapping.
+ */
+final class SuperdavAiTextToSpeechConversionModelTest extends WP_UnitTestCase {
+
+	/** Clean up provider runtime state. */
+	public function tear_down(): void {
+		ProviderTraceLogger::clear_runtime_context();
+		ModelCapabilityRegistry::forget( 'superdav-tts' );
+		ModelCapabilityRegistry::forget( 'superdav-transcribe' );
+		ModelCapabilityRegistry::forget( 'superdav-transcribe-flag' );
+		ModelCapabilityRegistry::forget( 'legacy-chat' );
+		$this->restore_provider_dependencies();
+		parent::tear_down();
+	}
+
+	/** TTS metadata is usable while unsupported-only transcription stays out of the SDK directory. */
+	public function test_metadata_exposes_tts_and_skips_unsupported_transcription(): void {
+		$models = $this->parse_models(
+			array(
+				array(
+					'id'           => 'superdav-tts',
+					'name'         => 'Superdav Speech',
+					'capabilities' => array(
+						'text_generation'          => false,
+						'text_to_speech_conversion' => true,
+						'audio_transcription'       => false,
+					),
+				),
+				array(
+					'id'           => 'superdav-transcribe',
+					'capabilities' => array( 'audio_transcription' => true ),
+				),
+				array(
+					'id'                           => 'superdav-transcribe-flag',
+					'supports_audio_transcription' => true,
+				),
+				array(
+					'id'   => 'legacy-chat',
+					'name' => 'Legacy Chat',
+				),
+			)
+		);
+
+		$this->assertSame( array( 'superdav-tts', 'legacy-chat' ), array_map( static fn( ModelMetadata $model ): string => $model->getId(), $models ) );
+		$tts = $models[0];
+		$this->assertContainsEquals( CapabilityEnum::textToSpeechConversion(), $tts->getSupportedCapabilities() );
+		$this->assertContainsEquals( CapabilityEnum::textGeneration(), $models[1]->getSupportedCapabilities() );
+
+		$options = array();
+		foreach ( $tts->getSupportedOptions() as $option ) {
+			$options[ $option->getName()->value ] = $option;
+		}
+		$this->assertTrue( $options['inputModalities']->isSupportedValue( array( ModalityEnum::text() ) ) );
+		$this->assertTrue( $options['outputModalities']->isSupportedValue( array( ModalityEnum::audio() ) ) );
+		$this->assertTrue( $options['outputFileType']->isSupportedValue( FileTypeEnum::inline() ) );
+		$this->assertSame( array_keys( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT ), $options['outputMimeType']->getSupportedValues() );
+		$this->assertSame( array( 'alloy' ), $options['outputSpeechVoice']->getSupportedValues() );
+		$this->assertArrayHasKey( 'customOptions', $options );
+	}
+
+	/** Provider dispatch selects the specialized TTS model without changing image or text dispatch. */
+	public function test_provider_dispatches_models_by_supported_capability(): void {
+		$method = new \ReflectionMethod( SuperdavAiProvider::class, 'createModel' );
+		$method->setAccessible( true );
+
+		$tts = $method->invoke( null, $this->tts_metadata(), SuperdavAiProvider::metadata() );
+		$image = $method->invoke( null, new ModelMetadata( 'image', 'Image', array( CapabilityEnum::imageGeneration() ), array() ), SuperdavAiProvider::metadata() );
+		$text = $method->invoke( null, new ModelMetadata( 'text', 'Text', array( CapabilityEnum::textGeneration() ), array() ), SuperdavAiProvider::metadata() );
+
+		$this->assertInstanceOf( SuperdavAiTextToSpeechConversionModel::class, $tts );
+		$this->assertInstanceOf( SuperdavAiImageGenerationModel::class, $image );
+		$this->assertInstanceOf( SuperdavAiTextGenerationModel::class, $text );
+	}
+
+	/** The SDK builder sends safe attributed options and returns one inline audio file. */
+	public function test_prompt_builder_converts_joined_text_to_inline_audio(): void {
+		list( $model, $transporter ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/wav' ), "\x00\x01\x02" ) );
+		$config = new ModelConfig();
+		$config->setOutputMimeType( 'audio/wav' );
+		$config->setOutputSpeechVoice( 'alloy' );
+		$config->setCustomOptions(
+			array(
+				'speed'    => 1.25,
+				'language' => 'en-US',
+			)
+		);
+		$model->setConfig( $config );
+		$model->setRequestOptions( RequestOptions::fromArray( array( RequestOptions::KEY_TIMEOUT => 123.0 ) ) );
+		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'superdav-tts', 42 );
+
+		$registry = new ProviderRegistry();
+		$registry->setHttpTransporter( $transporter );
+		$registry->registerProvider( SuperdavAiProvider::class );
+		$registry->setProviderRequestAuthentication( SuperdavAiProvider::class, new ApiKeyRequestAuthentication( 'test-token' ) );
+		$builder = new PromptBuilder(
+			$registry,
+			array(
+				new UserMessage( array( new MessagePart( 'First sentence.' ), new MessagePart( new File( 'AQ==', 'audio/mpeg' ) ) ) ),
+				new UserMessage( array( new MessagePart( 'Second sentence.' ) ) ),
+			)
+		);
+		$file = $builder->usingModel( $model )->convertTextToSpeech();
+
+		$this->assertNotNull( $transporter->request );
+		$this->assertSame( 'https://api.sdaiagent.com/v1/audio/speech', $transporter->request->getUri() );
+		$this->assertSame( 'application/json', $transporter->request->getHeaderAsString( 'content-type' ) );
+		$this->assertSame( 'Bearer test-token', $transporter->request->getHeaderAsString( 'authorization' ) );
+		$this->assertSame( '42', $transporter->request->getHeaderAsString( SuperdavAiProvider::SESSION_ATTRIBUTION_HEADER ) );
+		$this->assertSame( 123.0, $transporter->request->getOptions()?->getTimeout() );
+		$this->assertSame(
+			array(
+				'model'           => 'superdav-tts',
+				'input'           => "First sentence.\nSecond sentence.",
+				'voice'           => 'alloy',
+				'response_format' => 'wav',
+				'speed'           => 1.25,
+				'language'        => 'en-US',
+			),
+			$transporter->request->getData()
+		);
+		$this->assertTrue( $file->isInline() );
+		$this->assertSame( 'audio/wav', $file->getMimeType() );
+		$this->assertSame( base64_encode( "\x00\x01\x02" ), $file->getBase64Data() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Verifies the SDK's required inline binary representation.
+	}
+
+	/**
+	 * Every service-advertised MIME type maps to its exact request format.
+	 *
+	 * @dataProvider mime_type_provider
+	 */
+	public function test_maps_every_supported_mime_type( string $mime_type, string $response_format ): void {
+		list( $model, $transporter ) = $this->configured_model( new Response( 200, array( 'content-type' => $mime_type . '; charset=binary' ), 'audio' ) );
+		$config = new ModelConfig();
+		$config->setOutputMimeType( $mime_type );
+		$model->setConfig( $config );
+
+		$result = $model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+		$file   = $result->getCandidates()[0]->getMessage()->getParts()[0]->getFile();
+
+		$this->assertSame( $response_format, $transporter->request?->getData()['response_format'] ?? null );
+		$this->assertNotNull( $file );
+		$this->assertSame( $mime_type, $file->getMimeType() );
+		$this->assertStringStartsWith( 'superdav-tts-', $result->getId() );
+		$this->assertSame( 'stop', (string) $result->getCandidates()[0]->getFinishReason() );
+	}
+
+	/** @return array<string, array{0:string, 1:string}> */
+	public function mime_type_provider(): array {
+		return array(
+			'mp3'  => array( 'audio/mpeg', 'mp3' ),
+			'opus' => array( 'audio/ogg', 'opus' ),
+			'aac'  => array( 'audio/aac', 'aac' ),
+			'flac' => array( 'audio/flac', 'flac' ),
+			'wav'  => array( 'audio/wav', 'wav' ),
+			'pcm'  => array( 'audio/l16', 'pcm' ),
+		);
+	}
+
+	/** Defaults use the service's canonical voice and MP3 format. */
+	public function test_uses_service_defaults_when_voice_and_mime_are_unset(): void {
+		list( $model, $transporter ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+
+		$this->assertSame( 'alloy', $transporter->request?->getData()['voice'] ?? null );
+		$this->assertSame( 'mp3', $transporter->request?->getData()['response_format'] ?? null );
+	}
+
+	/**
+	 * Empty and oversized prompts fail before transport.
+	 *
+	 * @dataProvider invalid_prompt_provider
+	 */
+	public function test_rejects_invalid_text_prompt( string $text ): void {
+		list( $model ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+		$this->expectException( InvalidArgumentException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( $text ) ) ) ) );
+	}
+
+	/** @return array<string, array{0:string}> */
+	public function invalid_prompt_provider(): array {
+		return array(
+			'empty'         => array( '' ),
+			'whitespace'    => array( " \n\t " ),
+			'invalid UTF-8' => array( "\xC3\x28" ),
+			'over limit'    => array( str_repeat( 'é', SuperdavAiTextToSpeechConversionModel::MAX_INPUT_CHARACTERS + 1 ) ),
+		);
+	}
+
+	/** A prompt containing only non-text parts is rejected. */
+	public function test_rejects_non_text_only_prompt(): void {
+		list( $model ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+		$this->expectException( InvalidArgumentException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( new File( 'AQ==', 'audio/mpeg' ) ) ) ) ) );
+	}
+
+	/** Instructions are explicitly unsupported by the managed service contract. */
+	public function test_rejects_system_instruction(): void {
+		list( $model ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+		$config = new ModelConfig();
+		$config->setSystemInstruction( 'Speak softly.' );
+		$model->setConfig( $config );
+		$this->expectException( InvalidArgumentException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/**
+	 * Custom options are a strict allowlist with value validation.
+	 *
+	 * @param array<string, mixed> $custom_options Custom options.
+	 * @dataProvider invalid_custom_options_provider
+	 */
+	public function test_rejects_invalid_or_colliding_custom_options( array $custom_options ): void {
+		list( $model ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+		$config = new ModelConfig();
+		$config->setCustomOptions( $custom_options );
+		$model->setConfig( $config );
+		$this->expectException( InvalidArgumentException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/** @return array<string, array{0:array<string, mixed>}> */
+	public function invalid_custom_options_provider(): array {
+		return array(
+			'required collision'      => array( array( 'model' => 'other' ) ),
+			'unsupported instructions' => array( array( 'instructions' => 'Whisper.' ) ),
+			'unknown option'           => array( array( 'arbitrary' => true ) ),
+			'non-numeric speed'        => array( array( 'speed' => '1.0' ) ),
+			'out-of-range speed'       => array( array( 'speed' => 4.1 ) ),
+			'invalid language'         => array( array( 'language' => '../en' ) ),
+			'unsupported language'     => array( array( 'language' => 'fr-FR' ) ),
+		);
+	}
+
+	/** Unsupported configured voice and MIME values are rejected. */
+	public function test_rejects_unsupported_voice_and_mime(): void {
+		list( $model ) = $this->configured_model( new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'audio' ) );
+		$config = new ModelConfig();
+		$config->setOutputSpeechVoice( 'unknown' );
+		$model->setConfig( $config );
+
+		try {
+			$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+			$this->fail( 'An unsupported voice should fail.' );
+		} catch ( InvalidArgumentException $e ) {
+			$this->assertStringContainsString( 'voice', $e->getMessage() );
+		}
+
+		$config = new ModelConfig();
+		$config->setOutputMimeType( 'audio/webm' );
+		$model->setConfig( $config );
+		$this->expectException( InvalidArgumentException::class );
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/**
+	 * Malformed successful audio responses fail through the SDK response exception path.
+	 *
+	 * @dataProvider malformed_response_provider
+	 */
+	public function test_rejects_malformed_successful_response( ?string $content_type, ?string $body ): void {
+		$headers = null === $content_type ? array() : array( 'content-type' => $content_type );
+		list( $model ) = $this->configured_model( new Response( 200, $headers, $body ) );
+		$this->expectException( ResponseException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/** @return array<string, array{0:string|null, 1:string|null}> */
+	public function malformed_response_provider(): array {
+		return array(
+			'empty body'       => array( 'audio/mpeg', '' ),
+			'missing MIME'     => array( null, 'audio' ),
+			'unsupported MIME' => array( 'application/json', 'audio' ),
+			'mismatched MIME'  => array( 'audio/wav', 'audio' ),
+		);
+	}
+
+	/** Oversized binary responses fail before inline base64 expansion. */
+	public function test_rejects_oversized_audio_response(): void {
+		list( $model ) = $this->configured_model(
+			new Response( 200, array( 'content-type' => 'audio/mpeg' ), str_repeat( 'a', SuperdavAiTextToSpeechConversionModel::MAX_RESPONSE_BYTES + 1 ) )
+		);
+		$this->expectException( ResponseException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/** Non-success statuses use the SDK's normal scrubbed response exception mapping. */
+	public function test_maps_non_success_response_with_sdk_utility(): void {
+		list( $model ) = $this->configured_model( new Response( 400, array( 'content-type' => 'application/json' ), '{"error":{"message":"invalid"}}' ) );
+		$this->expectException( ClientException::class );
+
+		$model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( 'Hello.' ) ) ) ) );
+	}
+
+	/**
+	 * @return array{0:SuperdavAiTextToSpeechConversionModel, 1:RecordingAudioTransporter}
+	 */
+	private function configured_model( Response $response ): array {
+		$model       = new SuperdavAiTextToSpeechConversionModel( $this->tts_metadata(), SuperdavAiProvider::metadata() );
+		$transporter = new RecordingAudioTransporter( $response );
+		$model->setHttpTransporter( $transporter );
+		$model->setRequestAuthentication( new TestAudioRequestAuthentication() );
+
+		return array( $model, $transporter );
+	}
+
+	/** Return metadata through the same service-directory parser used in production. */
+	private function tts_metadata(): ModelMetadata {
+		$models = $this->parse_models(
+			array(
+				array(
+					'id'           => 'superdav-tts',
+					'name'         => 'Superdav Speech',
+					'capabilities' => array( 'text_to_speech_conversion' => true ),
+				),
+			)
+		);
+
+		return $models[0];
+	}
+
+	/**
+	 * @param list<array<string, mixed>> $items Service model entries.
+	 * @return list<ModelMetadata>
+	 */
+	private function parse_models( array $items ): array {
+		$directory = new SuperdavAiModelMetadataDirectory();
+		$method    = new \ReflectionMethod( $directory, 'parseResponseToModelMetadataList' );
+		$method->setAccessible( true );
+		$models = $method->invoke(
+			$directory,
+			new Response( 200, array( 'content-type' => 'application/json' ), (string) wp_json_encode( array( 'data' => $items ) ) )
+		);
+
+		return is_array( $models ) ? $models : array();
+	}
+
+	/** Restore singleton provider dependencies changed by the isolated builder registry. */
+	private function restore_provider_dependencies(): void {
+		$registry = AiClient::defaultRegistry();
+		try {
+			$transporter   = $registry->getHttpTransporter();
+			$authentication = $registry->getProviderRequestAuthentication( SuperdavAiProvider::class );
+		} catch ( \Throwable $e ) {
+			return;
+		}
+
+		$components = array( SuperdavAiProvider::availability(), SuperdavAiProvider::modelMetadataDirectory() );
+		foreach ( $components as $component ) {
+			if ( method_exists( $component, 'setHttpTransporter' ) ) {
+				$component->setHttpTransporter( $transporter );
+			}
+			if ( null !== $authentication && method_exists( $component, 'setRequestAuthentication' ) ) {
+				$component->setRequestAuthentication( $authentication );
+			}
+		}
+	}
+}
+
+/** Records the exact outgoing SDK request and returns a configured response. */
+final class RecordingAudioTransporter implements HttpTransporterInterface {
+	public ?Request $request = null;
+
+	public function __construct( private readonly Response $response ) {}
+
+	public function send( Request $request, ?RequestOptions $options = null ): Response {
+		$this->request = $request;
+		return $this->response;
+	}
+}
+
+/** Adds deterministic test authentication without exposing a real credential. */
+final class TestAudioRequestAuthentication implements RequestAuthenticationInterface {
+	public function authenticateRequest( Request $request ): Request {
+		return $request->withHeader( 'Authorization', 'Bearer test-token' );
+	}
+
+	public static function getJsonSchema(): array {
+		return array();
+	}
+}


### PR DESCRIPTION
## Summary

- add a first-class WordPress AI Client text-to-speech model for the managed `superdav-tts` service
- advertise TTS input, output, voice, MIME type, and custom options through model metadata and dispatch TTS capabilities through the provider
- validate prompt length and UTF-8, reject unsupported instructions and options, and enforce response MIME, body, and size limits
- preserve text fallback only for legacy metadata with no explicit capability declaration

## Security and compatibility

- authenticates service requests through the existing provider authentication path without exposing credentials
- returns validated binary speech as an inline AI Client file
- limits the language option to the service-advertised `en-US` contract and rejects unsupported models rather than treating them as text models
- updates WordPress 7 runtime stubs used by static analysis

## Worker self-verification
- PHPUnit: Tests: 4321, Assertions: 19854, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Focused TTS regression suite: 72 tests, 249 assertions.

Resolves #2645

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 16h 16m and 2,405,355 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text-to-speech support for Superdav AI models.
  * Convert text into audio using supported voices, languages, speeds, and output formats.
  * Generated audio is returned as an inline file result.
  * Superdav model metadata now exposes text-to-speech options when available.

* **Bug Fixes**
  * Models with explicitly empty capability lists are no longer incorrectly classified as text-generation models.
  * Added validation for unsupported voices, formats, prompts, speeds, and response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->