### PR TITLE
GH#2646: add authenticated speech gateway

### DIFF
--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -17,6 +17,7 @@ use SdAiAgent\Core\Features;
 use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\SpeechLocaleResolver;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -167,6 +168,7 @@ class FloatingWidget {
 		}
 
 		$onboarding_complete = OnboardingManager::is_complete();
+		$speech_locales      = ( new SpeechLocaleResolver() )->resolve();
 		$is_frontend         = 'frontend' === $context;
 		$force_onboarding    = false;
 		$viewed_post_id      = 0;
@@ -193,6 +195,7 @@ class FloatingWidget {
 			'sdAiAgentData',
 			[
 				'currentUserId'       => get_current_user_id(),
+				'speechLocales'       => $speech_locales,
 				'context'             => $context,
 				'isFrontend'          => $is_frontend,
 				'frontendOnboarding'  => ( $is_frontend && ( ! $onboarding_complete || $force_onboarding ) ) ? '1' : '',

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -15,6 +15,7 @@ namespace SdAiAgent\Admin;
 
 use SdAiAgent\Core\Features;
 use SdAiAgent\Core\InstructionsAddendum;
+use SdAiAgent\Core\SpeechLocaleResolver;
 use SdAiAgent\Core\WordPressPaths;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -308,7 +309,8 @@ class UnifiedAdminMenu {
 			wp_set_script_translations( 'sd-ai-agent-admin-page', 'superdav-ai-agent' );
 		}
 
-		$current_user = wp_get_current_user();
+		$current_user   = wp_get_current_user();
+		$speech_locales = ( new SpeechLocaleResolver() )->resolve();
 
 		wp_localize_script(
 			'sd-ai-agent-unified-admin',
@@ -319,6 +321,7 @@ class UnifiedAdminMenu {
 				'restNamespace'        => 'sd-ai-agent/v1',
 				'ajaxUrl'              => admin_url( 'admin-ajax.php' ),
 				'nonce'                => wp_create_nonce( 'wp_rest' ),
+				'speechLocales'        => $speech_locales,
 				'initialRoute'         => self::getCurrentRoute(),
 				'menuItems'            => self::getMenuItems(),
 				'connectorsUrl'        => self::getConnectorsUrl(),

--- a/includes/Core/ContextProviders.php
+++ b/includes/Core/ContextProviders.php
@@ -229,18 +229,25 @@ class ContextProviders {
 	 * @return array<string, mixed>
 	 */
 	public static function provide_user_context( array $page_context ): array {
-		$user = wp_get_current_user();
+		$user    = wp_get_current_user();
+		$locales = ( new SpeechLocaleResolver() )->resolve();
 
 		if ( ! $user || ! $user->exists() ) {
 			return [];
 		}
 
-		return [
+		$data = [
 			'Name'  => $user->display_name,
 			'Login' => $user->user_login,
 			'Email' => $user->user_email,
 			'Roles' => implode( ', ', $user->roles ),
 		];
+		if ( '' !== $locales['user_locale'] ) {
+			$data['Preferred User Language'] = $locales['user_locale'];
+			$data['Language Guidance']       = 'Treat the preferred language as an initial hint. Follow the language the user actually uses when it differs.';
+		}
+
+		return $data;
 	}
 
 	/**
@@ -252,7 +259,8 @@ class ContextProviders {
 	public static function provide_site_context( array $page_context ): array {
 		global $wp_version;
 
-		$theme = wp_get_theme();
+		$theme   = wp_get_theme();
+		$locales = ( new SpeechLocaleResolver() )->resolve();
 		// @phpstan-ignore-next-line
 		$plugin_count = count( get_option( 'active_plugins', [] ) );
 
@@ -263,6 +271,9 @@ class ContextProviders {
 			'Theme'          => $theme->get( 'Name' ) . ' ' . $theme->get( 'Version' ),
 			'Active Plugins' => (string) $plugin_count,
 		];
+		if ( '' !== $locales['site_locale'] ) {
+			$data['Site Language'] = $locales['site_locale'];
+		}
 
 		if ( is_multisite() ) {
 			$is_subdomain      = function_exists( 'is_subdomain_install' ) && is_subdomain_install();

--- a/includes/Core/SpeechLocaleResolver.php
+++ b/includes/Core/SpeechLocaleResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves WordPress speech-language hints without treating locale as authority.
+ */
+final class SpeechLocaleResolver {
+
+	/**
+	 * Resolve the current user's and site's locale hints.
+	 *
+	 * @return array{user_locale:string,site_locale:string,initial_locale:string}
+	 */
+	public function resolve(): array {
+		$user        = wp_get_current_user();
+		$user_value  = $user->exists() && is_string( $user->locale ) ? $user->locale : '';
+		$user_locale = $this->normalize_wordpress_locale( $user_value ) ?? '';
+		$site_locale = $this->normalize_wordpress_locale( get_locale() ) ?? '';
+
+		return array(
+			'user_locale'    => $user_locale,
+			'site_locale'    => $site_locale,
+			'initial_locale' => '' !== $user_locale ? $user_locale : $site_locale,
+		);
+	}
+
+	/**
+	 * Normalize a trusted WordPress locale to a conservative BCP-47 tag.
+	 */
+	public function normalize_wordpress_locale( string $locale ): ?string {
+		$locale = str_replace( array( '_', '@' ), '-', trim( $locale ) );
+
+		return $this->normalize_bcp47( $locale );
+	}
+
+	/**
+	 * Validate and normalize an untrusted client-supplied BCP-47 tag.
+	 */
+	public function normalize_client_locale( string $locale ): ?string {
+		$locale = trim( $locale );
+		if ( str_contains( $locale, '_' ) || str_contains( $locale, '@' ) ) {
+			return null;
+		}
+
+		return $this->normalize_bcp47( $locale );
+	}
+
+	/**
+	 * Apply conservative BCP-47 syntax and conventional casing.
+	 */
+	private function normalize_bcp47( string $locale ): ?string {
+		if ( '' === $locale || strlen( $locale ) > 63 ) {
+			return null;
+		}
+
+		$parts    = explode( '-', $locale );
+		$language = array_shift( $parts );
+		if ( ! is_string( $language ) || 1 !== preg_match( '/^[A-Za-z]{2,3}$/', $language ) ) {
+			return null;
+		}
+
+		$normalised = array( strtolower( $language ) );
+		if ( isset( $parts[0] ) && 1 === preg_match( '/^[A-Za-z]{4}$/', $parts[0] ) ) {
+			$normalised[] = ucfirst( strtolower( array_shift( $parts ) ) );
+		}
+
+		if ( isset( $parts[0] ) && 1 === preg_match( '/^(?:[A-Za-z]{2}|[0-9]{3})$/', $parts[0] ) ) {
+			$normalised[] = strtoupper( array_shift( $parts ) );
+		}
+
+		foreach ( $parts as $part ) {
+			if ( 1 !== preg_match( '/^(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3})$/', $part ) ) {
+				return null;
+			}
+
+			$normalised[] = strtolower( $part );
+		}
+
+		return implode( '-', $normalised );
+	}
+}

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -32,6 +32,7 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const DEFAULT_MODEL_ID           = 'superdav-chat-pro';
 	public const STRONG_MODEL_ID            = 'superdav-chat-strong';
 	public const IMAGE_MODEL_ID             = 'superdav-image';
+	public const TEXT_TO_SPEECH_MODEL_ID    = 'superdav-tts';
 	public const SESSION_ATTRIBUTION_HEADER = 'X-Superdav-Session-ID';
 	public const JOURNEY_ATTRIBUTION_HEADER = 'X-Superdav-Journey-ID';
 	public const IDEMPOTENCY_HEADER         = 'Idempotency-Key';

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClient.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClient.php
@@ -81,8 +81,12 @@ final class SuperdavAiTranscriptionClient {
 			return $this->error( 'sd_ai_agent_invalid_transcription_prompt', __( 'The transcription prompt is invalid.', 'superdav-ai-agent' ), 400 );
 		}
 
-		$boundary = 'sd-ai-agent-' . bin2hex( random_bytes( 16 ) );
-		$body     = $this->build_multipart_body( $audio, $language, $prompt, $boundary );
+		try {
+			$boundary = 'sd-ai-agent-' . bin2hex( random_bytes( 16 ) );
+		} catch ( \Random\RandomException ) {
+			return $this->unavailable_error();
+		}
+		$body = $this->build_multipart_body( $audio, $language, $prompt, $boundary );
 		if ( strlen( $body ) > self::MAX_REQUEST_BYTES ) {
 			return $this->error( 'sd_ai_agent_audio_too_large', __( 'The audio recording exceeds the supported size limit.', 'superdav-ai-agent' ), 413 );
 		}

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClient.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClient.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Infrastructure\AiClient\Superdav;
+
+use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\SpeechLocaleResolver;
+use SdAiAgent\Core\SuperdavSiteConnectionService;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Bounded explicit client for Superdav speech capabilities and transcription.
+ *
+ * WordPress AI Client does not yet expose a speech-to-text model interface, so
+ * this class reuses its provider registry, authentication, and HTTP transport
+ * without advertising transcription as an SDK model capability.
+ */
+final class SuperdavAiTranscriptionClient {
+
+	public const MODEL_ID              = 'superdav-transcribe';
+	public const INPUT_MIME_TYPE       = 'audio/wav';
+	public const MAX_REQUEST_BYTES     = 10 * 1024 * 1024;
+	public const MAX_AUDIO_BYTES       = self::MAX_REQUEST_BYTES - 4096;
+	public const MAX_DURATION_SECONDS  = 25 * 60;
+	public const MAX_PROMPT_CHARACTERS = 2048;
+	public const MAX_RESPONSE_BYTES    = 64 * 1024;
+	public const REQUEST_TIMEOUT       = 35.0;
+
+	private SuperdavSiteConnectionService $connection;
+	private SpeechLocaleResolver $locale_resolver;
+
+	public function __construct( ?SuperdavSiteConnectionService $connection = null, ?SpeechLocaleResolver $locale_resolver = null ) {
+		$this->connection      = $connection ?? new SuperdavSiteConnectionService();
+		$this->locale_resolver = $locale_resolver ?? new SpeechLocaleResolver();
+	}
+
+	/**
+	 * Fetch the current authenticated speech capability contract.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function get_capabilities(): array|WP_Error {
+		$response = $this->send_request(
+			HttpMethodEnum::GET(),
+			'audio/capabilities',
+			array( 'Accept' => 'application/json' )
+		);
+		if ( $response instanceof WP_Error ) {
+			return $response;
+		}
+
+		return $this->decode_json_response( $response );
+	}
+
+	/**
+	 * Forward one already-validated WAV buffer and return normalized text only.
+	 *
+	 * @return array{text:string,language?:string,duration_ms?:int,request_id:string}|WP_Error
+	 */
+	public function transcribe( string $audio, ?string $language = null, ?string $prompt = null ): array|WP_Error {
+		if ( '' === $audio || strlen( $audio ) > self::MAX_AUDIO_BYTES ) {
+			return $this->error( 'sd_ai_agent_audio_too_large', __( 'The audio recording exceeds the supported size limit.', 'superdav-ai-agent' ), 413 );
+		}
+		if ( null !== $language ) {
+			$language = $this->locale_resolver->normalize_client_locale( $language );
+			if ( null === $language ) {
+				return $this->error( 'sd_ai_agent_invalid_speech_language', __( 'The speech language is invalid.', 'superdav-ai-agent' ), 400 );
+			}
+		}
+		if ( null !== $prompt && ( '' === trim( $prompt ) || $this->unicode_length( $prompt ) > self::MAX_PROMPT_CHARACTERS ) ) {
+			return $this->error( 'sd_ai_agent_invalid_transcription_prompt', __( 'The transcription prompt is invalid.', 'superdav-ai-agent' ), 400 );
+		}
+
+		$boundary = 'sd-ai-agent-' . bin2hex( random_bytes( 16 ) );
+		$body     = $this->build_multipart_body( $audio, $language, $prompt, $boundary );
+		if ( strlen( $body ) > self::MAX_REQUEST_BYTES ) {
+			return $this->error( 'sd_ai_agent_audio_too_large', __( 'The audio recording exceeds the supported size limit.', 'superdav-ai-agent' ), 413 );
+		}
+
+		$response = $this->send_request(
+			HttpMethodEnum::POST(),
+			'audio/transcriptions',
+			array(
+				'Accept'          => 'application/json',
+				'Content-Type'    => 'multipart/form-data; boundary=' . $boundary,
+				'Idempotency-Key' => wp_generate_uuid4(),
+			),
+			$body
+		);
+		unset( $body, $audio );
+		if ( $response instanceof WP_Error ) {
+			return $response;
+		}
+
+		$data = $this->decode_json_response( $response );
+		if ( $data instanceof WP_Error ) {
+			return $data;
+		}
+
+		$text = $data['text'] ?? null;
+		if ( ! is_string( $text ) || '' === trim( $text ) || 1 !== preg_match( '//u', $text ) || $this->unicode_length( $text ) > 4096 ) {
+			return $this->malformed_response_error();
+		}
+
+		$result = array(
+			'text'       => $text,
+			'request_id' => $this->sanitize_request_id( $data['request_id'] ?? null ),
+		);
+		if ( array_key_exists( 'language', $data ) ) {
+			$response_language = is_string( $data['language'] ) ? $this->locale_resolver->normalize_client_locale( $data['language'] ) : null;
+			if ( null === $response_language ) {
+				return $this->malformed_response_error();
+			}
+			$result['language'] = $response_language;
+		}
+		if ( array_key_exists( 'duration', $data ) ) {
+			if ( ! is_numeric( $data['duration'] ) ) {
+				return $this->malformed_response_error();
+			}
+			$duration = (float) $data['duration'];
+			if ( ! is_finite( $duration ) || $duration < 0 || $duration > self::MAX_DURATION_SECONDS ) {
+				return $this->malformed_response_error();
+			}
+			$result['duration_ms'] = (int) ceil( $duration * 1000 );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Send an authenticated request through the WordPress AI Client transport.
+	 *
+	 * @param HttpMethodEnum                     $method  HTTP method.
+	 * @param string                             $path    Service-relative path.
+	 * @param array<string, string|list<string>> $headers Request headers.
+	 * @param string|null                        $body    Optional raw request body.
+	 */
+	private function send_request( HttpMethodEnum $method, string $path, array $headers, ?string $body = null ): Response|WP_Error {
+		try {
+			$status = $this->connection->ensure_site_token();
+			if ( $status instanceof WP_Error || empty( $status['configured'] ) ) {
+				return $this->unavailable_error();
+			}
+
+			ProviderCredentialLoader::load();
+			$registry = AiClient::defaultRegistry();
+			if ( ! $registry->hasProvider( SuperdavAiProvider::PROVIDER_ID ) ) {
+				return $this->unavailable_error();
+			}
+
+			$authentication = $registry->getProviderRequestAuthentication( SuperdavAiProvider::PROVIDER_ID );
+			if ( null === $authentication ) {
+				return $this->unavailable_error();
+			}
+
+			$options = new RequestOptions();
+			$options->setTimeout( self::REQUEST_TIMEOUT );
+			$options->setConnectTimeout( 5.0 );
+			$options->setMaxRedirects( 0 );
+			$request = new Request(
+				$method,
+				SuperdavAiProvider::configured_service_url( $path ),
+				SuperdavAiProvider::with_session_attribution( $headers ),
+				$body,
+				$options
+			);
+			$request = $authentication->authenticateRequest( $request );
+
+			$response = $registry->getHttpTransporter()->send( $request );
+		} catch ( \Throwable $e ) {
+			return $this->is_timeout_exception( $e )
+				? $this->error( 'sd_ai_agent_speech_timeout', __( 'The speech service timed out. Please try again.', 'superdav-ai-agent' ), 504 )
+				: $this->unavailable_error();
+		}
+
+		if ( ! $response->isSuccessful() ) {
+			return $this->map_response_error( $response->getStatusCode() );
+		}
+
+		return $response;
+	}
+
+	/** @return array<string, mixed>|WP_Error */
+	private function decode_json_response( Response $response ): array|WP_Error {
+		$body         = $response->getBody();
+		$content_type = $response->getHeaderAsString( 'content-type' );
+		$content_type = is_string( $content_type ) ? strtolower( trim( explode( ';', $content_type, 2 )[0] ) ) : '';
+		if ( 'application/json' !== $content_type || null === $body || '' === $body || strlen( $body ) > self::MAX_RESPONSE_BYTES ) {
+			return $this->malformed_response_error();
+		}
+
+		$data = $response->getData();
+		return is_array( $data ) ? $data : $this->malformed_response_error();
+	}
+
+	private function map_response_error( int $status ): WP_Error {
+		if ( in_array( $status, array( 408, 504 ), true ) ) {
+			return $this->error( 'sd_ai_agent_speech_timeout', __( 'The speech service timed out. Please try again.', 'superdav-ai-agent' ), 504 );
+		}
+		if ( 429 === $status ) {
+			return $this->error( 'sd_ai_agent_speech_limit_exceeded', __( 'The speech service limit was reached. Please try again later.', 'superdav-ai-agent' ), 429 );
+		}
+
+		return $this->unavailable_error();
+	}
+
+	private function unavailable_error(): WP_Error {
+		return $this->error( 'sd_ai_agent_speech_unavailable', __( 'The speech service is temporarily unavailable.', 'superdav-ai-agent' ), 503 );
+	}
+
+	private function malformed_response_error(): WP_Error {
+		return $this->error( 'sd_ai_agent_speech_malformed_response', __( 'The speech service returned an invalid response.', 'superdav-ai-agent' ), 502 );
+	}
+
+	private function error( string $code, string $message, int $status ): WP_Error {
+		return new WP_Error( $code, $message, array( 'status' => $status ) );
+	}
+
+	private function sanitize_request_id( mixed $request_id ): string {
+		return is_string( $request_id ) && 1 === preg_match( '/^[A-Za-z0-9._:-]{1,128}$/', $request_id )
+			? $request_id
+			: 'speech-' . wp_generate_uuid4();
+	}
+
+	/** Detect transport timeout failures without exposing exception details. */
+	private function is_timeout_exception( \Throwable $exception ): bool {
+		$depth = 0;
+		do {
+			$message = strtolower( $exception->getMessage() );
+			if ( str_contains( $message, 'timed out' ) || str_contains( $message, 'timeout' ) || str_contains( $message, 'time-out' ) ) {
+				return true;
+			}
+
+			$exception = $exception->getPrevious();
+			++$depth;
+		} while ( $exception instanceof \Throwable && $depth < 5 );
+
+		return false;
+	}
+
+	private function build_multipart_body( string $audio, ?string $language, ?string $prompt, string $boundary ): string {
+		$fields = array(
+			'model'           => self::MODEL_ID,
+			'response_format' => 'json',
+		);
+		if ( null !== $language && '' !== $language ) {
+			$fields['language'] = $language;
+		}
+		if ( null !== $prompt && '' !== $prompt ) {
+			$fields['prompt'] = $prompt;
+		}
+
+		$body = '';
+		foreach ( $fields as $name => $value ) {
+			$body .= '--' . $boundary . "\r\n";
+			$body .= 'Content-Disposition: form-data; name="' . $name . '"' . "\r\n\r\n";
+			$body .= $value . "\r\n";
+		}
+		$body .= '--' . $boundary . "\r\n";
+		$body .= 'Content-Disposition: form-data; name="file"; filename="audio.wav"' . "\r\n";
+		$body .= 'Content-Type: ' . self::INPUT_MIME_TYPE . "\r\n\r\n";
+		$body .= $audio . "\r\n";
+		$body .= '--' . $boundary . '--' . "\r\n";
+
+		return $body;
+	}
+
+	private function unicode_length( string $value ): int {
+		if ( 1 !== preg_match( '//u', $value ) ) {
+			return PHP_INT_MAX;
+		}
+
+		return function_exists( 'mb_strlen' ) ? mb_strlen( $value, 'UTF-8' ) : (int) preg_match_all( '/./us', $value );
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -71,6 +71,7 @@ use SdAiAgent\REST\RestController;
 use SdAiAgent\REST\SessionController;
 use SdAiAgent\REST\SettingsController;
 use SdAiAgent\REST\SkillController;
+use SdAiAgent\REST\SpeechController;
 use SdAiAgent\REST\ToolController;
 use SdAiAgent\REST\TraceController;
 use SdAiAgent\REST\WebhookController;
@@ -137,6 +138,7 @@ use XWP\DI\Decorators\Module;
 		KnowledgeController::class,
 		SessionController::class,
 		SettingsController::class,
+		SpeechController::class,
 		ConnectorsController::class,
 		CustomerConversationController::class,
 		WebhookController::class,

--- a/includes/REST/SpeechController.php
+++ b/includes/REST/SpeechController.php
@@ -1,0 +1,726 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\REST;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\SpeechLocaleResolver;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextToSpeechConversionModel;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTranscriptionClient;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\ApiBasedImplementation\Contracts\ApiBasedModelInterface;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\TextToSpeechConversion\Contracts\TextToSpeechConversionModelInterface;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Authenticated WordPress boundary for managed speech operations.
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'speech',
+	container: 'sd-ai-agent',
+)]
+final class SpeechController extends XWP_REST_Controller {
+
+	use PermissionTrait;
+
+	public const UPLOAD_FIELD                   = 'audio';
+	public const MAX_SYNTHESIS_CHARACTERS       = 2000;
+	public const MAX_SYNTHESIS_RESPONSE_BYTES   = 10 * 1024 * 1024;
+	private const MAX_CAPABILITY_RESPONSE_ITEMS = 20;
+
+	private SuperdavAiTranscriptionClient $speech_client;
+	private SpeechLocaleResolver $locale_resolver;
+	private \Closure $upload_provenance_check;
+
+	public function __construct(
+		?SuperdavAiTranscriptionClient $speech_client = null,
+		?SpeechLocaleResolver $locale_resolver = null,
+		?\Closure $upload_provenance_check = null
+	) {
+		$this->speech_client           = $speech_client ?? new SuperdavAiTranscriptionClient();
+		$this->locale_resolver         = $locale_resolver ?? new SpeechLocaleResolver();
+		$this->upload_provenance_check = $upload_provenance_check ?? static fn( string $path ): bool => is_uploaded_file( $path );
+	}
+
+	/** Return the current safe service capability surface. */
+	#[REST_Route(
+		route: 'capabilities',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_chat_permission',
+	)]
+	public function handle_capabilities( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		unset( $request );
+		$capabilities = $this->get_sanitized_capabilities();
+		if ( $capabilities instanceof WP_Error ) {
+			return $capabilities;
+		}
+
+		return new WP_REST_Response( $capabilities, 200 );
+	}
+
+	/** Transcribe one validated temporary WAV upload. */
+	#[REST_Route(
+		route: 'transcriptions',
+		methods: WP_REST_Server::CREATABLE,
+		guard: 'check_chat_permission',
+	)]
+	public function handle_transcription( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$temporary_path = '';
+		try {
+			$files = $request->get_file_params();
+			if ( 1 !== count( $files ) || ! isset( $files[ self::UPLOAD_FIELD ] ) || ! is_array( $files[ self::UPLOAD_FIELD ] ) ) {
+				return $this->invalid_audio_error();
+			}
+
+			/** @var array<string, mixed> $upload */
+			$upload = $files[ self::UPLOAD_FIELD ];
+			if ( UPLOAD_ERR_OK !== ( $upload['error'] ?? null )
+				|| ! is_string( $upload['tmp_name'] ?? null )
+				|| ! is_string( $upload['name'] ?? null )
+				|| ! is_string( $upload['type'] ?? null )
+			) {
+				return $this->invalid_audio_error();
+			}
+
+			$temporary_path = $upload['tmp_name'];
+			if ( '' === $temporary_path || ! ( $this->upload_provenance_check )( $temporary_path ) || ! is_file( $temporary_path ) ) {
+				$temporary_path = '';
+				return $this->invalid_audio_error();
+			}
+
+			$fields = $request->get_body_params();
+			if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'model', 'language', 'prompt', 'session_id' ) ) ) {
+				return $this->invalid_audio_error();
+			}
+
+			if ( isset( $fields['model'] ) && ! is_string( $fields['model'] ) ) {
+				return $this->invalid_audio_error();
+			}
+			$model = isset( $fields['model'] ) ? trim( $fields['model'] ) : '';
+			if ( '' !== $model && SuperdavAiTranscriptionClient::MODEL_ID !== $model ) {
+				return $this->unsupported_error();
+			}
+
+			$language = $this->optional_client_locale( $fields['language'] ?? null );
+			if ( $language instanceof WP_Error ) {
+				return $language;
+			}
+
+			$prompt = $this->optional_plain_text( $fields['prompt'] ?? null, SuperdavAiTranscriptionClient::MAX_PROMPT_CHARACTERS );
+			if ( $prompt instanceof WP_Error ) {
+				return $prompt;
+			}
+
+			if ( ! $this->is_safe_upload_filename( $upload['name'] ) || SuperdavAiTranscriptionClient::INPUT_MIME_TYPE !== strtolower( trim( $upload['type'] ) ) ) {
+				return $this->invalid_audio_error();
+			}
+
+			$file_size = filesize( $temporary_path );
+			if ( false === $file_size || $file_size <= 0 ) {
+				return $this->invalid_audio_error();
+			}
+			if ( $file_size > SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES ) {
+				return $this->audio_too_large_error();
+			}
+
+			$detected_mime = $this->detect_mime_type( $temporary_path );
+			if ( ! in_array( $detected_mime, array( 'audio/wav', 'audio/x-wav', 'audio/wave', 'audio/vnd.wave' ), true ) ) {
+				return $this->invalid_audio_error();
+			}
+
+			$audio = file_get_contents( $temporary_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads one provenance-checked bounded PHP upload.
+			if ( false === $audio || strlen( $audio ) !== $file_size ) {
+				return $this->invalid_audio_error();
+			}
+
+			$duration = $this->wav_duration_seconds( $audio );
+			if ( null === $duration ) {
+				return $this->invalid_audio_error();
+			}
+			if ( $duration > SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS ) {
+				return $this->audio_too_long_error();
+			}
+
+			$session_id = $this->optional_session_id( $fields['session_id'] ?? null );
+			if ( $session_id instanceof WP_Error ) {
+				return $session_id;
+			}
+
+			$capabilities = $this->get_sanitized_capabilities();
+			if ( $capabilities instanceof WP_Error ) {
+				return $capabilities;
+			}
+			if ( $file_size > $capabilities['transcription']['max_bytes'] ) {
+				return $this->audio_too_large_error();
+			}
+			if ( $duration > $capabilities['transcription']['max_duration_seconds'] ) {
+				return $this->audio_too_long_error();
+			}
+
+			ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, SuperdavAiTranscriptionClient::MODEL_ID, $session_id );
+			try {
+				$result = $this->speech_client->transcribe( $audio, $language, $prompt );
+			} finally {
+				ProviderTraceLogger::clear_runtime_context();
+				unset( $audio );
+			}
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+
+			return new WP_REST_Response( $result, 200 );
+		} finally {
+			if ( '' !== $temporary_path && is_file( $temporary_path ) ) {
+				wp_delete_file( $temporary_path );
+			}
+		}
+	}
+
+	/** Convert one bounded plain-text turn through the bundled AI Client model. */
+	#[REST_Route(
+		route: 'synthesis',
+		methods: WP_REST_Server::CREATABLE,
+		guard: 'check_chat_permission',
+	)]
+	public function handle_synthesis( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$fields = $request->get_json_params();
+		if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'text', 'voice', 'language', 'format', 'mime_type', 'speed', 'session_id' ) ) ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$text = $this->required_speakable_text( $fields['text'] ?? null );
+		if ( $text instanceof WP_Error ) {
+			return $text;
+		}
+
+		if ( isset( $fields['voice'] ) && ! is_string( $fields['voice'] ) ) {
+			return $this->invalid_synthesis_error();
+		}
+		$voice = isset( $fields['voice'] ) ? trim( $fields['voice'] ) : SuperdavAiTextToSpeechConversionModel::DEFAULT_VOICE;
+		if ( ! in_array( $voice, SuperdavAiTextToSpeechConversionModel::SUPPORTED_VOICES, true ) ) {
+			return $this->unsupported_error();
+		}
+
+		$language = $this->optional_client_locale( $fields['language'] ?? null );
+		if ( $language instanceof WP_Error ) {
+			return $language;
+		}
+		if ( null !== $language && ! in_array( $language, SuperdavAiTextToSpeechConversionModel::SUPPORTED_LANGUAGES, true ) ) {
+			return $this->unsupported_error();
+		}
+
+		if ( ( isset( $fields['format'] ) && ! is_string( $fields['format'] ) )
+			|| ( isset( $fields['mime_type'] ) && ! is_string( $fields['mime_type'] ) )
+		) {
+			return $this->invalid_synthesis_error();
+		}
+		$format = isset( $fields['format'] ) ? strtolower( trim( $fields['format'] ) ) : '';
+		$mime   = isset( $fields['mime_type'] ) ? strtolower( trim( $fields['mime_type'] ) ) : '';
+		if ( '' !== $format && '' !== $mime && ( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT[ $mime ] ?? '' ) !== $format ) {
+			return $this->unsupported_error();
+		}
+		if ( '' === $mime ) {
+			$format = '' !== $format ? $format : 'mp3';
+			$mime   = array_search( $format, SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT, true );
+			$mime   = is_string( $mime ) ? $mime : '';
+		}
+		if ( ! isset( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT[ $mime ] ) ) {
+			return $this->unsupported_error();
+		}
+
+		$speed = $fields['speed'] ?? 1.0;
+		if ( ( ! is_int( $speed ) && ! is_float( $speed ) ) || ! is_finite( (float) $speed ) || $speed < SuperdavAiTextToSpeechConversionModel::MIN_SPEED || $speed > SuperdavAiTextToSpeechConversionModel::MAX_SPEED ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$session_id = $this->optional_session_id( $fields['session_id'] ?? null );
+		if ( $session_id instanceof WP_Error ) {
+			return $session_id;
+		}
+
+		$capabilities = $this->get_sanitized_capabilities();
+		if ( $capabilities instanceof WP_Error ) {
+			return $capabilities;
+		}
+		$tts       = $capabilities['text_to_speech'];
+		$voice_ids = array_column( $tts['voices'], 'id' );
+		if ( $this->unicode_length( $text ) > $tts['max_input_characters']
+			|| ! in_array( $voice, $voice_ids, true )
+			|| ( null !== $language && ! $this->voice_supports_locale( $tts['voices'], $voice, $language ) )
+			|| ! in_array( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT[ $mime ], $tts['output_formats'], true )
+			|| ! in_array( $mime, $tts['output_mime_types'], true )
+			|| $speed < $tts['speed']['minimum']
+			|| $speed > $tts['speed']['maximum']
+		) {
+			return $this->unsupported_error();
+		}
+
+		try {
+			ProviderCredentialLoader::load();
+			$config = new ModelConfig();
+			$config->setOutputMimeType( $mime );
+			$config->setOutputSpeechVoice( $voice );
+			$custom_options = array( 'speed' => (float) $speed );
+			if ( null !== $language ) {
+				$custom_options['language'] = $language;
+			}
+			$config->setCustomOptions( $custom_options );
+
+			$model = AiClient::defaultRegistry()->getProviderModel( SuperdavAiProvider::PROVIDER_ID, (string) $tts['model'], $config );
+			if ( ! $model instanceof TextToSpeechConversionModelInterface || ! $model instanceof ApiBasedModelInterface ) {
+				return $this->speech_unavailable_error();
+			}
+			$request_options = new RequestOptions();
+			$request_options->setTimeout( SuperdavAiTranscriptionClient::REQUEST_TIMEOUT );
+			$request_options->setConnectTimeout( 5.0 );
+			$request_options->setMaxRedirects( 0 );
+			$model->setRequestOptions( $request_options );
+
+			ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, (string) $tts['model'], $session_id );
+			$result = $model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( $text ) ) ) ) );
+		} catch ( ResponseException ) {
+			return $this->malformed_response_error();
+		} catch ( \Throwable $e ) {
+			return $this->map_synthesis_exception( $e );
+		} finally {
+			ProviderTraceLogger::clear_runtime_context();
+		}
+
+		$candidates = $result->getCandidates();
+		$parts      = isset( $candidates[0] ) ? $candidates[0]->getMessage()->getParts() : array();
+		$file       = isset( $parts[0] ) ? $parts[0]->getFile() : null;
+		if ( ! $file instanceof File || ! $file->isInline() || $file->isRemote() || $file->getMimeType() !== $mime ) {
+			return $this->malformed_response_error();
+		}
+
+		$audio = $file->getBase64Data();
+		if ( ! is_string( $audio ) || '' === $audio ) {
+			return $this->malformed_response_error();
+		}
+		$decoded = base64_decode( $audio, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validates the SDK inline-audio payload before returning it.
+		if ( false === $decoded || '' === $decoded || strlen( $decoded ) > self::MAX_SYNTHESIS_RESPONSE_BYTES ) {
+			return $this->malformed_response_error();
+		}
+		unset( $decoded );
+
+		return new WP_REST_Response(
+			array(
+				'audio'      => $audio,
+				'mime_type'  => $mime,
+				'request_id' => $this->sanitize_request_id( $result->getId() ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * @return array{
+	 *     available:true,
+	 *     text_to_speech:array{
+	 *         model:string,
+	 *         output_formats:list<string>,
+	 *         output_mime_types:list<string>,
+	 *         max_input_characters:int,
+	 *         max_response_bytes:int,
+	 *         speed:array{minimum:float,maximum:float},
+	 *         voices:list<array{id:string,name:string,locales:list<string>}>
+	 *     },
+	 *     transcription:array{
+	 *         model:string,
+	 *         accepted_input_mime_types:list<string>,
+	 *         max_bytes:int,
+	 *         max_duration_seconds:int,
+	 *         response_formats:list<string>,
+	 *         automatic_language_detection:bool
+	 *     },
+	 *     locales:array{user_locale:string,site_locale:string,initial_locale:string},
+	 *     request_id:string
+	 * }|WP_Error
+	 */
+	private function get_sanitized_capabilities(): array|WP_Error {
+		$remote = $this->speech_client->get_capabilities();
+		if ( $remote instanceof WP_Error ) {
+			return $remote;
+		}
+
+		$tts           = isset( $remote['text_to_speech'] ) && is_array( $remote['text_to_speech'] ) ? $remote['text_to_speech'] : array();
+		$transcription = isset( $remote['transcription'] ) && is_array( $remote['transcription'] ) ? $remote['transcription'] : array();
+		if ( SuperdavAiProvider::TEXT_TO_SPEECH_MODEL_ID !== ( $tts['model'] ?? null )
+			|| SuperdavAiTranscriptionClient::MODEL_ID !== ( $transcription['model'] ?? null )
+		) {
+			return $this->speech_unavailable_error();
+		}
+
+		$formats       = $this->sanitize_string_list( $tts['output_formats'] ?? null, array_values( SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT ) );
+		$mimes         = array_keys(
+			array_filter(
+				SuperdavAiTextToSpeechConversionModel::MIME_TYPE_TO_RESPONSE_FORMAT,
+				static fn( string $format ): bool => in_array( $format, $formats, true )
+			)
+		);
+		$voices        = $this->sanitize_voices( $tts['voices'] ?? null );
+		$speed         = isset( $tts['speed'] ) && is_array( $tts['speed'] ) ? $tts['speed'] : array();
+		$minimum       = isset( $speed['minimum'] ) && is_numeric( $speed['minimum'] ) ? max( SuperdavAiTextToSpeechConversionModel::MIN_SPEED, (float) $speed['minimum'] ) : NAN;
+		$maximum       = isset( $speed['maximum'] ) && is_numeric( $speed['maximum'] ) ? min( SuperdavAiTextToSpeechConversionModel::MAX_SPEED, (float) $speed['maximum'] ) : NAN;
+		$maximum_input = isset( $tts['max_input_characters'] ) && is_numeric( $tts['max_input_characters'] )
+			? min( self::MAX_SYNTHESIS_CHARACTERS, (int) $tts['max_input_characters'] )
+			: 0;
+
+		$accepted_mimes   = $this->sanitize_string_list( $transcription['accepted_input_mime_types'] ?? null, array( SuperdavAiTranscriptionClient::INPUT_MIME_TYPE ) );
+		$response_formats = $this->sanitize_string_list( $transcription['response_formats'] ?? null, array( 'json' ) );
+		$max_bytes        = isset( $transcription['max_bytes'] ) && is_numeric( $transcription['max_bytes'] )
+			? min( SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES, (int) $transcription['max_bytes'] )
+			: 0;
+		$max_duration     = isset( $transcription['max_duration_seconds'] ) && is_numeric( $transcription['max_duration_seconds'] )
+			? min( SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS, (int) $transcription['max_duration_seconds'] )
+			: 0;
+
+		if ( array() === $formats || array() === $mimes || array() === $voices || ! is_finite( $minimum ) || ! is_finite( $maximum )
+			|| $minimum > $maximum || $maximum_input <= 0 || array() === $accepted_mimes || array() === $response_formats
+			|| $max_bytes <= 0 || $max_duration <= 0
+		) {
+			return $this->speech_unavailable_error();
+		}
+
+		return array(
+			'available'      => true,
+			'text_to_speech' => array(
+				'model'                => SuperdavAiProvider::TEXT_TO_SPEECH_MODEL_ID,
+				'output_formats'       => $formats,
+				'output_mime_types'    => $mimes,
+				'max_input_characters' => $maximum_input,
+				'max_response_bytes'   => self::MAX_SYNTHESIS_RESPONSE_BYTES,
+				'speed'                => array(
+					'minimum' => $minimum,
+					'maximum' => $maximum,
+				),
+				'voices'               => $voices,
+			),
+			'transcription'  => array(
+				'model'                        => SuperdavAiTranscriptionClient::MODEL_ID,
+				'accepted_input_mime_types'    => $accepted_mimes,
+				'max_bytes'                    => $max_bytes,
+				'max_duration_seconds'         => $max_duration,
+				'response_formats'             => $response_formats,
+				'automatic_language_detection' => true === ( $transcription['automatic_language_detection'] ?? false ),
+			),
+			'locales'        => $this->locale_resolver->resolve(),
+			'request_id'     => $this->sanitize_request_id( $remote['request_id'] ?? null ),
+		);
+	}
+
+	/**
+	 * @param mixed $values    Candidate values.
+	 * @param array $allowlist Allowed values.
+	 * @phpstan-param list<string> $allowlist
+	 * @return list<string>
+	 */
+	private function sanitize_string_list( mixed $values, array $allowlist ): array {
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
+		$result = array();
+		foreach ( array_slice( $values, 0, self::MAX_CAPABILITY_RESPONSE_ITEMS ) as $value ) {
+			if ( is_string( $value ) && in_array( $value, $allowlist, true ) && ! in_array( $value, $result, true ) ) {
+				$result[] = $value;
+			}
+		}
+
+		return $result;
+	}
+
+	/** @return list<array{id:string,name:string,locales:list<string>}> */
+	private function sanitize_voices( mixed $voices ): array {
+		if ( ! is_array( $voices ) ) {
+			return array();
+		}
+
+		$result = array();
+		foreach ( array_slice( $voices, 0, self::MAX_CAPABILITY_RESPONSE_ITEMS ) as $voice ) {
+			if ( ! is_array( $voice ) || ! isset( $voice['id'] ) || ! is_string( $voice['id'] )
+				|| ! in_array( $voice['id'], SuperdavAiTextToSpeechConversionModel::SUPPORTED_VOICES, true )
+			) {
+				continue;
+			}
+
+			$locales = array();
+			if ( isset( $voice['locales'] ) && is_array( $voice['locales'] ) ) {
+				foreach ( array_slice( $voice['locales'], 0, self::MAX_CAPABILITY_RESPONSE_ITEMS ) as $locale ) {
+					$locale = is_string( $locale ) ? $this->locale_resolver->normalize_client_locale( $locale ) : null;
+					if ( null !== $locale && in_array( $locale, SuperdavAiTextToSpeechConversionModel::SUPPORTED_LANGUAGES, true ) ) {
+						$locales[] = $locale;
+					}
+				}
+			}
+			if ( array() === $locales ) {
+				continue;
+			}
+
+			$name = isset( $voice['name'] ) && is_string( $voice['name'] ) ? sanitize_text_field( $voice['name'] ) : $voice['id'];
+			if ( '' === $name || $this->unicode_length( $name ) > 80 ) {
+				$name = $voice['id'];
+			}
+
+			$result[] = array(
+				'id'      => $voice['id'],
+				'name'    => $name,
+				'locales' => array_values( array_unique( $locales ) ),
+			);
+		}
+
+		return $result;
+	}
+
+	/** @param list<array{id:string,name:string,locales:list<string>}> $voices */
+	private function voice_supports_locale( array $voices, string $voice_id, string $locale ): bool {
+		foreach ( $voices as $voice ) {
+			if ( $voice_id === $voice['id'] ) {
+				return in_array( $locale, $voice['locales'], true );
+			}
+		}
+
+		return false;
+	}
+
+	private function optional_client_locale( mixed $value ): string|null|WP_Error {
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		if ( ! is_string( $value ) ) {
+			return $this->invalid_language_error();
+		}
+
+		$locale = $this->locale_resolver->normalize_client_locale( $value );
+		return null !== $locale ? $locale : $this->invalid_language_error();
+	}
+
+	private function optional_plain_text( mixed $value, int $maximum ): string|null|WP_Error {
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		if ( ! is_string( $value ) || 1 !== preg_match( '//u', $value ) ) {
+			return $this->invalid_audio_error();
+		}
+
+		$value = trim( wp_strip_all_tags( $value ) );
+		if ( '' === $value || $this->unicode_length( $value ) > $maximum ) {
+			return $this->invalid_audio_error();
+		}
+
+		return $value;
+	}
+
+	private function required_speakable_text( mixed $value ): string|WP_Error {
+		if ( ! is_string( $value ) || 1 !== preg_match( '//u', $value ) || $this->unicode_length( $value ) > self::MAX_SYNTHESIS_CHARACTERS * 4 ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$text = html_entity_decode( wp_strip_all_tags( strip_shortcodes( $value ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text = preg_replace( '/\s+/u', ' ', trim( $text ) );
+		if ( ! is_string( $text ) || '' === $text || 1 !== preg_match( '/[\p{L}\p{N}]/u', $text ) || $this->unicode_length( $text ) > self::MAX_SYNTHESIS_CHARACTERS ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		return $text;
+	}
+
+	private function optional_session_id( mixed $value ): int|WP_Error {
+		if ( null === $value || '' === $value || 0 === $value ) {
+			return 0;
+		}
+		if ( ! is_int( $value ) && ! ( is_string( $value ) && ctype_digit( $value ) ) ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$session_id = (int) $value;
+		$session    = $session_id > 0 ? Database::get_session( $session_id ) : null;
+		if ( ! $session || (int) $session->user_id !== get_current_user_id() ) {
+			return new WP_Error( 'rest_forbidden', __( 'You do not have permission to use this chat session.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+
+		return $session_id;
+	}
+
+	private function detect_mime_type( string $path ): string {
+		if ( ! class_exists( '\finfo' ) ) {
+			return '';
+		}
+
+		$finfo = new \finfo( FILEINFO_MIME_TYPE );
+		$mime  = $finfo->file( $path );
+		return is_string( $mime ) ? strtolower( trim( $mime ) ) : '';
+	}
+
+	private function is_safe_upload_filename( string $filename ): bool {
+		return 1 === preg_match( '/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/', $filename )
+			&& ! str_contains( $filename, '..' )
+			&& ! str_contains( $filename, '/' )
+			&& ! str_contains( $filename, '\\' );
+	}
+
+	/** Parse the strict PCM WAV subset accepted by the managed service. */
+	private function wav_duration_seconds( string $audio ): ?float {
+		$length = strlen( $audio );
+		if ( $length < 44 || 'RIFF' !== substr( $audio, 0, 4 ) || 'WAVE' !== substr( $audio, 8, 4 ) ) {
+			return null;
+		}
+
+		$riff_size = $this->little_endian_uint32( $audio, 4 );
+		if ( null === $riff_size || $riff_size + 8 !== $length ) {
+			return null;
+		}
+
+		$offset       = 12;
+		$byte_rate    = null;
+		$block_align  = null;
+		$data_bytes   = 0;
+		$found_format = false;
+		$allowed      = array( 'fmt ', 'data', 'fact', 'LIST', 'JUNK', 'bext', 'iXML' );
+		while ( $offset < $length ) {
+			if ( $offset + 8 > $length ) {
+				return null;
+			}
+			$chunk_id   = substr( $audio, $offset, 4 );
+			$chunk_size = $this->little_endian_uint32( $audio, $offset + 4 );
+			if ( null === $chunk_size || ! in_array( $chunk_id, $allowed, true ) ) {
+				return null;
+			}
+			$chunk_start = $offset + 8;
+			$chunk_end   = $chunk_start + $chunk_size;
+			$padded_end  = $chunk_end + ( $chunk_size % 2 );
+			if ( $chunk_end > $length || $padded_end > $length ) {
+				return null;
+			}
+
+			if ( 'fmt ' === $chunk_id ) {
+				if ( $found_format || $chunk_size < 16 ) {
+					return null;
+				}
+				$audio_format = $this->little_endian_uint16( $audio, $chunk_start );
+				$channels     = $this->little_endian_uint16( $audio, $chunk_start + 2 );
+				$sample_rate  = $this->little_endian_uint32( $audio, $chunk_start + 4 );
+				$byte_rate    = $this->little_endian_uint32( $audio, $chunk_start + 8 );
+				$block_align  = $this->little_endian_uint16( $audio, $chunk_start + 12 );
+				$sample_bits  = $this->little_endian_uint16( $audio, $chunk_start + 14 );
+				if ( 1 !== $audio_format || ! $channels || ! $sample_rate || ! $byte_rate || ! $block_align || ! $sample_bits
+					|| 0 !== $sample_bits % 8 || $block_align !== $channels * ( $sample_bits / 8 ) || $byte_rate !== $sample_rate * $block_align
+				) {
+					return null;
+				}
+				$found_format = true;
+			} elseif ( 'data' === $chunk_id ) {
+				if ( ! $block_align || 0 !== $chunk_size % $block_align ) {
+					return null;
+				}
+				$data_bytes += $chunk_size;
+			}
+			$offset = $padded_end;
+		}
+
+		return $found_format && $byte_rate && $data_bytes > 0 && $offset === $length
+			? $data_bytes / $byte_rate
+			: null;
+	}
+
+	private function little_endian_uint16( string $value, int $offset ): ?int {
+		$decoded = unpack( 'vvalue', substr( $value, $offset, 2 ) );
+		return is_array( $decoded ) && isset( $decoded['value'] ) ? (int) $decoded['value'] : null;
+	}
+
+	private function little_endian_uint32( string $value, int $offset ): ?int {
+		$decoded = unpack( 'Vvalue', substr( $value, $offset, 4 ) );
+		return is_array( $decoded ) && isset( $decoded['value'] ) ? (int) $decoded['value'] : null;
+	}
+
+	private function unicode_length( string $value ): int {
+		return function_exists( 'mb_strlen' ) ? mb_strlen( $value, 'UTF-8' ) : (int) preg_match_all( '/./us', $value );
+	}
+
+	private function sanitize_request_id( mixed $request_id ): string {
+		return is_string( $request_id ) && 1 === preg_match( '/^[A-Za-z0-9._:-]{1,128}$/', $request_id )
+			? $request_id
+			: 'speech-' . wp_generate_uuid4();
+	}
+
+	private function invalid_audio_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_audio', __( 'The audio recording is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+
+	private function audio_too_large_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_audio_too_large', __( 'The audio recording exceeds the supported size limit.', 'superdav-ai-agent' ), array( 'status' => 413 ) );
+	}
+
+	private function audio_too_long_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_audio_too_long', __( 'The audio recording exceeds the supported duration limit.', 'superdav-ai-agent' ), array( 'status' => 413 ) );
+	}
+
+	private function invalid_synthesis_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_speech_text', __( 'The speech request is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+
+	private function invalid_language_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_speech_language', __( 'The speech language is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+
+	private function unsupported_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_speech_unsupported', __( 'The requested speech option is not supported.', 'superdav-ai-agent' ), array( 'status' => 422 ) );
+	}
+
+	private function speech_unavailable_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_speech_unavailable', __( 'The speech service is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+	}
+
+	private function malformed_response_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_speech_malformed_response', __( 'The speech service returned an invalid response.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+	}
+
+	private function map_synthesis_exception( \Throwable $exception ): WP_Error {
+		$status = $exception->getCode();
+		if ( 429 === $status ) {
+			return new WP_Error( 'sd_ai_agent_speech_limit_exceeded', __( 'The speech service limit was reached. Please try again later.', 'superdav-ai-agent' ), array( 'status' => 429 ) );
+		}
+		if ( in_array( $status, array( 408, 504 ), true ) || $this->is_timeout_exception( $exception ) ) {
+			return new WP_Error( 'sd_ai_agent_speech_timeout', __( 'The speech service timed out. Please try again.', 'superdav-ai-agent' ), array( 'status' => 504 ) );
+		}
+
+		return $this->speech_unavailable_error();
+	}
+
+	/** Detect transport timeout failures without returning exception details. */
+	private function is_timeout_exception( \Throwable $exception ): bool {
+		$depth = 0;
+		do {
+			$message = strtolower( $exception->getMessage() );
+			if ( str_contains( $message, 'timed out' ) || str_contains( $message, 'timeout' ) || str_contains( $message, 'time-out' ) ) {
+				return true;
+			}
+
+			$exception = $exception->getPrevious();
+			++$depth;
+		} while ( $exception instanceof \Throwable && $depth < 5 );
+
+		return false;
+	}
+}

--- a/includes/REST/SpeechController.php
+++ b/includes/REST/SpeechController.php
@@ -145,7 +145,7 @@ final class SpeechController extends XWP_REST_Controller {
 			}
 
 			$detected_mime = $this->detect_mime_type( $temporary_path );
-			if ( ! in_array( $detected_mime, array( 'audio/wav', 'audio/x-wav', 'audio/wave', 'audio/vnd.wave' ), true ) ) {
+			if ( '' !== $detected_mime && ! in_array( $detected_mime, array( 'audio/wav', 'audio/x-wav', 'audio/wave', 'audio/vnd.wave' ), true ) ) {
 				return $this->invalid_audio_error();
 			}
 

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -684,7 +684,7 @@ namespace WordPress\AiClient\Providers\Http\Contracts {
 
 	interface HttpTransporterInterface {
 		/** @return \WordPress\AiClient\Providers\Http\DTO\Response */
-		public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response;
+		public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response;
 	}
 
 	interface RequestAuthenticationInterface {
@@ -706,6 +706,9 @@ namespace WordPress\AiClient\Providers\Http\Enums {
 	}
 
 	class HttpMethodEnum {
+		/** @return self */
+		public static function GET(): self { return new self(); }
+
 		/** @return self */
 		public static function POST(): self { return new self(); }
 	}
@@ -733,6 +736,16 @@ namespace WordPress\AiClient\Providers\Http\DTO {
 		/** @param float|null $timeout Timeout in seconds. */
 		public function setTimeout( ?float $timeout ): void {}
 
+		/** @param float|null $timeout Connection timeout in seconds. */
+		public function setConnectTimeout( ?float $timeout ): void {}
+
+		public function getConnectTimeout(): ?float { return null; }
+
+		/** @param int|null $max_redirects Maximum redirect count. */
+		public function setMaxRedirects( ?int $max_redirects ): void {}
+
+		public function getMaxRedirects(): ?int { return null; }
+
 		/**
 		 * @param array<string, mixed> $array Request options.
 		 * @return self
@@ -749,6 +762,10 @@ namespace WordPress\AiClient\Providers\Http\DTO {
 
 		/** @return string|null */
 		public function getHeaderAsString( string $name ): ?string { return null; }
+
+		public function getStatusCode(): int { return 200; }
+
+		public function isSuccessful(): bool { return true; }
 	}
 
 	class ApiKeyRequestAuthentication implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
@@ -795,6 +812,15 @@ namespace WordPress\AiClient\Providers\Http\Util {
 	}
 }
 
+namespace WordPress\AiClient\Providers\ApiBasedImplementation\Contracts {
+
+	interface ApiBasedModelInterface extends \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+		public function setRequestOptions( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options ): void;
+
+		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+	}
+}
+
 namespace WordPress\AiClient\Providers\ApiBasedImplementation {
 
 	abstract class AbstractApiProvider {
@@ -830,7 +856,7 @@ namespace WordPress\AiClient\Providers\ApiBasedImplementation {
 		public static function url( string $path = '' ): string { return $path; }
 	}
 
-	abstract class AbstractApiBasedModel implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+	abstract class AbstractApiBasedModel implements \WordPress\AiClient\Providers\ApiBasedImplementation\Contracts\ApiBasedModelInterface {
 		/**
 		 * @param \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata Model metadata.
 		 * @param \WordPress\AiClient\Providers\DTO\ProviderMetadata $providerMetadata Provider metadata.
@@ -855,7 +881,7 @@ namespace WordPress\AiClient\Providers\ApiBasedImplementation {
 		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
 		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
 			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
-				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
 			};
 		}
 
@@ -921,7 +947,7 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
 		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
 			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
-				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
 			};
 		}
 
@@ -976,7 +1002,7 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
 		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
 			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
-				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
 			};
 		}
 
@@ -1027,10 +1053,17 @@ namespace WordPress\AiClient {
 		 * @param string $model_id
 		 * @return mixed
 		 */
-		public function getProviderModel( string $provider_id, string $model_id ): mixed { return null; }
+		public function getProviderModel( string $provider_id, string $model_id, ?\WordPress\AiClient\Providers\Models\DTO\ModelConfig $model_config = null ): mixed { return null; }
 
 		/** @param string $provider_id */
 		public function getProviderRequestAuthentication( string $provider_id ): mixed { return null; }
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
+		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request, ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions $options = null ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+			};
+		}
 
 		/**
 		 * @param string $provider_id

--- a/tests/SdAiAgent/Admin/FloatingWidgetTest.php
+++ b/tests/SdAiAgent/Admin/FloatingWidgetTest.php
@@ -58,6 +58,7 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 	public function tear_down(): void {
 		parent::tear_down();
 		delete_option( Settings::OPTION_NAME );
+		remove_all_filters( 'locale' );
 		wp_dequeue_script( 'sd-ai-agent-floating-widget' );
 		wp_deregister_script( 'sd-ai-agent-floating-widget' );
 	}
@@ -219,6 +220,24 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 
 		$data = $this->get_localized_widget_data();
 		$this->assertSame( '', $data['settingsPageUrl'] );
+	}
+
+	/** The widget receives separate normalized user and site speech hints. */
+	public function test_enqueue_assets_frontend_localizes_speech_locale_hints(): void {
+		wp_set_current_user( $this->editor_id );
+		update_user_meta( $this->editor_id, 'locale', 'fr_FR' );
+		add_filter( 'locale', static fn(): string => 'pt_BR' );
+		Settings::instance()->update( [ 'show_on_frontend' => true ] );
+		$fixture_dir = dirname( __DIR__, 2 ) . '/fixtures/assets';
+		add_filter( 'sd_ai_agent_build_dir', static fn() => $fixture_dir );
+
+		FloatingWidget::enqueue_assets_frontend();
+		remove_all_filters( 'sd_ai_agent_build_dir' );
+
+		$data = $this->get_localized_widget_data();
+		$this->assertSame( 'fr-FR', $data['speechLocales']['user_locale'] );
+		$this->assertSame( 'pt-BR', $data['speechLocales']['site_locale'] );
+		$this->assertSame( 'fr-FR', $data['speechLocales']['initial_locale'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -34,6 +34,13 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 	}
 
+	public function tear_down(): void {
+		remove_all_filters( 'locale' );
+		wp_dequeue_script( 'sd-ai-agent-unified-admin' );
+		wp_deregister_script( 'sd-ai-agent-unified-admin' );
+		parent::tear_down();
+	}
+
 	// ─── Constants ────────────────────────────────────────────────────────────
 
 	/**
@@ -351,6 +358,27 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_build_dir' );
 
 		$this->assertFalse( wp_script_is( 'sd-ai-agent-unified-admin', 'enqueued' ) );
+	}
+
+	/** The unified admin receives separate normalized user and site speech hints. */
+	public function test_enqueue_assets_localizes_speech_locale_hints(): void {
+		wp_set_current_user( $this->admin_id );
+		update_user_meta( $this->admin_id, 'locale', 'fr_FR' );
+		add_filter( 'locale', static fn(): string => 'pt_BR' );
+		$fixture_dir = dirname( __DIR__, 2 ) . '/fixtures/assets';
+		add_filter( 'sd_ai_agent_build_dir', static fn() => $fixture_dir );
+
+		UnifiedAdminMenu::enqueueAssets( 'toplevel_page_' . UnifiedAdminMenu::SLUG );
+		remove_all_filters( 'sd_ai_agent_build_dir' );
+
+		$script_data = (string) wp_scripts()->get_data( 'sd-ai-agent-unified-admin', 'data' );
+		$matched     = preg_match( '/var sdAiAgentData = (\{[^\n]+\});/', $script_data, $matches );
+		$this->assertSame( 1, $matched );
+		$data = json_decode( $matches[1], true );
+		$this->assertIsArray( $data );
+		$this->assertSame( 'fr-FR', $data['speechLocales']['user_locale'] );
+		$this->assertSame( 'pt-BR', $data['speechLocales']['site_locale'] );
+		$this->assertSame( 'fr-FR', $data['speechLocales']['initial_locale'] );
 	}
 
 	// ─── render ───────────────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/ContextProvidersTest.php
+++ b/tests/SdAiAgent/Core/ContextProvidersTest.php
@@ -35,6 +35,7 @@ class ContextProvidersTest extends WP_UnitTestCase {
 	 */
 	public function tear_down(): void {
 		$this->reset_static_state();
+		remove_all_filters( 'locale' );
 		parent::tear_down();
 	}
 
@@ -335,6 +336,7 @@ class ContextProvidersTest extends WP_UnitTestCase {
 				'role'         => 'administrator',
 			]
 		);
+		update_user_meta( $user_id, 'locale', 'fr_FR' );
 		wp_set_current_user( $user_id );
 
 		$result = ContextProviders::provide_user_context( [] );
@@ -344,6 +346,17 @@ class ContextProvidersTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'Email', $result );
 		$this->assertArrayHasKey( 'Roles', $result );
 		$this->assertSame( 'Test User', $result['Name'] );
+		$this->assertSame( 'fr-FR', $result['Preferred User Language'] );
+		$this->assertStringContainsString( 'language the user actually uses', $result['Language Guidance'] );
+	}
+
+	/** Site context exposes only the normalized site-language hint. */
+	public function test_provide_site_context_includes_site_language(): void {
+		add_filter( 'locale', static fn(): string => 'pt_BR' );
+
+		$result = ContextProviders::provide_site_context( array() );
+
+		$this->assertSame( 'pt-BR', $result['Site Language'] );
 	}
 
 	// ── provide_post_context ─────────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/SpeechLocaleResolverTest.php
+++ b/tests/SdAiAgent/Core/SpeechLocaleResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Tests for the canonical speech locale resolver.
+ *
+ * @package SdAiAgent\Tests\Core
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\SpeechLocaleResolver;
+use WP_UnitTestCase;
+
+/** Covers trusted WordPress locale normalization and untrusted client input. */
+final class SpeechLocaleResolverTest extends WP_UnitTestCase {
+
+	private SpeechLocaleResolver $resolver;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->resolver = new SpeechLocaleResolver();
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'locale' );
+		parent::tear_down();
+	}
+
+	/** WordPress underscore locales become conventionally-cased BCP-47 hints. */
+	public function test_normalizes_wordpress_locales(): void {
+		$this->assertSame( 'pt-BR', $this->resolver->normalize_wordpress_locale( 'pt_BR' ) );
+		$this->assertSame( 'zh-Hant-TW', $this->resolver->normalize_wordpress_locale( 'zh_Hant_TW' ) );
+		$this->assertSame( 'de-DE-formal', $this->resolver->normalize_wordpress_locale( 'de_DE_formal' ) );
+	}
+
+	/** Client locales must already use bounded BCP-47 syntax. */
+	public function test_rejects_malformed_client_locales(): void {
+		$this->assertNull( $this->resolver->normalize_client_locale( 'pt_BR' ) );
+		$this->assertNull( $this->resolver->normalize_client_locale( '../en-US' ) );
+		$this->assertNull( $this->resolver->normalize_client_locale( 'en-12' ) );
+		$this->assertNull( $this->resolver->normalize_client_locale( 'en-US-abcd' ) );
+		$this->assertNull( $this->resolver->normalize_client_locale( 'en-US<script>' ) );
+		$this->assertNull( $this->resolver->normalize_client_locale( str_repeat( 'a', 100 ) ) );
+	}
+
+	/** Valid client tags are normalized without adding subtags. */
+	public function test_normalizes_valid_client_locale_casing(): void {
+		$this->assertSame( 'en-US', $this->resolver->normalize_client_locale( 'EN-us' ) );
+		$this->assertSame( 'sr-Latn-RS', $this->resolver->normalize_client_locale( 'sr-latn-rs' ) );
+		$this->assertSame( 'sl-rozaj-biske-1994', $this->resolver->normalize_client_locale( 'SL-ROZAJ-BISKE-1994' ) );
+	}
+
+	/** User and site hints remain separate while the user hint wins initially. */
+	public function test_resolves_user_and_site_locale_precedence(): void {
+		add_filter( 'locale', static fn(): string => 'pt_BR' );
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		update_user_meta( $user_id, 'locale', 'fr_FR' );
+		wp_set_current_user( $user_id );
+
+		$this->assertSame(
+			array(
+				'user_locale'    => 'fr-FR',
+				'site_locale'    => 'pt-BR',
+				'initial_locale' => 'fr-FR',
+			),
+			$this->resolver->resolve()
+		);
+	}
+
+	/** The site fallback is not mislabeled as an explicit user preference. */
+	public function test_resolves_site_locale_when_user_has_no_locale_override(): void {
+		add_filter( 'locale', static fn(): string => 'pt_BR' );
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertSame(
+			array(
+				'user_locale'    => '',
+				'site_locale'    => 'pt-BR',
+				'initial_locale' => 'pt-BR',
+			),
+			$this->resolver->resolve()
+		);
+	}
+}

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClientTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiTranscriptionClientTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for the explicit managed transcription client.
+ *
+ * @package SdAiAgent\Tests\Infrastructure\AiClient\Superdav
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Infrastructure\AiClient\Superdav;
+
+use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTranscriptionClient;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WP_Error;
+use WP_UnitTestCase;
+
+/** Covers bounded requests, response normalization, and scrubbed failure mapping. */
+final class SuperdavAiTranscriptionClientTest extends WP_UnitTestCase {
+
+	private HttpTransporterInterface $original_transporter;
+
+	public function set_up(): void {
+		parent::set_up();
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		( new SuperdavAiProviderHandler() )->register_provider();
+		$registry                   = AiClient::defaultRegistry();
+		$this->original_transporter = $registry->getHttpTransporter();
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'test-speech-token', false );
+	}
+
+	public function tear_down(): void {
+		AiClient::defaultRegistry()->setHttpTransporter( $this->original_transporter );
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		parent::tear_down();
+	}
+
+	/** Capabilities use current SDK auth/options and return only decoded data. */
+	public function test_fetches_authenticated_capabilities(): void {
+		$transporter = $this->use_outcomes(
+			array(
+				$this->json_response( array( 'text_to_speech' => array( 'model' => 'superdav-tts' ) ) ),
+			)
+		);
+
+		$result = ( new SuperdavAiTranscriptionClient() )->get_capabilities();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'superdav-tts', $result['text_to_speech']['model'] );
+		$this->assertCount( 1, $transporter->requests );
+		$request = $transporter->requests[0];
+		$this->assertSame( 'https://api.sdaiagent.com/v1/audio/capabilities', $request->getUri() );
+		$this->assertSame( 'Bearer test-speech-token', $request->getHeaderAsString( 'authorization' ) );
+		$this->assertSame( 35.0, $request->getOptions()?->getTimeout() );
+		$this->assertSame( 5.0, $request->getOptions()?->getConnectTimeout() );
+		$this->assertSame( 0, $request->getOptions()?->getMaxRedirects() );
+	}
+
+	/** One controlled multipart request returns normalized public transcript fields. */
+	public function test_transcribes_bounded_audio_once(): void {
+		$transporter = $this->use_outcomes(
+			array(
+				$this->json_response(
+					array(
+						'text'       => 'Olá mundo',
+						'language'   => 'PT-br',
+						'duration'   => 1.25,
+						'request_id' => 'request-123',
+						'internal'   => 'discard-me',
+					)
+				),
+			)
+		);
+
+		$result = ( new SuperdavAiTranscriptionClient() )->transcribe( 'RIFF-controlled-audio', 'PT-br', 'Meeting notes' );
+
+		$this->assertSame(
+			array(
+				'text'        => 'Olá mundo',
+				'request_id'  => 'request-123',
+				'language'    => 'pt-BR',
+				'duration_ms' => 1250,
+			),
+			$result
+		);
+		$this->assertCount( 1, $transporter->requests );
+		$request = $transporter->requests[0];
+		$this->assertSame( 'https://api.sdaiagent.com/v1/audio/transcriptions', $request->getUri() );
+		$this->assertSame( 'Bearer test-speech-token', $request->getHeaderAsString( 'authorization' ) );
+		$this->assertNotSame( '', $request->getHeaderAsString( 'idempotency-key' ) );
+		$body = $request->getBody();
+		$this->assertIsString( $body );
+		$this->assertStringContainsString( 'name="model"', $body );
+		$this->assertStringContainsString( SuperdavAiTranscriptionClient::MODEL_ID, $body );
+		$this->assertStringContainsString( 'name="file"; filename="audio.wav"', $body );
+		$this->assertStringContainsString( 'Content-Type: audio/wav', $body );
+		$this->assertStringContainsString( 'RIFF-controlled-audio', $body );
+	}
+
+	/** Oversized input fails before the transport can receive audio. */
+	public function test_rejects_oversized_audio_before_transport(): void {
+		$transporter = $this->use_outcomes( array() );
+
+		$result = ( new SuperdavAiTranscriptionClient() )->transcribe( str_repeat( 'a', SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES + 1 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_audio_too_large', $result->get_error_code() );
+		$this->assertCount( 0, $transporter->requests );
+	}
+
+	/** Wrong content types and upstream rate limits become stable scrubbed errors. */
+	public function test_maps_malformed_and_rate_limited_responses(): void {
+		$this->use_outcomes( array( new Response( 200, array( 'content-type' => 'text/plain' ), '{"secret":"hidden"}' ) ) );
+		$malformed = ( new SuperdavAiTranscriptionClient() )->get_capabilities();
+		$this->assertInstanceOf( WP_Error::class, $malformed );
+		$this->assertSame( 'sd_ai_agent_speech_malformed_response', $malformed->get_error_code() );
+		$this->assertStringNotContainsString( 'hidden', $malformed->get_error_message() );
+
+		$this->use_outcomes( array( new Response( 429, array( 'content-type' => 'application/json' ), '{"error":"secret detail"}' ) ) );
+		$limited = ( new SuperdavAiTranscriptionClient() )->get_capabilities();
+		$this->assertInstanceOf( WP_Error::class, $limited );
+		$this->assertSame( 'sd_ai_agent_speech_limit_exceeded', $limited->get_error_code() );
+		$this->assertStringNotContainsString( 'secret detail', $limited->get_error_message() );
+	}
+
+	/** Transport timeout detail is reduced to the public timeout contract. */
+	public function test_maps_transport_timeout_without_leaking_detail(): void {
+		$this->use_outcomes( array( new \RuntimeException( 'Connection timed out with private host detail' ) ) );
+
+		$result = ( new SuperdavAiTranscriptionClient() )->get_capabilities();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_speech_timeout', $result->get_error_code() );
+		$this->assertStringNotContainsString( 'private host detail', $result->get_error_message() );
+	}
+
+	/** @param list<Response|\Throwable> $outcomes Queued transport outcomes. */
+	private function use_outcomes( array $outcomes ): QueuedTranscriptionTransporter {
+		$transporter = new QueuedTranscriptionTransporter( $outcomes );
+		AiClient::defaultRegistry()->setHttpTransporter( $transporter );
+		return $transporter;
+	}
+
+	/** @param array<string, mixed> $data JSON response data. */
+	private function json_response( array $data ): Response {
+		return new Response( 200, array( 'content-type' => 'application/json; charset=utf-8' ), (string) wp_json_encode( $data ) );
+	}
+}
+
+/** Deterministic SDK transport used to inspect requests without network access. */
+final class QueuedTranscriptionTransporter implements HttpTransporterInterface {
+
+	/** @var list<Request> */
+	public array $requests = array();
+
+	/** @param list<Response|\Throwable> $outcomes Queued outcomes. */
+	public function __construct( private array $outcomes ) {}
+
+	public function send( Request $request, ?RequestOptions $options = null ): Response {
+		$this->requests[] = $request;
+		$outcome          = array_shift( $this->outcomes );
+		if ( $outcome instanceof \Throwable ) {
+			throw $outcome;
+		}
+		if ( ! $outcome instanceof Response ) {
+			throw new \RuntimeException( 'No test response configured.' );
+		}
+
+		return $outcome;
+	}
+}

--- a/tests/SdAiAgent/REST/SpeechControllerTest.php
+++ b/tests/SdAiAgent/REST/SpeechControllerTest.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Tests for the authenticated speech REST boundary.
+ *
+ * @package SdAiAgent\Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Core\RolePermissions;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\REST\SpeechController;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_UnitTestCase;
+
+/** Covers permission, upload, capability, synthesis, and redaction contracts. */
+final class SpeechControllerTest extends WP_UnitTestCase {
+
+	private \WP_REST_Server $server;
+
+	private int $editor_id;
+	private int $subscriber_id;
+	private HttpTransporterInterface $original_transporter;
+	private SpeechControllerTransporter $transporter;
+	private SpeechController $controller;
+
+	public function set_up(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Standard WordPress REST action.
+		do_action( 'rest_api_init' );
+
+		parent::set_up();
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		( new SuperdavAiProviderHandler() )->register_provider();
+		$registry                   = AiClient::defaultRegistry();
+		$this->original_transporter = $registry->getHttpTransporter();
+		$this->transporter          = new SpeechControllerTransporter();
+		$registry->setHttpTransporter( $this->transporter );
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'controller-secret-token', false );
+
+		$this->editor_id     = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->controller    = new SpeechController( null, null, static fn( string $path ): bool => is_file( $path ) );
+	}
+
+	public function tear_down(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		AiClient::defaultRegistry()->setHttpTransporter( $this->original_transporter );
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( RolePermissions::OPTION_NAME );
+		parent::tear_down();
+	}
+
+	/** DI registers all private speech routes and executes their permission guard. */
+	public function test_registers_guarded_speech_routes(): void {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/speech/capabilities', $routes );
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/speech/transcriptions', $routes );
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/speech/synthesis', $routes );
+
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/speech/capabilities' ) );
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/** Logged-out and denied users fail while a configured editor may use speech. */
+	public function test_enforces_chat_permissions_for_every_speech_route(): void {
+		wp_set_current_user( 0 );
+		$logged_out = $this->controller->check_chat_permission();
+		$this->assertInstanceOf( WP_Error::class, $logged_out );
+		$this->assertSame( 401, $logged_out->get_error_data()['status'] );
+
+		wp_set_current_user( $this->subscriber_id );
+		$denied = $this->controller->check_chat_permission();
+		$this->assertInstanceOf( WP_Error::class, $denied );
+		$this->assertSame( 403, $denied->get_error_data()['status'] );
+
+		wp_set_current_user( $this->editor_id );
+		$this->assertTrue( $this->controller->check_chat_permission() );
+	}
+
+	/** Capabilities expose only public bounded speech and locale fields. */
+	public function test_returns_sanitized_capabilities_and_locale_hints(): void {
+		wp_set_current_user( $this->editor_id );
+		$response = $this->controller->handle_capabilities( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/speech/capabilities' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'superdav-tts', $data['text_to_speech']['model'] );
+		$this->assertSame( SpeechController::MAX_SYNTHESIS_CHARACTERS, $data['text_to_speech']['max_input_characters'] );
+		$this->assertSame( 'superdav-transcribe', $data['transcription']['model'] );
+		$this->assertSame( array( 'audio/wav' ), $data['transcription']['accepted_input_mime_types'] );
+		$this->assertArrayHasKey( 'user_locale', $data['locales'] );
+		$this->assertArrayNotHasKey( 'upstream_private', $data );
+		$serialized = (string) wp_json_encode( $data );
+		$this->assertStringNotContainsString( 'controller-secret-token', $serialized );
+		$this->assertStringNotContainsString( 'discard-me', $serialized );
+	}
+
+	/** A valid synthetic WAV is forwarded once and its temporary file is removed. */
+	public function test_transcribes_valid_wav_and_deletes_temporary_file(): void {
+		wp_set_current_user( $this->editor_id );
+		$path = $this->write_temporary_audio( $this->valid_wav() );
+		$request = $this->transcription_request( $path, array( 'language' => 'en-US', 'prompt' => 'Meeting notes' ) );
+
+		$response = $this->controller->handle_transcription( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame(
+			array(
+				'text'        => 'Synthetic transcript',
+				'request_id'  => 'transcription-request',
+				'language'    => 'en-US',
+				'duration_ms' => 100,
+			),
+			$response->get_data()
+		);
+		$this->assertFileDoesNotExist( $path );
+		$this->assertSame( 1, $this->transporter->request_count_for( '/audio/transcriptions' ) );
+		$service_request = $this->transporter->last_request_for( '/audio/transcriptions' );
+		$this->assertNotNull( $service_request );
+		$this->assertStringNotContainsString( 'browser-recording.wav', (string) $service_request->getBody() );
+		$serialized = (string) wp_json_encode( $response->get_data() );
+		$this->assertStringNotContainsString( $path, $serialized );
+		$this->assertStringNotContainsString( 'controller-secret-token', $serialized );
+	}
+
+	/** Bad WAV signatures fail locally, delete the upload, and make no service call. */
+	public function test_rejects_bad_magic_bytes_before_network_access(): void {
+		wp_set_current_user( $this->editor_id );
+		$path    = $this->write_temporary_audio( str_repeat( 'x', 64 ) );
+		$request = $this->transcription_request( $path );
+
+		$result = $this->controller->handle_transcription( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_invalid_audio', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $path );
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** Extra or non-scalar transcription fields fail before any upstream request. */
+	public function test_rejects_uncontrolled_transcription_fields_and_releases_upload(): void {
+		wp_set_current_user( $this->editor_id );
+		$path    = $this->write_temporary_audio( $this->valid_wav() );
+		$request = $this->transcription_request( $path, array( 'extra' => 'not-forwarded' ) );
+
+		$result = $this->controller->handle_transcription( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_invalid_audio', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $path );
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** Bounded plain text resolves the bundled SDK model and returns inline audio. */
+	public function test_synthesizes_text_through_ai_client_model(): void {
+		wp_set_current_user( $this->editor_id );
+		$request = $this->synthesis_request(
+			array(
+				'text'      => '<p>Hello <strong>world</strong>.</p>',
+				'voice'     => 'alloy',
+				'language'  => 'en-US',
+				'mime_type' => 'audio/wav',
+				'speed'     => 1.25,
+			)
+		);
+
+		$response = $this->controller->handle_synthesis( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertSame( base64_encode( 'synthetic-audio' ), $data['audio'] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Verifies the explicit inline audio response contract.
+		$this->assertSame( 'audio/wav', $data['mime_type'] );
+		$this->assertStringStartsWith( 'superdav-tts-', $data['request_id'] );
+		$this->assertSame( 1, $this->transporter->request_count_for( '/audio/speech' ) );
+		$speech_request = $this->transporter->last_request_for( '/audio/speech' );
+		$this->assertNotNull( $speech_request );
+		$this->assertSame( 'Hello world.', $speech_request->getData()['input'] ?? null );
+		$this->assertSame( 'Bearer controller-secret-token', $speech_request->getHeaderAsString( 'authorization' ) );
+		$this->assertSame( 35.0, $speech_request->getOptions()?->getTimeout() );
+		$this->assertSame( 5.0, $speech_request->getOptions()?->getConnectTimeout() );
+		$this->assertSame( 0, $speech_request->getOptions()?->getMaxRedirects() );
+	}
+
+	/** Invalid synthesis fields fail before service capability discovery. */
+	public function test_rejects_invalid_synthesis_before_network_access(): void {
+		wp_set_current_user( $this->editor_id );
+		$result = $this->controller->handle_synthesis( $this->synthesis_request( array( 'text' => 'Hello', 'voice' => array( 'alloy' ) ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_invalid_speech_text', $result->get_error_code() );
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** Malformed SDK audio output is scrubbed behind the stable response error. */
+	public function test_rejects_malformed_synthesis_response_without_raw_body(): void {
+		wp_set_current_user( $this->editor_id );
+		$this->transporter->speech_response = new Response( 200, array( 'content-type' => 'text/plain' ), 'private malformed body' );
+
+		$result = $this->controller->handle_synthesis( $this->synthesis_request( array( 'text' => 'Hello' ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_speech_malformed_response', $result->get_error_code() );
+		$this->assertStringNotContainsString( 'private malformed body', $result->get_error_message() );
+	}
+
+	/** @param array<string, mixed> $fields Request body fields. */
+	private function transcription_request( string $path, array $fields = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/speech/transcriptions' );
+		$request->set_body_params( $fields );
+		$request->set_file_params(
+			array(
+				SpeechController::UPLOAD_FIELD => array(
+					'error'    => UPLOAD_ERR_OK,
+					'tmp_name' => $path,
+					'name'     => 'browser-recording.wav',
+					'type'     => 'audio/wav',
+				),
+			)
+		);
+
+		return $request;
+	}
+
+	/** @param array<string, mixed> $fields JSON request fields. */
+	private function synthesis_request( array $fields ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/speech/synthesis' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( $fields ) );
+		return $request;
+	}
+
+	private function write_temporary_audio( string $audio ): string {
+		$path = wp_tempnam( 'sd-ai-agent-speech-test.wav' );
+		$this->assertIsString( $path );
+		$this->assertNotFalse( file_put_contents( $path, $audio ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Creates an isolated synthetic upload fixture.
+		return $path;
+	}
+
+	/** Return a 100ms mono 16-bit PCM WAV fixture. */
+	private function valid_wav(): string {
+		$data = str_repeat( "\0", 3200 );
+		$fmt  = pack( 'vvVVvv', 1, 1, 16000, 32000, 2, 16 );
+		return 'RIFF' . pack( 'V', 36 + strlen( $data ) ) . 'WAVEfmt ' . pack( 'V', 16 ) . $fmt . 'data' . pack( 'V', strlen( $data ) ) . $data;
+	}
+}
+
+/** Routes deterministic service responses by the managed request path. */
+final class SpeechControllerTransporter implements HttpTransporterInterface {
+
+	/** @var list<Request> */
+	public array $requests = array();
+
+	public Response $speech_response;
+
+	public function __construct() {
+		$this->speech_response = new Response( 200, array( 'content-type' => 'audio/wav' ), 'synthetic-audio' );
+	}
+
+	public function send( Request $request, ?RequestOptions $options = null ): Response {
+		$this->requests[] = $request;
+		$uri              = $request->getUri();
+		if ( str_ends_with( $uri, '/audio/capabilities' ) ) {
+			return $this->json_response( $this->capabilities() );
+		}
+		if ( str_ends_with( $uri, '/models' ) ) {
+			return $this->json_response(
+				array(
+					'object' => 'list',
+					'data'   => array(
+						array(
+							'id'           => 'superdav-tts',
+							'name'         => 'Superdav Speech',
+							'capabilities' => array( 'text_to_speech_conversion' => true ),
+						),
+					),
+				)
+			);
+		}
+		if ( str_ends_with( $uri, '/audio/transcriptions' ) ) {
+			return $this->json_response(
+				array(
+					'text'       => 'Synthetic transcript',
+					'language'   => 'en-US',
+					'duration'   => 0.1,
+					'request_id' => 'transcription-request',
+				)
+			);
+		}
+		if ( str_ends_with( $uri, '/audio/speech' ) ) {
+			return $this->speech_response;
+		}
+
+		throw new \RuntimeException( 'Unexpected test request.' );
+	}
+
+	public function request_count_for( string $suffix ): int {
+		return count( array_filter( $this->requests, static fn( Request $request ): bool => str_ends_with( $request->getUri(), $suffix ) ) );
+	}
+
+	public function last_request_for( string $suffix ): ?Request {
+		$matches = array_values( array_filter( $this->requests, static fn( Request $request ): bool => str_ends_with( $request->getUri(), $suffix ) ) );
+		return array() === $matches ? null : $matches[ count( $matches ) - 1 ];
+	}
+
+	/** @return array<string, mixed> */
+	private function capabilities(): array {
+		return array(
+			'text_to_speech' => array(
+				'model'                => 'superdav-tts',
+				'output_formats'       => array( 'mp3', 'opus', 'aac', 'flac', 'wav', 'pcm', 'unsafe' ),
+				'max_input_characters' => 4096,
+				'speed'                => array( 'minimum' => 0.25, 'maximum' => 4 ),
+				'voices'               => array(
+					array( 'id' => 'alloy', 'name' => 'Alloy', 'locales' => array( 'en-US', '../unsafe' ) ),
+					array( 'id' => 'unsafe-voice', 'name' => 'Discard me', 'locales' => array( 'en-US' ) ),
+				),
+			),
+			'transcription'  => array(
+				'model'                        => 'superdav-transcribe',
+				'accepted_input_mime_types'    => array( 'audio/wav', 'application/octet-stream' ),
+				'max_bytes'                    => 10 * 1024 * 1024,
+				'max_duration_seconds'         => 1500,
+				'response_formats'             => array( 'json', 'verbose_json' ),
+				'automatic_language_detection' => true,
+			),
+			'upstream_private' => 'discard-me',
+			'request_id'       => 'capabilities-request',
+		);
+	}
+
+	/** @param array<string, mixed> $data Response body. */
+	private function json_response( array $data ): Response {
+		return new Response( 200, array( 'content-type' => 'application/json' ), (string) wp_json_encode( $data ) );
+	}
+}

--- a/tests/fixtures/assets/unified-admin.asset.php
+++ b/tests/fixtures/assets/unified-admin.asset.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+	'dependencies' => [],
+	'version'      => 'test',
+];


### PR DESCRIPTION
## Summary

- add authenticated REST endpoints for speech capabilities, WAV transcription, and managed speech synthesis
- resolve canonical locale hints from the user, site, and browser context without overriding detected conversation language
- enforce bounded WAV parsing, temporary-file provenance and cleanup, response validation, and stable scrubbed errors
- register the speech gateway and transcription client through the existing DI and Superdav provider architecture

## Security

- requires the real current WordPress user and the existing chat capability gate
- keeps the site-scoped Superdav bearer token server-side
- rejects malformed or oversized uploads before upstream capability discovery
- accepts only strict WAV input, does not create Media Library attachments, and removes temporary files on success and failure
- does not expose source text, transcripts, audio, request bodies, credentials, or upstream error details in REST errors

## Verification

- live unauthenticated requests return HTTP 401 for capabilities GET, transcription POST, and synthesis POST
- PHP-FPM was reloaded after switching the local plugin symlink to avoid stale realpath cache entries during runtime verification

## Worker self-verification
- PHPUnit: Tests: 4343, Assertions: 19972, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2646

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol
