### PR TITLE
Allow reversible block edits without confirmation

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -870,7 +870,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],
@@ -997,7 +997,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],
@@ -1067,7 +1067,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],
@@ -1155,7 +1155,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],
@@ -1218,7 +1218,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],
@@ -1311,7 +1311,7 @@ class BlockAbilities {
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
 						'readonly'    => false,
-						'destructive' => true,
+						'destructive' => false,
 						'idempotent'  => false,
 					],
 				],

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -10,6 +10,7 @@
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\BlockAbilities;
+use SdAiAgent\Core\ToolPermissionResolver;
 use WP_UnitTestCase;
 
 /**
@@ -25,6 +26,44 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		// Create an admin user and set as current user for capability checks.
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_id );
+	}
+
+	/**
+	 * Reversible block mutations should auto-execute under the default tool policy.
+	 */
+	public function test_reversible_block_mutations_are_non_destructive_for_default_tool_policy(): void {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'WP 7.0+ Abilities API is not available.' );
+		}
+
+		if ( null === wp_get_ability( 'sd-ai-agent/edit-block-tree' ) ) {
+			// wp_register_ability() must run during the Abilities API init hook.
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+			global $wp_current_filter;
+			$wp_current_filter[] = 'wp_abilities_api_init';
+			try {
+				BlockAbilities::register_abilities();
+			} finally {
+				array_pop( $wp_current_filter );
+			}
+		}
+
+		$reversible_block_abilities = [
+			'sd-ai-agent/edit-block-tree',
+			'sd-ai-agent/update-blocks',
+			'sd-ai-agent/rewrite-post-blocks',
+			'sd-ai-agent/insert-pattern',
+			'sd-ai-agent/revert-to-revision',
+			'sd-ai-agent/replace-block-range',
+		];
+
+		foreach ( $reversible_block_abilities as $ability_id ) {
+			$ability = wp_get_ability( $ability_id );
+
+			$this->assertInstanceOf( \WP_Ability::class, $ability, $ability_id );
+			$this->assertSame( 'write', ToolPermissionResolver::classify_ability( $ability ), $ability_id );
+			$this->assertFalse( ToolPermissionResolver::ability_needs_confirmation( $ability_id, $ability, [] ), $ability_id );
+		}
 	}
 
 	// ─── markdown-to-blocks ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Reclassifies reversible block-content mutation abilities as non-destructive writes so the default `auto` permission policy runs them without a confirmation prompt.
- Keeps capability checks and destructive prompts intact for non-reversible operations such as deletes, option deletes, theme activation, and outbound messaging.
- Adds PHPUnit coverage proving these block operations classify as `write` and do not require confirmation by default.

## Worker self-verification
- PHPUnit: Tests: 4344, Assertions: 19997, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Notes:
- `pnpm run verify` was attempted first and hit a transient database deadlock in an unrelated `GlobalStylesServiceTest`; a later full `pnpm run test:php` passed with no errors or failures.
- `pnpm run check:bundle` was rerun after build completed and passed; the first parallel run raced against build output and read an incomplete chunk set.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.5
