### PR TITLE
feat: prompt users to report completed job failures

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -206,6 +206,7 @@ System notices:
 - Account-action notices (billing, connection, setup) should use `Surface Active` with `Border Accent`, `role="status"`, friendly action-oriented copy, and a single primary button-style link CTA when an action URL is available.
 - Avoid framing customer account actions as errors; do not surface provider phrases such as “rejected” or “insufficient” in the chat UI when a clearer next step is available.
 - Background-job failure cards use fixed, customer-safe copy with one next step, an optional safe last-completed phase, and a correlation ID for support. Never show provider errors, prompts, tool payloads, paths, or stack traces; only show a retry button when retry is the prescribed action.
+- After a completed job has an explicit tool or runtime failure, show a compact warning-surface reporting prompt with **No**, **No, never**, **Yes**, and **Yes, always** choices. Explain the sanitized diagnostic payload in supporting text, keep **Yes, always** as the single primary action, and stack the copy and actions on compact screens.
 
 ### Cards (suggestion / template)
 

--- a/includes/Feedback/ReportSender.php
+++ b/includes/Feedback/ReportSender.php
@@ -10,7 +10,8 @@ declare(strict_types=1);
  * normal plugin operation).
  *
  * The endpoint is fixed — no API key is required. User consent is collected
- * per submission via the feedback-consent modal before this method is called.
+ * through the manual feedback modal or the completed-job failure prompt. The
+ * prompt can also retain a user-scoped choice to report future failures.
  *
  * @package SdAiAgent\Feedback
  * @license GPL-2.0-or-later

--- a/src/components/__tests__/automatic-feedback-prompt.test.js
+++ b/src/components/__tests__/automatic-feedback-prompt.test.js
@@ -1,0 +1,219 @@
+/**
+ * Tests for automatic post-failure feedback reporting.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
+import { createElement, createRoot } from '@wordpress/element';
+import { act } from 'react';
+
+import AutomaticFeedbackPrompt from '../automatic-feedback-prompt';
+import {
+	FEEDBACK_REPORTING_PREFERENCE_KEY,
+	setFeedbackReportingPreference,
+	toolCallsContainFailure,
+} from '../../utils/feedback-reporting';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+jest.mock( '../../store', () => 'sd-ai-agent' );
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, ...props } ) => {
+		const { createElement: createWpElement } =
+			jest.requireActual( '@wordpress/element' );
+		return createWpElement( 'button', props, children );
+	},
+} ) );
+
+const failure = { reason: 'tool_call_error', eventId: 'job-17' };
+
+/**
+ * Render the automatic feedback prompt.
+ *
+ * @return {Promise<{container: HTMLElement, root: import('@wordpress/element').Root}>}
+ *   Rendered prompt and root.
+ */
+async function renderPrompt() {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render(
+			createElement( AutomaticFeedbackPrompt, {
+				sessionId: 17,
+				failure,
+			} )
+		);
+	} );
+	return { container, root };
+}
+
+/**
+ * Find a rendered button by its visible label.
+ *
+ * @param {HTMLElement} container Rendered test container.
+ * @param {string}      label     Button label.
+ * @return {HTMLButtonElement|undefined} Matching button.
+ */
+function button( container, label ) {
+	return [ ...container.querySelectorAll( 'button' ) ].find(
+		( item ) => item.textContent === label
+	);
+}
+
+describe( 'AutomaticFeedbackPrompt', () => {
+	let setFeedbackBanner;
+
+	beforeEach( () => {
+		delete global.sdAiAgentData;
+		localStorage.clear();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( { success: true } );
+		setFeedbackBanner = jest.fn();
+		useDispatch.mockReturnValue( { setFeedbackBanner } );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	} );
+
+	test( 'offers all four reporting choices after a detected failure', async () => {
+		const { container, root } = await renderPrompt();
+
+		expect( container.textContent ).toContain(
+			'It looks like part of this job failed.'
+		);
+		expect( button( container, 'No' ) ).toBeDefined();
+		expect( button( container, 'No, never' ) ).toBeDefined();
+		expect( button( container, 'Yes' ) ).toBeDefined();
+		expect( button( container, 'Yes, always' ) ).toBeDefined();
+
+		await act( async () => root.unmount() );
+	} );
+
+	test( 'No dismisses once and No, never persists the opt-out', async () => {
+		let rendered = await renderPrompt();
+		await act( async () => {
+			button( rendered.container, 'No' ).click();
+		} );
+		expect( setFeedbackBanner ).toHaveBeenCalledWith( null );
+		expect(
+			localStorage.getItem( FEEDBACK_REPORTING_PREFERENCE_KEY )
+		).toBeNull();
+		await act( async () => rendered.root.unmount() );
+
+		setFeedbackBanner.mockClear();
+		rendered = await renderPrompt();
+		await act( async () => {
+			button( rendered.container, 'No, never' ).click();
+		} );
+		expect(
+			localStorage.getItem( FEEDBACK_REPORTING_PREFERENCE_KEY )
+		).toBe( 'never' );
+		expect( setFeedbackBanner ).toHaveBeenCalledWith( null );
+		await act( async () => rendered.root.unmount() );
+	} );
+
+	test( 'Yes sends this report without changing the preference', async () => {
+		const { container, root } = await renderPrompt();
+		await act( async () => {
+			button( container, 'Yes' ).click();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/sd-ai-agent/v1/feedback/send',
+				method: 'POST',
+				data: expect.objectContaining( {
+					report_type: 'self_reported',
+					session_id: 17,
+				} ),
+			} )
+		);
+		expect(
+			localStorage.getItem( FEEDBACK_REPORTING_PREFERENCE_KEY )
+		).toBeNull();
+		expect( setFeedbackBanner ).toHaveBeenCalledWith( null );
+
+		await act( async () => root.unmount() );
+	} );
+
+	test( 'Yes, always sends now and automatically sends later failures', async () => {
+		let rendered = await renderPrompt();
+		await act( async () => {
+			button( rendered.container, 'Yes, always' ).click();
+			await Promise.resolve();
+		} );
+		expect(
+			localStorage.getItem( FEEDBACK_REPORTING_PREFERENCE_KEY )
+		).toBe( 'always' );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		await act( async () => rendered.root.unmount() );
+
+		apiFetch.mockClear();
+		setFeedbackBanner.mockClear();
+		rendered = await renderPrompt();
+		await act( async () => Promise.resolve() );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( rendered.container.querySelector( 'button' ) ).toBeNull();
+		expect( setFeedbackBanner ).toHaveBeenCalledWith( null );
+		await act( async () => rendered.root.unmount() );
+	} );
+} );
+
+describe( 'feedback reporting helpers', () => {
+	test( 'scopes persistent consent to the current WordPress user', () => {
+		localStorage.clear();
+		global.sdAiAgentData = { currentUserId: 42 };
+		setFeedbackReportingPreference( 'always' );
+
+		expect(
+			localStorage.getItem( `${ FEEDBACK_REPORTING_PREFERENCE_KEY }:42` )
+		).toBe( 'always' );
+		expect(
+			localStorage.getItem( FEEDBACK_REPORTING_PREFERENCE_KEY )
+		).toBeNull();
+	} );
+
+	test( 'detects explicit tool response failures only', () => {
+		expect(
+			toolCallsContainFailure( [
+				{ type: 'call', id: '1' },
+				{
+					type: 'response',
+					id: '1',
+					response: { error: 'failed' },
+				},
+			] )
+		).toBe( true );
+		expect(
+			toolCallsContainFailure( [
+				{
+					type: 'response',
+					id: '2',
+					response: { success: true },
+				},
+			] )
+		).toBe( false );
+		expect(
+			toolCallsContainFailure( [
+				{
+					type: 'response',
+					response: {
+						success: true,
+						result: { success: false, error: 'Validation failed.' },
+					},
+				},
+			] )
+		).toBe( true );
+	} );
+} );

--- a/src/components/automatic-feedback-prompt.js
+++ b/src/components/automatic-feedback-prompt.js
@@ -1,0 +1,176 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import STORE_NAME from '../store';
+import {
+	FEEDBACK_REPORTING_PREFERENCES,
+	getFeedbackReportingPreference,
+	setFeedbackReportingPreference,
+	submitAutomaticFeedback,
+} from '../utils/feedback-reporting';
+
+/**
+ * Ask whether a detected completed-job failure should be reported.
+ *
+ * @param {Object} props           Component props.
+ * @param {number} props.sessionId Current session ID.
+ * @param {Object} props.failure   Failure metadata from the completed job.
+ * @return {JSX.Element|null} Automatic feedback prompt.
+ */
+export default function AutomaticFeedbackPrompt( { sessionId, failure } ) {
+	const { setFeedbackBanner } = useDispatch( STORE_NAME );
+	const [ preference, setPreference ] = useState(
+		getFeedbackReportingPreference
+	);
+	const [ isSending, setIsSending ] = useState( false );
+	const [ isSent, setIsSent ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const autoAttemptedRef = useRef( '' );
+
+	const dismiss = useCallback( () => {
+		setFeedbackBanner( null );
+	}, [ setFeedbackBanner ] );
+
+	const sendReport = useCallback( async () => {
+		if ( ! sessionId || ! failure || isSending || isSent ) {
+			return;
+		}
+
+		setIsSending( true );
+		setError( '' );
+		try {
+			await submitAutomaticFeedback( sessionId, failure );
+			setIsSent( true );
+			setFeedbackBanner( null );
+		} catch {
+			setError(
+				__(
+					'The report could not be sent. You can try again.',
+					'superdav-ai-agent'
+				)
+			);
+		} finally {
+			setIsSending( false );
+		}
+	}, [ failure, isSending, isSent, sessionId, setFeedbackBanner ] );
+
+	useEffect( () => {
+		if ( ! failure || ! sessionId ) {
+			return;
+		}
+
+		if ( preference === FEEDBACK_REPORTING_PREFERENCES.NEVER ) {
+			dismiss();
+			return;
+		}
+
+		if ( preference === FEEDBACK_REPORTING_PREFERENCES.ALWAYS ) {
+			const eventKey = `${ sessionId }:${
+				failure.eventId ||
+				failure.reason ||
+				failure.exitReason ||
+				'error'
+			}`;
+			if ( autoAttemptedRef.current === eventKey ) {
+				return;
+			}
+			autoAttemptedRef.current = eventKey;
+			sendReport();
+		}
+	}, [ dismiss, failure, preference, sendReport, sessionId ] );
+
+	if (
+		! failure ||
+		! sessionId ||
+		isSent ||
+		( preference === FEEDBACK_REPORTING_PREFERENCES.NEVER && ! error ) ||
+		( preference === FEEDBACK_REPORTING_PREFERENCES.ALWAYS && ! error )
+	) {
+		return null;
+	}
+
+	const choosePreference = ( nextPreference ) => {
+		setFeedbackReportingPreference( nextPreference );
+		setPreference( nextPreference );
+	};
+
+	return (
+		<div
+			className="sd-ai-agent-feedback-prompt"
+			role="region"
+			aria-label={ __( 'Report detected problem', 'superdav-ai-agent' ) }
+		>
+			<div className="sd-ai-agent-feedback-prompt__content">
+				<div className="sd-ai-agent-feedback-prompt__copy">
+					<p className="sd-ai-agent-feedback-prompt__text">
+						{ __(
+							'It looks like part of this job failed. Would you like to report the problem?',
+							'superdav-ai-agent'
+						) }
+					</p>
+					<p className="sd-ai-agent-feedback-prompt__privacy">
+						{ __(
+							'The report includes a sanitized copy of this conversation and basic environment details. Passwords, API keys, and credentials are removed.',
+							'superdav-ai-agent'
+						) }
+					</p>
+					{ error && (
+						<p className="sd-ai-agent-feedback-prompt__error">
+							{ error }
+						</p>
+					) }
+				</div>
+				<div className="sd-ai-agent-feedback-prompt__actions">
+					<Button
+						variant="tertiary"
+						onClick={ () => {
+							choosePreference(
+								FEEDBACK_REPORTING_PREFERENCES.NEVER
+							);
+							dismiss();
+						} }
+						disabled={ isSending }
+					>
+						{ __( 'No, never', 'superdav-ai-agent' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={ dismiss }
+						disabled={ isSending }
+					>
+						{ __( 'No', 'superdav-ai-agent' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={ sendReport }
+						disabled={ isSending }
+					>
+						{ __( 'Yes', 'superdav-ai-agent' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ () => {
+							choosePreference(
+								FEEDBACK_REPORTING_PREFERENCES.ALWAYS
+							);
+							sendReport();
+						} }
+						disabled={ isSending }
+					>
+						{ isSending
+							? __( 'Sending…', 'superdav-ai-agent' )
+							: __( 'Yes, always', 'superdav-ai-agent' ) }
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
 import ActionCard from '../action-card';
+import AutomaticFeedbackPrompt from '../automatic-feedback-prompt';
 import CompactConversationActionCard from '../compact-conversation-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import useTextToSpeech from '../use-text-to-speech';
@@ -48,6 +49,7 @@ export default function MessageList() {
 		pendingActionCard,
 		providers,
 		showToolCallDetails,
+		feedbackBanner,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
 		const settings = store.getSettings();
@@ -71,6 +73,7 @@ export default function MessageList() {
 			pendingActionCard: store.getPendingActionCard(),
 			providers: store.getProviders(),
 			showToolCallDetails: settings?.show_tool_call_details === true,
+			feedbackBanner: store.getFeedbackBanner?.() || null,
 		};
 	}, [] );
 
@@ -230,6 +233,13 @@ export default function MessageList() {
 								onCancel={ () => setPendingActionCard( null ) }
 							/>
 						) }
+
+					{ ! sending && (
+						<AutomaticFeedbackPrompt
+							sessionId={ currentSessionId }
+							failure={ feedbackBanner }
+						/>
+					) }
 				</div>
 			</div>
 

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -23,6 +23,7 @@ jest.mock( '@wordpress/i18n', () => ( {
 jest.mock( '../../../store', () => 'sd-ai-agent' );
 
 jest.mock( '../../feedback-consent-modal', () => () => null );
+jest.mock( '../../automatic-feedback-prompt', () => () => null );
 
 jest.mock( '../../use-text-to-speech', () => () => ( {
 	speak: jest.fn(),

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -21,6 +21,7 @@ jest.mock( '@wordpress/i18n', () => ( {
 
 jest.mock( '../../../store', () => 'sd-ai-agent' );
 jest.mock( '../../feedback-consent-modal', () => () => null );
+jest.mock( '../../automatic-feedback-prompt', () => () => null );
 jest.mock( '../../chat-redesign/message-items', () => ( {
 	AssistantMessage: () => null,
 	RunningMessage: () => null,

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -11,6 +11,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
+import AutomaticFeedbackPrompt from '../automatic-feedback-prompt';
 import CompactConversationActionCard from '../compact-conversation-action-card';
 import RecoverableJobActionCard from '../recoverable-job-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
@@ -103,6 +104,7 @@ export default function WidgetMessageList() {
 		pendingToolResultRetry,
 		providers,
 		showToolCallDetails,
+		feedbackBanner,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
 		const settings = store.getSettings();
@@ -117,6 +119,7 @@ export default function WidgetMessageList() {
 			pendingToolResultRetry: store.getPendingToolResultRetry?.(),
 			providers: store.getProviders(),
 			showToolCallDetails: settings?.show_tool_call_details === true,
+			feedbackBanner: store.getFeedbackBanner?.() || null,
 		};
 	}, [] );
 
@@ -245,6 +248,13 @@ export default function WidgetMessageList() {
 								onCancel={ () => setPendingActionCard( null ) }
 							/>
 						) }
+
+					{ ! sending && (
+						<AutomaticFeedbackPrompt
+							sessionId={ currentSessionId }
+							failure={ feedbackBanner }
+						/>
+					) }
 				</div>
 			</div>
 

--- a/src/components/feedback-consent-modal.js
+++ b/src/components/feedback-consent-modal.js
@@ -8,8 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Feedback consent modal.
  *
- * Shown when the user invokes /report-issue, clicks a thumbs-down button, or
- * when the auto-prompt banner fires on spin_detected / timeout / max_iterations.
+ * Shown when the user invokes /report-issue or clicks a thumbs-down button.
+ * Detected completed-job failures use the separate four-choice inline prompt.
  *
  * Features (t182):
  *   1. Summary stats: message count, tool call count, environment keys.

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -842,17 +842,57 @@
 	font-size: 13px;
 }
 
-.sdaa-feedback-banner__text {
+.sd-ai-agent-feedback-prompt {
+	margin: 12px 16px;
+}
+
+.sd-ai-agent-feedback-prompt__content {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	background: #fff8e5;
+	border-left: 4px solid #dba617;
+	border-radius: 4px;
+	padding: 10px 12px;
+	font-size: 13px;
+}
+
+.sd-ai-agent-feedback-prompt__copy {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.sd-ai-agent-feedback-prompt__text {
 	margin: 0;
 	color: #1d2327;
 	flex: 1;
 }
 
-.sdaa-feedback-banner__actions {
+.sd-ai-agent-feedback-prompt__privacy,
+.sd-ai-agent-feedback-prompt__error {
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.sd-ai-agent-feedback-prompt__privacy {
+	color: #646970;
+}
+
+.sd-ai-agent-feedback-prompt__error {
+	color: #d63638;
+}
+
+.sd-ai-agent-feedback-prompt__actions {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	flex-shrink: 0;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 .sdaa-feedback-banner__send-btn {
@@ -866,6 +906,17 @@
 	font-size: 12px !important;
 	color: #646970 !important;
 	text-decoration: none !important;
+}
+
+@media (max-width: 600px) {
+	.sd-ai-agent-feedback-prompt__content {
+		flex-direction: column;
+	}
+
+	.sd-ai-agent-feedback-prompt__actions {
+		justify-content: flex-start;
+		width: 100%;
+	}
 }
 
 /* ── Boot error screen ─────────────────────────────────────────────────────── */

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -15,6 +15,7 @@ import {
 } from '../../utils/notification-manager';
 import { playDing, playDong, playThinking } from '../../utils/sound-manager';
 import { emitReflectionEvents } from '../reflection-emitter';
+import { toolCallsContainFailure } from '../../utils/feedback-reporting';
 
 // A session/job pair must have exactly one polling loop. Multiple mounted chat
 // surfaces can discover or resume the same durable job at nearly the same time;
@@ -221,6 +222,7 @@ export const actions = {
 			}
 
 			dispatch.setSending( true );
+			dispatch.setFeedbackBanner?.( null );
 			try {
 				const result = await apiFetch( {
 					path: `/sd-ai-agent/v1/sessions/${ sessionId }/resume`,
@@ -286,6 +288,7 @@ export const actions = {
 			dispatch.setPendingToolResultRetry( null );
 			dispatch.setPendingActionCard( null );
 			dispatch.setSending( true );
+			dispatch.setFeedbackBanner?.( null );
 
 			let postSucceeded = false;
 			let lastErr = null;
@@ -458,6 +461,10 @@ export const actions = {
 						dispatch.appendMessage( {
 							role: 'system',
 							parts: [ { text: 'Error: Request timed out.' } ],
+						} );
+						dispatch.setFeedbackBanner?.( {
+							reason: 'timeout',
+							eventId: jobId,
 						} );
 						dispatch.setSending( false );
 					}
@@ -754,6 +761,10 @@ export const actions = {
 										},
 									],
 								} );
+								dispatch.setFeedbackBanner?.( {
+									reason: 'client_tool_submission_error',
+									eventId: jobId,
+								} );
 								dispatch.setSending( false );
 							}
 							stopPolling();
@@ -950,6 +961,16 @@ export const actions = {
 							if ( ! isCreditNotice && ! failureDiagnostic ) {
 								dispatch.setStreamError( true, sessionId );
 							}
+							if ( ! isCreditNotice ) {
+								dispatch.setFeedbackBanner?.( {
+									reason:
+										result.exit_reason ||
+										result.reason ||
+										failureDiagnostic?.reason ||
+										'job_error',
+									eventId: jobId,
+								} );
+							}
 							// WP_Error max_iterations — show feedback banner (t183).
 							const errMsg = `${ rawErrorMessage } ${
 								result.reason || ''
@@ -1100,6 +1121,16 @@ export const actions = {
 							);
 						}
 
+						if (
+							toolCallsContainFailure( resultToolCalls ) &&
+							select.getCurrentSessionId() === sessionId
+						) {
+							dispatch.setFeedbackBanner?.( {
+								reason: 'tool_call_error',
+								eventId: jobId,
+							} );
+						}
+
 						const FEEDBACK_EXIT_REASONS = [
 							'spin_detected',
 							'timeout',
@@ -1178,6 +1209,10 @@ export const actions = {
 										},
 									],
 								} );
+								dispatch.setFeedbackBanner?.( {
+									reason: 'job_result_retrieval_error',
+									eventId: jobId,
+								} );
 							}
 							dispatch.setSending( false );
 							dispatch.setLiveToolCalls( [] );
@@ -1237,6 +1272,10 @@ export const actions = {
 								],
 							} );
 							dispatch.setStreamError( true, sessionId );
+							dispatch.setFeedbackBanner?.( {
+								reason: 'server_connection_error',
+								eventId: jobId,
+							} );
 							dispatch.setSending( false );
 							dispatch.setLiveToolCalls( [] );
 						}

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -187,8 +187,8 @@ export const initialState = {
 	// { reason: string, attempted_steps: string[] } or null.
 	inabilityReported: null,
 
-	// Feedback banner (t183) — set when the AI exits due to spin/timeout/max_iterations.
-	// { exitReason: string } or null.
+	// Completed-job feedback prompt (t183) — set for explicit tool/runtime failures.
+	// { reason?: string, exitReason?: string, eventId?: string } or null.
 	feedbackBanner: null,
 
 	// Message queue — messages typed while the agent is processing.
@@ -406,9 +406,9 @@ export const actions = {
 	},
 
 	/**
-	 * Set or clear the feedback banner (t183).
-	 * Set to an object { exitReason } when the AI exits due to
-	 * spin_detected, timeout, or max_iterations; set to null to dismiss.
+	 * Set or clear the completed-job feedback prompt (t183).
+	 * Set to failure metadata after an explicit tool/runtime failure; set to
+	 * null when the user responds or a new job starts.
 	 *
 	 * @param {Object|null} data - Banner data or null.
 	 * @return {Object} Redux action.
@@ -1685,8 +1685,7 @@ export const selectors = {
 	},
 
 	/**
-	 * Get feedback banner data (t183).
-	 * Returns { exitReason } when the AI exited due to spin/timeout/max_iterations, or null.
+	 * Get completed-job feedback prompt data (t183).
 	 *
 	 * @param {import('../../types').StoreState} state
 	 * @return {Object|null} Feedback banner data or null.

--- a/src/utils/feedback-reporting.js
+++ b/src/utils/feedback-reporting.js
@@ -1,0 +1,134 @@
+/**
+ * Automatic feedback reporting preferences and submission helpers.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+export const FEEDBACK_REPORTING_PREFERENCE_KEY =
+	'sdAiAgentFeedbackReportingPreference';
+
+export const FEEDBACK_REPORTING_PREFERENCES = {
+	ASK: 'ask',
+	NEVER: 'never',
+	ALWAYS: 'always',
+};
+
+const pendingReports = new Map();
+
+/**
+ * Scope persistent consent to the logged-in WordPress user.
+ *
+ * @return {string} Browser storage key for the current user.
+ */
+function getPreferenceStorageKey() {
+	const currentUserId = globalThis.sdAiAgentData?.currentUserId;
+	return currentUserId
+		? `${ FEEDBACK_REPORTING_PREFERENCE_KEY }:${ currentUserId }`
+		: FEEDBACK_REPORTING_PREFERENCE_KEY;
+}
+
+/**
+ * Read the browser-local automatic reporting preference.
+ *
+ * @return {'ask'|'never'|'always'} Saved preference.
+ */
+export function getFeedbackReportingPreference() {
+	try {
+		const preference = localStorage.getItem( getPreferenceStorageKey() );
+		if (
+			preference === FEEDBACK_REPORTING_PREFERENCES.NEVER ||
+			preference === FEEDBACK_REPORTING_PREFERENCES.ALWAYS
+		) {
+			return preference;
+		}
+	} catch {
+		// Storage may be unavailable in privacy-restricted browser contexts.
+	}
+
+	return FEEDBACK_REPORTING_PREFERENCES.ASK;
+}
+
+/**
+ * Persist the browser-local automatic reporting preference.
+ *
+ * @param {'ask'|'never'|'always'} preference Preference to save.
+ */
+export function setFeedbackReportingPreference( preference ) {
+	try {
+		if ( preference === FEEDBACK_REPORTING_PREFERENCES.ASK ) {
+			localStorage.removeItem( getPreferenceStorageKey() );
+			return;
+		}
+		localStorage.setItem( getPreferenceStorageKey(), preference );
+	} catch {
+		// A blocked storage write must not prevent one-time reporting.
+	}
+}
+
+/**
+ * Whether a terminal tool log contains an explicit failed response.
+ *
+ * @param {Array} toolCalls Flat tool call and response entries.
+ * @return {boolean} True when a tool response explicitly failed.
+ */
+export function toolCallsContainFailure( toolCalls ) {
+	if ( ! Array.isArray( toolCalls ) ) {
+		return false;
+	}
+
+	return toolCalls.some( ( entry ) => {
+		if ( entry?.status === 'error' ) {
+			return true;
+		}
+
+		if ( entry?.type !== 'response' && entry?.type !== 'result' ) {
+			return false;
+		}
+
+		const result = entry.response ?? entry.result;
+		const nestedResult = result?.result;
+		return Boolean(
+			result &&
+				typeof result === 'object' &&
+				( result.success === false ||
+					result.error ||
+					( nestedResult &&
+						typeof nestedResult === 'object' &&
+						( nestedResult.success === false ||
+							nestedResult.error ) ) )
+		);
+	} );
+}
+
+/**
+ * Submit one sanitized automatic feedback report.
+ *
+ * Concurrent mounts can observe the same store event. Reuse the in-flight
+ * request so the main chat and floating widget cannot submit duplicate reports.
+ *
+ * @param {number} sessionId Current session ID.
+ * @param {Object} failure   Detected failure metadata.
+ * @return {Promise<*>} Feedback endpoint response.
+ */
+export function submitAutomaticFeedback( sessionId, failure ) {
+	const failureReason = failure?.reason || failure?.exitReason || 'job_error';
+	const eventKey = `${ sessionId }:${ failure?.eventId || failureReason }`;
+	if ( pendingReports.has( eventKey ) ) {
+		return pendingReports.get( eventKey );
+	}
+
+	const reason = String( failureReason ).replace( /[_-]+/g, ' ' );
+	const request = apiFetch( {
+		path: '/sd-ai-agent/v1/feedback/send',
+		method: 'POST',
+		data: {
+			report_type: 'self_reported',
+			user_description: `Automatically detected after the agent finished: ${ reason }.`,
+			session_id: sessionId,
+			strip_tool_results: false,
+		},
+	} ).finally( () => pendingReports.delete( eventKey ) );
+
+	pendingReports.set( eventKey, request );
+	return request;
+}


### PR DESCRIPTION
## Summary
- detect explicit tool and runtime failures when an agent job reaches a terminal state
- show a post-job prompt with **No**, **No, never**, **Yes**, and **Yes, always** choices
- retain automatic-reporting preferences per WordPress user and deduplicate submissions across chat surfaces
- send reports through the existing sanitized feedback endpoint while preserving manual thumbs-down reporting
- document the responsive warning-surface pattern in `DESIGN.md`

## Verification
- Focused JavaScript: 3 suites, 18 tests passed
- `pnpm run verify`: passed

## Worker self-verification
- PHPUnit: Tests: 4343, Assertions: 19975, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Notes
- A separate full JavaScript run surfaced existing failures in `src/store/__tests__/index.test.js` (`select.getSessions` is absent from that test's selector mock) and `src/components/chat-redesign/__tests__/customer-simple-mode.test.js` (`combineReducers` is absent from its `@wordpress/data` mock). The three affected feature suites pass.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.5 spent 8h 38m and 540,067 tokens on this with the user in an interactive session.