### PR TITLE
GH#2648: add abuse-resistant public embed speech

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -299,6 +299,13 @@ Base unit: **4px**
 - Populate voice and speed controls from authenticated speech capabilities. Browser speech fallback remains disabled unless the current user explicitly enables it.
 - Preserve responsive parity: status copy may wrap above the composer, while icon controls retain the mobile touch-target rules and visible keyboard focus used by other chat actions.
 
+**Public static embed:**
+- Public speech is a separate site opt-in and uses raw dependency-free controls rather than WordPress components. Keep typed chat unchanged when it is off or unavailable.
+- Show the configured disclosure and an explicit acknowledgement before revealing push-to-talk or voice-mode controls. Never prompt for microphone access during script load, configuration, session creation, or restored preferences.
+- Push-to-talk, read-aloud/stop, and optional voice mode use clear text labels, pressed states, visible focus, and the shared Listening, Transcribing, Thinking, Speaking, and fallback status region.
+- Voice mode may auto-submit a completed transcript and auto-play only its associated assistant reply. Playback returns to idle; a new recording always requires a fresh keyboard or pointer gesture.
+- Closing or hiding the embed stops capture/playback, aborts public chat and speech requests, clears timers, and revokes object URLs. Do not retain audio or standalone transcripts in browser or WordPress storage.
+
 ### Border Radius Scale
 
 | Size | Value | Use |

--- a/docs/embed-widget.html
+++ b/docs/embed-widget.html
@@ -8,6 +8,7 @@
 	<body>
 		<h1>Static docs chat fixture</h1>
 		<p>This page intentionally runs outside WordPress and must not provide any <code>wp</code> globals.</p>
+		<p>Public speech remains controlled by the WordPress site. When enabled, the widget shows the configured disclosure before any visitor-initiated microphone request; no speech credential or model option is embedded in this page.</p>
 		<script>
 			window.sdAiAgentEmbed = {
 				apiBase: 'https://example.com/wp-json/sd-ai-agent/v1',

--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -20,6 +20,59 @@ The browser contract is configuration only. It does not grant permissions. The
 WordPress site must enable `public_chat_enabled`, configure at least one
 `public_chat_collection_ids` entry, and list each docs origin in
 `public_chat_allowed_origins`; requests from other origins fail before a job is
-created. The widget calls only `/public-chat/config`, `/public-chat/session`,
-`/public-chat/run`, and `/public-chat/job/{id}` with `credentials: 'omit'`, so
-it does not send WordPress cookies or REST nonces from the docs domain.
+created. The widget calls public-chat routes with `credentials: 'omit'`, so it
+does not send WordPress cookies or REST nonces from the docs domain. Session and
+job tokens are opaque, origin- and embed-bound, kept in memory, and sent in
+request bodies or the standard `Authorization: Bearer` header rather than query
+strings.
+
+## Optional public speech
+
+Public speech is separately opt-in. Existing embeds remain text-only until an
+administrator enables `public_chat_speech_enabled`. The operator can also set a
+service voice (`auto` by default), a recording-duration ceiling, a synthesized
+reply character ceiling, a localizable microphone disclosure, and whether the
+explicit voice-conversation toggle is available. Server hard ceilings still
+apply when configured values are higher. Disabling public speech takes effect
+on the next request, including for already-created public chat sessions.
+
+When enabled, the public configuration response exposes only fixed capture and
+output MIME types, bounded numeric limits, labels, disclosure text, and feature
+availability. It does not expose the site credential, service account state,
+model routes, raw capability responses, or unrestricted synthesis options. The
+widget may then call these additional routes:
+
+- `POST /public-chat/speech/transcriptions` with exactly one temporary
+  `recording.wav` part and the active session/embed context.
+- `POST /public-chat/speech/synthesis` with a short-lived, one-use grant issued
+  for the completed assistant reply. The route accepts no caller-provided text,
+  model, voice, URL, file, or custom service options.
+
+The widget shows the configured disclosure before the first microphone prompt
+and never requests capture during script loading, configuration, session
+creation, or preference restoration. Push-to-talk is the default. Optional
+voice-conversation mode auto-submits the completed transcript and reads its
+associated reply, then returns to idle; each new recording still requires a
+fresh visitor gesture. Typed chat remains available if speech is unsupported,
+denied, disabled, rate-limited, exhausted, or temporarily unavailable.
+
+Browser capture requires `navigator.mediaDevices.getUserMedia`, `MediaRecorder`,
+and `AudioContext` support for one advertised capture format. The configured
+embed locale is tried first, then `navigator.language`, then managed automatic
+detection. A normalized detected language becomes the ephemeral speech hint for
+later turns in that session.
+
+Public speech uses stricter request frequency, per-session concurrency,
+site-wide concurrency, byte, duration, character, and daily/session usage
+budgets than authenticated speech. Source and synthesized audio are temporary:
+they are not added to WordPress uploads or the Media Library and are not stored
+in chat rows, options, analytics, feedback, browser storage, or service-worker
+caches. Only text that is subsequently submitted through normal public chat can
+follow the existing optional conversation-review retention policy. Closing the
+widget or leaving/hiding the page aborts active requests, stops media tracks and
+playback, clears timers, and revokes object URLs.
+
+Operators can attach a metrics sink to the
+`sd_ai_agent_public_speech_metric` action. Its fixed envelope contains only the
+operation, outcome/status category, and latency/byte/duration buckets—never
+audio, transcripts, tokens, origins, addresses, user agents, or session IDs.

--- a/docs/frontend-widget-capabilities.md
+++ b/docs/frontend-widget-capabilities.md
@@ -6,6 +6,30 @@ The widget can start a chat from a public page, but tool execution still passes
 through the same per-tool capability layer and core-capability layer used by the
 admin chat UI.
 
+## Public static embed boundary
+
+The static docs embed is intentionally separate from the authenticated frontend
+widget. It sends no WordPress cookies and receives no WordPress REST nonce or
+managed-service credential. Public chat and public speech are independently
+disabled by default. Every speech request must pass the configured origin,
+embed ID, active opaque session token, speech-specific rate/concurrency limits,
+and per-session/site spend budgets before managed service work begins.
+
+Anonymous transcription accepts only one strict temporary PCM WAV under the
+configured byte and duration ceilings. It creates no attachment and stores no
+audio or standalone transcript. Anonymous synthesis accepts no text; the server
+resolves a short-lived one-use grant bound to the completed assistant reply,
+session, embed, origin, voice, locale, and text hash. The client receives only
+bounded inline audio. Public job polling carries the session token in the
+standard `Authorization: Bearer` header, never the URL.
+
+The embed keeps speech progressive: disclosure precedes the first microphone
+prompt, capture starts only from a visitor gesture, typed chat remains usable on
+every speech failure, and close/page-hide cleanup aborts requests and releases
+tracks, timers, playback, and object URLs. Voice-conversation mode may auto-send
+and auto-read one turn but never reopens the microphone without another gesture.
+See `docs/embed-widget.md` for the operator contract and retention details.
+
 ## Recommendation
 
 The frontend widget should require `RolePermissions::current_user_has_chat_access()`

--- a/includes/Abilities/PublicChatSetupAbilities.php
+++ b/includes/Abilities/PublicChatSetupAbilities.php
@@ -42,52 +42,77 @@ class PublicChatSetupAbilities {
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
-						'action'             => array(
+						'action'                       => array(
 							'type'        => 'string',
 							'description' => 'Action to perform: status, configure, disable, or snippet.',
 							'enum'        => array( 'status', 'configure', 'disable', 'snippet' ),
 						),
-						'enabled'            => array(
+						'enabled'                      => array(
 							'type'        => 'boolean',
 							'description' => 'Whether public chat should be enabled during configure. Defaults to the currently saved state when omitted.',
 						),
-						'origins'            => array(
+						'origins'                      => array(
 							'type'        => 'array',
 							'description' => 'Allowed public docs/front-end origins such as https://docs.example.com. Empty means same-origin only.',
 							'items'       => array( 'type' => 'string' ),
 						),
-						'collection_slugs'   => array(
+						'collection_slugs'             => array(
 							'type'        => 'array',
 							'description' => 'Existing knowledge collection slugs allowed for anonymous docs answers.',
 							'items'       => array( 'type' => 'string' ),
 						),
-						'provider_id'        => array(
+						'provider_id'                  => array(
 							'type'        => 'string',
 							'description' => 'Optional provider ID to force for public chat. Omit to use the saved public/default provider.',
 						),
-						'model_id'           => array(
+						'model_id'                     => array(
 							'type'        => 'string',
 							'description' => 'Optional model ID to force for public chat. Omit to use the saved public/default model.',
 						),
-						'agent_id'           => array(
+						'agent_id'                     => array(
 							'type'        => 'integer',
 							'description' => 'Optional fixed public agent ID. Defaults to the saved value or 0.',
 						),
-						'embed_id'           => array(
+						'embed_id'                     => array(
 							'type'        => 'string',
 							'description' => 'Public embed identifier. Defaults to docs.',
 						),
-						'rate_limit_per_min' => array(
+						'rate_limit_per_min'           => array(
 							'type'        => 'integer',
 							'description' => 'Per-session/IP public message limit per minute, 1–60.',
 						),
-						'message_max_length' => array(
+						'message_max_length'           => array(
 							'type'        => 'integer',
 							'description' => 'Maximum customer message length, 1–8000 characters.',
 						),
-						'max_iterations'     => array(
+						'max_iterations'               => array(
 							'type'        => 'integer',
 							'description' => 'Maximum tool-calling iterations for public chat, 1–8.',
+						),
+						'speech_enabled'               => array(
+							'type'        => 'boolean',
+							'description' => 'Whether bounded public embed speech is enabled. Defaults to false.',
+						),
+						'speech_voice'                 => array(
+							'type'        => 'string',
+							'description' => 'Server-selected managed voice ID, or auto.',
+							'enum'        => array( 'auto', 'alloy' ),
+						),
+						'speech_max_recording_seconds' => array(
+							'type'        => 'integer',
+							'description' => 'Maximum visitor recording duration, 1–60 seconds.',
+						),
+						'speech_max_tts_characters'    => array(
+							'type'        => 'integer',
+							'description' => 'Maximum associated assistant-response characters read aloud, 1–1000.',
+						),
+						'speech_voice_mode_enabled'    => array(
+							'type'        => 'boolean',
+							'description' => 'Whether visitors may explicitly enable turn-based voice conversation mode.',
+						),
+						'speech_disclosure'            => array(
+							'type'        => 'string',
+							'description' => 'Localizable microphone disclosure shown before the first permission request.',
 						),
 					),
 					'required'   => array( 'action' ),
@@ -223,14 +248,30 @@ class PublicChatSetupAbilities {
 		}
 
 		$int_fields = array(
-			'rate_limit_per_min' => array( 'public_chat_rate_limit_per_min', 1, 60 ),
-			'message_max_length' => array( 'public_chat_message_max_length', 1, 8000 ),
-			'max_iterations'     => array( 'public_chat_max_iterations', 1, 8 ),
+			'rate_limit_per_min'           => array( 'public_chat_rate_limit_per_min', 1, 60 ),
+			'message_max_length'           => array( 'public_chat_message_max_length', 1, 8000 ),
+			'max_iterations'               => array( 'public_chat_max_iterations', 1, 8 ),
+			'speech_max_recording_seconds' => array( 'public_chat_speech_max_recording_seconds', 1, 60 ),
+			'speech_max_tts_characters'    => array( 'public_chat_speech_max_tts_characters', 1, 1000 ),
 		);
 		foreach ( $int_fields as $input_key => $spec ) {
 			if ( array_key_exists( $input_key, $input ) ) {
 				$updates[ $spec[0] ] = max( (int) $spec[1], min( (int) $spec[2], (int) $input[ $input_key ] ) );
 			}
+		}
+
+		foreach ( array( 'speech_enabled', 'speech_voice_mode_enabled' ) as $boolean_key ) {
+			if ( array_key_exists( $boolean_key, $input ) ) {
+				$updates[ 'public_chat_' . $boolean_key ] = (bool) $input[ $boolean_key ];
+			}
+		}
+		if ( array_key_exists( 'speech_voice', $input ) ) {
+			$voice                               = sanitize_key( (string) $input['speech_voice'] );
+			$updates['public_chat_speech_voice'] = in_array( $voice, array( 'auto', 'alloy' ), true ) ? $voice : 'auto';
+		}
+		if ( array_key_exists( 'speech_disclosure', $input ) ) {
+			$disclosure                               = sanitize_textarea_field( (string) $input['speech_disclosure'] );
+			$updates['public_chat_speech_disclosure'] = function_exists( 'mb_substr' ) ? mb_substr( $disclosure, 0, 500 ) : substr( $disclosure, 0, 500 );
 		}
 
 		$settings->update( $updates );
@@ -270,17 +311,23 @@ class PublicChatSetupAbilities {
 		$all = $settings->get();
 
 		return array(
-			'public_chat_enabled'            => (bool) ( $all['public_chat_enabled'] ?? false ),
-			'public_chat_embed_id'           => sanitize_key( (string) ( $all['public_chat_embed_id'] ?? 'docs' ) ),
-			'public_chat_allowed_origins'    => self::sanitize_string_list( $all['public_chat_allowed_origins'] ?? array(), 'sanitize_text_field' ),
-			'public_chat_provider_id'        => sanitize_text_field( (string) ( $all['public_chat_provider_id'] ?? '' ) ),
-			'public_chat_model_id'           => sanitize_text_field( (string) ( $all['public_chat_model_id'] ?? '' ) ),
-			'public_chat_agent_id'           => absint( $all['public_chat_agent_id'] ?? 0 ),
-			'public_chat_collection_ids'     => self::sanitize_string_list( $all['public_chat_collection_ids'] ?? array(), 'sanitize_key' ),
-			'public_chat_allowed_abilities'  => self::sanitize_string_list( $all['public_chat_allowed_abilities'] ?? self::SAFE_PUBLIC_ABILITIES, 'sanitize_text_field' ),
-			'public_chat_max_iterations'     => max( 1, min( 8, (int) ( $all['public_chat_max_iterations'] ?? 4 ) ) ),
-			'public_chat_message_max_length' => max( 1, min( 8000, (int) ( $all['public_chat_message_max_length'] ?? 2000 ) ) ),
-			'public_chat_rate_limit_per_min' => max( 1, min( 60, (int) ( $all['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
+			'public_chat_enabled'                      => (bool) ( $all['public_chat_enabled'] ?? false ),
+			'public_chat_embed_id'                     => sanitize_key( (string) ( $all['public_chat_embed_id'] ?? 'docs' ) ),
+			'public_chat_allowed_origins'              => self::sanitize_string_list( $all['public_chat_allowed_origins'] ?? array(), 'sanitize_text_field' ),
+			'public_chat_provider_id'                  => sanitize_text_field( (string) ( $all['public_chat_provider_id'] ?? '' ) ),
+			'public_chat_model_id'                     => sanitize_text_field( (string) ( $all['public_chat_model_id'] ?? '' ) ),
+			'public_chat_agent_id'                     => absint( $all['public_chat_agent_id'] ?? 0 ),
+			'public_chat_collection_ids'               => self::sanitize_string_list( $all['public_chat_collection_ids'] ?? array(), 'sanitize_key' ),
+			'public_chat_allowed_abilities'            => self::sanitize_string_list( $all['public_chat_allowed_abilities'] ?? self::SAFE_PUBLIC_ABILITIES, 'sanitize_text_field' ),
+			'public_chat_max_iterations'               => max( 1, min( 8, (int) ( $all['public_chat_max_iterations'] ?? 4 ) ) ),
+			'public_chat_message_max_length'           => max( 1, min( 8000, (int) ( $all['public_chat_message_max_length'] ?? 2000 ) ) ),
+			'public_chat_rate_limit_per_min'           => max( 1, min( 60, (int) ( $all['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
+			'public_chat_speech_enabled'               => (bool) ( $all['public_chat_speech_enabled'] ?? false ),
+			'public_chat_speech_voice'                 => sanitize_key( (string) ( $all['public_chat_speech_voice'] ?? 'auto' ) ),
+			'public_chat_speech_max_recording_seconds' => max( 1, min( 60, (int) ( $all['public_chat_speech_max_recording_seconds'] ?? 30 ) ) ),
+			'public_chat_speech_max_tts_characters'    => max( 1, min( 1000, (int) ( $all['public_chat_speech_max_tts_characters'] ?? 1000 ) ) ),
+			'public_chat_speech_voice_mode_enabled'    => (bool) ( $all['public_chat_speech_voice_mode_enabled'] ?? false ),
+			'public_chat_speech_disclosure'            => sanitize_textarea_field( (string) ( $all['public_chat_speech_disclosure'] ?? '' ) ),
 		);
 	}
 
@@ -313,6 +360,8 @@ class PublicChatSetupAbilities {
 			'uses_public_token_flow'       => true,
 			'uses_customer_simple_ui'      => true,
 			'sends_credentials_from_embed' => false,
+			'public_speech_opt_in'         => ! empty( $public_settings['public_chat_speech_enabled'] ),
+			'public_speech_session_bound'  => true,
 		);
 	}
 
@@ -351,6 +400,9 @@ class PublicChatSetupAbilities {
 		if ( self::SAFE_PUBLIC_ABILITIES !== ( $public_settings['public_chat_allowed_abilities'] ?? array() ) ) {
 			$warnings[] = __( 'The setup tool forces the anonymous ability allowlist back to knowledge-search only.', 'superdav-ai-agent' );
 		}
+		if ( ! empty( $public_settings['public_chat_speech_voice_mode_enabled'] ) && empty( $public_settings['public_chat_speech_enabled'] ) ) {
+			$warnings[] = __( 'Voice conversation mode is configured but public speech remains disabled.', 'superdav-ai-agent' );
+		}
 
 		return $warnings;
 	}
@@ -372,6 +424,10 @@ class PublicChatSetupAbilities {
 		$steps[] = __( 'Build the plugin assets with pnpm run build and copy build/embed-widget.js plus build/style-embed-widget.css to the docs site.', 'superdav-ai-agent' );
 		$steps[] = __( 'Embed the returned snippet on the customer/docs frontend.', 'superdav-ai-agent' );
 		$steps[] = __( 'Run a logged-out browser smoke test with a real docs question and confirm only public-chat endpoints are called.', 'superdav-ai-agent' );
+		if ( ! empty( $public_settings['public_chat_speech_enabled'] ) ) {
+			$steps[] = __( 'Confirm the microphone disclosure appears before the browser permission prompt, then verify one bounded transcription and one granted assistant playback.', 'superdav-ai-agent' );
+			$steps[] = __( 'Verify arbitrary synthesis text, replayed grants, extra uploads, and non-allowlisted origins are rejected before managed service spend.', 'superdav-ai-agent' );
+		}
 
 		if ( ! empty( $public_settings['public_chat_allowed_origins'] ) ) {
 			$steps[] = __( 'Verify a non-allowlisted Origin receives sd_ai_agent_public_chat_origin_forbidden from /public-chat/session.', 'superdav-ai-agent' );

--- a/includes/Core/PublicChatSecurity.php
+++ b/includes/Core/PublicChatSecurity.php
@@ -1,0 +1,704 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextToSpeechConversionModel;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTranscriptionClient;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared authorization and abuse controls for anonymous public chat traffic.
+ */
+final class PublicChatSecurity {
+
+	public const SESSION_TTL = DAY_IN_SECONDS;
+
+	private const TOKEN_PURPOSE                   = 'public_chat_session_v2';
+	private const SYNTHESIS_GRANT_PURPOSE         = 'public_chat_synthesis_v1';
+	private const SYNTHESIS_GRANT_TTL             = 2 * MINUTE_IN_SECONDS;
+	private const SPEECH_RATE_LIMIT_PER_MINUTE    = 4;
+	private const SPEECH_SITE_CONCURRENCY         = 3;
+	private const SPEECH_SESSION_SECONDS_BUDGET   = 300;
+	private const SPEECH_SITE_SECONDS_BUDGET      = 36000;
+	private const SPEECH_SESSION_CHARACTER_BUDGET = 10000;
+	private const SPEECH_SITE_CHARACTER_BUDGET    = 500000;
+
+	private Settings $settings;
+	private SpeechLocaleResolver $locale_resolver;
+
+	public function __construct( ?Settings $settings = null, ?SpeechLocaleResolver $locale_resolver = null ) {
+		$this->settings        = $settings ?? Settings::instance();
+		$this->locale_resolver = $locale_resolver ?? new SpeechLocaleResolver();
+	}
+
+	/**
+	 * Return the complete server-side public-chat policy with bounded speech settings.
+	 *
+	 * @return array{
+	 *     enabled:bool,
+	 *     origins:list<string>,
+	 *     provider_id:string,
+	 *     model_id:string,
+	 *     agent_id:int,
+	 *     embed_id:string,
+	 *     collections:list<string>,
+	 *     abilities:list<string>,
+	 *     iterations:int,
+	 *     message_length:int,
+	 *     rate_limit:int,
+	 *     review_recording_enabled:bool,
+	 *     review_retention_days:int,
+	 *     review_disclosure:string,
+	 *     speech_enabled:bool,
+	 *     speech_voice:string,
+	 *     speech_max_recording_seconds:int,
+	 *     speech_max_audio_bytes:int,
+	 *     speech_max_tts_characters:int,
+	 *     speech_voice_mode_enabled:bool,
+	 *     speech_disclosure:string
+	 * }
+	 */
+	public function settings(): array {
+		$settings = $this->settings->get();
+		$allowed  = $settings['public_chat_allowed_abilities'] ?? array( 'sd-ai-agent/knowledge-search' );
+		$allowed  = is_array( $allowed ) ? $this->sanitize_string_list( $allowed, 'sanitize_text_field' ) : array();
+
+		$collections = $settings['public_chat_collection_ids'] ?? array();
+		$collections = is_array( $collections ) ? $this->sanitize_string_list( $collections, 'sanitize_key' ) : array();
+
+		$origins = $settings['public_chat_allowed_origins'] ?? array();
+		$origins = is_array( $origins ) ? $this->sanitize_string_list( $origins, 'sanitize_text_field' ) : array();
+
+		$review_retention_days = max( 1, min( 90, (int) ( $settings['public_chat_review_retention_days'] ?? 7 ) ) );
+		$review_disclosure     = sanitize_textarea_field( (string) ( $settings['public_chat_review_disclosure'] ?? '' ) );
+		if ( '' === $review_disclosure ) {
+			$review_disclosure = sprintf(
+				/* translators: %d: maximum number of days an opted-in anonymous chat is retained. */
+				__( 'This conversation may be recorded for quality review and retained for up to %d days.', 'superdav-ai-agent' ),
+				$review_retention_days
+			);
+		}
+
+		$speech_disclosure = sanitize_textarea_field( (string) ( $settings['public_chat_speech_disclosure'] ?? '' ) );
+		if ( '' === $speech_disclosure ) {
+			$speech_disclosure = __( 'Microphone audio is sent to this site’s managed AI service for transcription and is not retained as audio.', 'superdav-ai-agent' );
+		}
+
+		$voice = sanitize_key( (string) ( $settings['public_chat_speech_voice'] ?? 'auto' ) );
+		if ( 'auto' !== $voice && ! in_array( $voice, SuperdavAiTextToSpeechConversionModel::SUPPORTED_VOICES, true ) ) {
+			$voice = 'auto';
+		}
+
+		$max_recording_seconds = max(
+			1,
+			min(
+				60,
+				SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS,
+				(int) ( $settings['public_chat_speech_max_recording_seconds'] ?? 30 )
+			)
+		);
+		$max_tts_characters    = max(
+			1,
+			min(
+				1000,
+				(int) ( $settings['public_chat_speech_max_tts_characters'] ?? 1000 )
+			)
+		);
+
+		return array(
+			'enabled'                      => (bool) ( $settings['public_chat_enabled'] ?? false ),
+			'origins'                      => $origins,
+			'provider_id'                  => sanitize_text_field( (string) ( $settings['public_chat_provider_id'] ?? '' ) ),
+			'model_id'                     => sanitize_text_field( (string) ( $settings['public_chat_model_id'] ?? '' ) ),
+			'agent_id'                     => absint( $settings['public_chat_agent_id'] ?? 0 ),
+			'embed_id'                     => sanitize_key( (string) ( $settings['public_chat_embed_id'] ?? 'docs' ) ),
+			'collections'                  => $collections,
+			'abilities'                    => $allowed,
+			'iterations'                   => max( 1, min( 8, (int) ( $settings['public_chat_max_iterations'] ?? 4 ) ) ),
+			'message_length'               => max( 1, min( 8000, (int) ( $settings['public_chat_message_max_length'] ?? 2000 ) ) ),
+			'rate_limit'                   => max( 1, min( 60, (int) ( $settings['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
+			'review_recording_enabled'     => (bool) ( $settings['public_chat_review_recording_enabled'] ?? false ),
+			'review_retention_days'        => $review_retention_days,
+			'review_disclosure'            => $review_disclosure,
+			'speech_enabled'               => (bool) ( $settings['public_chat_speech_enabled'] ?? false ),
+			'speech_voice'                 => $voice,
+			'speech_max_recording_seconds' => $max_recording_seconds,
+			'speech_max_audio_bytes'       => min( SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES, 44 + ( $max_recording_seconds * 32000 ) ),
+			'speech_max_tts_characters'    => $max_tts_characters,
+			'speech_voice_mode_enabled'    => (bool) ( $settings['public_chat_speech_voice_mode_enabled'] ?? false ),
+			'speech_disclosure'            => $speech_disclosure,
+		);
+	}
+
+	/** Validate public chat, optional speech, and the request origin. */
+	public function check_available( WP_REST_Request $request, bool $require_speech = false ): true|WP_Error {
+		$config = $this->settings();
+		if ( empty( $config['enabled'] ) ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_disabled', __( 'Public chat is not enabled.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
+		}
+		if ( empty( $config['collections'] ) ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_unconfigured', __( 'Public chat has no documentation collection configured.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+		if ( $require_speech && empty( $config['speech_enabled'] ) ) {
+			return new WP_Error( 'sd_ai_agent_public_speech_disabled', __( 'Public speech is not enabled.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
+		}
+
+		$origin = $this->request_origin( $request );
+		if ( ! $this->origin_is_allowed( $origin, $config['origins'] ) ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_origin_forbidden', __( 'This origin is not allowed to use public chat.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+
+		return true;
+	}
+
+	/** Resolve the public-chat request origin or referer. */
+	public function request_origin( WP_REST_Request $request ): string {
+		$origin = (string) $request->get_header( 'origin' );
+		if ( '' === $origin ) {
+			$origin = (string) $request->get_header( 'referer' );
+		}
+
+		return $origin;
+	}
+
+	/** Return an opaque stable binding for one normalized origin. */
+	public function origin_binding( string $origin ): string {
+		return $this->origin_hash( $origin );
+	}
+
+	/**
+	 * Add public CORS headers only for an allowlisted request origin.
+	 *
+	 * @param WP_REST_Response $response        REST response.
+	 * @param string           $origin          Request origin.
+	 * @param list<string>     $allowed_origins Configured origin allowlist.
+	 */
+	// phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is a PHPStan type.
+	public function add_cors( WP_REST_Response $response, string $origin, array $allowed_origins ): WP_REST_Response {
+		if ( $this->origin_is_allowed( $origin, $allowed_origins ) ) {
+			$response->header( 'Access-Control-Allow-Origin', $origin );
+			$response->header( 'Access-Control-Allow-Credentials', 'false' );
+			$response->header( 'Vary', 'Origin' );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Check a request origin against the configured public allowlist.
+	 *
+	 * @param string       $origin          Request origin.
+	 * @param list<string> $allowed_origins Configured origin allowlist.
+	 */
+	// phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is a PHPStan type.
+	public function origin_is_allowed( string $origin, array $allowed_origins ): bool {
+		if ( '' === $origin ) {
+			return empty( $allowed_origins );
+		}
+
+		$origin_host = wp_parse_url( $origin, PHP_URL_HOST );
+		$origin_host = is_string( $origin_host ) ? strtolower( $origin_host ) : '';
+		if ( '' === $origin_host ) {
+			return false;
+		}
+		if ( empty( $allowed_origins ) ) {
+			$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+			return is_string( $home_host ) && strtolower( $home_host ) === $origin_host;
+		}
+
+		foreach ( $allowed_origins as $allowed ) {
+			$allowed_host = wp_parse_url( (string) $allowed, PHP_URL_HOST );
+			$allowed_host = is_string( $allowed_host ) ? strtolower( $allowed_host ) : strtolower( (string) $allowed );
+			if ( $origin_host === $allowed_host ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** Create a signed token bound to the configured embed and request origin. */
+	public function create_token( string $session_uuid, string $embed_id, string $origin ): string {
+		$payload = wp_json_encode(
+			array(
+				'sid' => $session_uuid,
+				'eid' => $embed_id,
+				'org' => $this->origin_hash( $origin ),
+				'exp' => time() + self::SESSION_TTL,
+			)
+		);
+		$payload = false === $payload ? '{}' : $payload;
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- URL-safe HMAC token encoding.
+		$body = rtrim( strtr( base64_encode( $payload ), '+/', '-_' ), '=' );
+		$sig  = hash_hmac( 'sha256', self::TOKEN_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
+
+		return $body . '.' . $sig;
+	}
+
+	/** @return array{sid:string,eid:string,org:string,exp:int}|WP_Error */
+	public function parse_token( string $token ): array|WP_Error {
+		$parts = explode( '.', $token, 2 );
+		if ( 2 !== count( $parts ) ) {
+			return $this->invalid_token_error();
+		}
+
+		[ $body, $sig ] = $parts;
+		$expected       = hash_hmac( 'sha256', self::TOKEN_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
+		if ( ! hash_equals( $expected, $sig ) ) {
+			return $this->invalid_token_error();
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes a verified URL-safe token payload.
+		$decoded = base64_decode( strtr( $body, '-_', '+/' ), true );
+		$data    = is_string( $decoded ) ? json_decode( $decoded, true ) : null;
+		if ( ! is_array( $data ) || ! is_string( $data['sid'] ?? null ) || ! is_string( $data['eid'] ?? null )
+			|| ! is_string( $data['org'] ?? null ) || empty( $data['exp'] ) || (int) $data['exp'] < time()
+		) {
+			return $this->invalid_token_error();
+		}
+
+		return array(
+			'sid' => sanitize_key( $data['sid'] ),
+			'eid' => sanitize_key( $data['eid'] ),
+			'org' => sanitize_text_field( $data['org'] ),
+			'exp' => (int) $data['exp'],
+		);
+	}
+
+	/** Public session transient key. */
+	public function session_key( string $session_uuid ): string {
+		return 'sd_ai_agent_public_chat_' . md5( $session_uuid );
+	}
+
+	/**
+	 * Resolve an active token/session and enforce its embed and origin bindings.
+	 *
+	 * @return array{session_uuid:string,session:array<int|string,mixed>,origin:string,token_hash:string}|WP_Error
+	 */
+	public function authorize_session( WP_REST_Request $request, string $token, string $embed_id = '', bool $require_speech = false ): array|WP_Error {
+		$available = $this->check_available( $request, $require_speech );
+		if ( true !== $available ) {
+			return $available;
+		}
+
+		$config = $this->settings();
+		$parsed = $this->parse_token( $token );
+		if ( $parsed instanceof WP_Error ) {
+			return $parsed;
+		}
+
+		$origin  = $this->request_origin( $request );
+		$session = get_transient( $this->session_key( $parsed['sid'] ) );
+		if ( ! is_array( $session ) ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_session_expired', __( 'Public chat session expired.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+
+		$configured_embed = (string) $config['embed_id'];
+		$session_embed    = isset( $session['embed_id'] ) && is_string( $session['embed_id'] ) ? $session['embed_id'] : '';
+		$session_origin   = isset( $session['origin_hash'] ) && is_string( $session['origin_hash'] ) ? $session['origin_hash'] : '';
+		if ( '' === $configured_embed || $parsed['eid'] !== $configured_embed || $session_embed !== $configured_embed
+			|| ( '' !== $embed_id && $embed_id !== $configured_embed )
+			|| ! hash_equals( $parsed['org'], $this->origin_hash( $origin ) )
+			|| ! hash_equals( $session_origin, $this->origin_hash( $origin ) )
+		) {
+			return $this->invalid_token_error();
+		}
+
+		return array(
+			'session_uuid' => $parsed['sid'],
+			'session'      => $session,
+			'origin'       => $origin,
+			'token_hash'   => hash( 'sha256', $token ),
+		);
+	}
+
+	/** Consume a scoped per-session/IP operation token. */
+	public function check_rate_limit( string $session_uuid, int $limit, string $scope = 'chat' ): true|WP_Error {
+		$ip  = sanitize_text_field( wp_unslash( (string) ( $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0' ) ) );
+		$key = 'sd_ai_agent_public_' . sanitize_key( $scope ) . '_rate_' . md5( $session_uuid . '|' . $ip . '|' . gmdate( 'YmdHi' ) );
+		$hit = (int) get_transient( $key );
+		if ( $hit >= $limit ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_rate_limited', __( 'Too many public requests. Please wait before trying again.', 'superdav-ai-agent' ), array( 'status' => 429 ) );
+		}
+
+		set_transient( $key, $hit + 1, MINUTE_IN_SECONDS + 5 );
+		return true;
+	}
+
+	/** Consume the stricter speech-specific request rate. */
+	public function check_speech_rate_limit( string $session_uuid ): true|WP_Error {
+		return $this->check_rate_limit( $session_uuid, self::SPEECH_RATE_LIMIT_PER_MINUTE, 'speech' );
+	}
+
+	/**
+	 * Acquire one per-session and one bounded site-wide speech execution slot.
+	 *
+	 * @return array{owner:string,keys:list<string>}|WP_Error
+	 */
+	public function acquire_speech_lock( string $session_uuid ): array|WP_Error {
+		$owner       = wp_generate_uuid4();
+		$expires_at  = time() + 60;
+		$session_key = 'sd_ai_agent_public_speech_lock_' . md5( $session_uuid );
+		if ( ! $this->acquire_option_lock( $session_key, $owner, $expires_at ) ) {
+			return $this->speech_busy_error();
+		}
+
+		for ( $slot = 0; $slot < self::SPEECH_SITE_CONCURRENCY; ++$slot ) {
+			$site_key = 'sd_ai_agent_public_speech_site_lock_' . $slot;
+			if ( $this->acquire_option_lock( $site_key, $owner, $expires_at ) ) {
+				return array(
+					'owner' => $owner,
+					'keys'  => array( $session_key, $site_key ),
+				);
+			}
+		}
+
+		$this->release_option_lock( $session_key, $owner );
+		return $this->speech_busy_error();
+	}
+
+	/** @param array{owner:string,keys:list<string>} $lock */
+	public function release_speech_lock( array $lock ): void {
+		foreach ( $lock['keys'] as $key ) {
+			$this->release_option_lock( $key, $lock['owner'] );
+		}
+	}
+
+	/** Reserve bounded anonymous speech units before upstream spend. */
+	public function consume_speech_budget( string $session_uuid, string $operation, int $units ): true|WP_Error {
+		$is_transcription = 'transcription' === $operation;
+		$session_limit    = $is_transcription ? self::SPEECH_SESSION_SECONDS_BUDGET : self::SPEECH_SESSION_CHARACTER_BUDGET;
+		$site_limit       = $is_transcription ? self::SPEECH_SITE_SECONDS_BUDGET : self::SPEECH_SITE_CHARACTER_BUDGET;
+		$unit_key         = $is_transcription ? 'seconds' : 'characters';
+		$session_key      = 'sd_ai_agent_public_speech_' . $unit_key . '_' . md5( $session_uuid );
+		$site_key         = 'sd_ai_agent_public_speech_site_' . $unit_key . '_' . gmdate( 'Ymd' );
+		$session_used     = (int) get_transient( $session_key );
+		$site_used        = (int) get_transient( $site_key );
+
+		if ( $units < 1 || $session_used + $units > $session_limit || $site_used + $units > $site_limit ) {
+			return new WP_Error( 'sd_ai_agent_public_speech_limit_exceeded', __( 'The public speech limit was reached. Please continue with typed chat.', 'superdav-ai-agent' ), array( 'status' => 429 ) );
+		}
+
+		set_transient( $session_key, $session_used + $units, self::SESSION_TTL );
+		set_transient( $site_key, $site_used + $units, DAY_IN_SECONDS + HOUR_IN_SECONDS );
+		return true;
+	}
+
+	/** Save a normalized detected language as an ephemeral session hint. */
+	public function update_session_language( string $session_uuid, mixed $language ): void {
+		$language = is_string( $language ) ? $this->locale_resolver->normalize_client_locale( $language ) : null;
+		if ( null === $language ) {
+			return;
+		}
+
+		$key     = $this->session_key( $session_uuid );
+		$session = get_transient( $key );
+		if ( ! is_array( $session ) ) {
+			return;
+		}
+		$session['speech_locale'] = $language;
+		set_transient( $key, $session, self::SESSION_TTL );
+	}
+
+	/** Normalize an optional public client locale. */
+	public function normalize_locale( mixed $locale ): string|null|WP_Error {
+		if ( null === $locale || '' === $locale ) {
+			return null;
+		}
+		if ( ! is_string( $locale ) ) {
+			return $this->invalid_language_error();
+		}
+
+		$normalized = $this->locale_resolver->normalize_client_locale( $locale );
+		return null !== $normalized ? $normalized : $this->invalid_language_error();
+	}
+
+	/**
+	 * Emit content-free public speech telemetry for an operator-provided sink.
+	 *
+	 * @param string $operation        Availability, transcription, or synthesis.
+	 * @param string $outcome          Fixed success or failure category.
+	 * @param int    $status_code      HTTP-style result status.
+	 * @param float  $started_at       Request start from microtime(true).
+	 * @param int    $audio_bytes      Validated recording bytes, when known.
+	 * @param float  $duration_seconds Validated recording duration, when known.
+	 */
+	public function record_speech_metric( string $operation, string $outcome, int $status_code, float $started_at, int $audio_bytes = 0, float $duration_seconds = 0.0 ): void {
+		$operations = array( 'availability', 'transcription', 'synthesis' );
+		$outcomes   = array( 'available', 'unavailable', 'success', 'permission_denied', 'limit_denied', 'validation_failed', 'failed' );
+		$operation  = in_array( $operation, $operations, true ) ? $operation : 'availability';
+		$outcome    = in_array( $outcome, $outcomes, true ) ? $outcome : 'failed';
+		$latency_ms = max( 0, (int) round( ( microtime( true ) - $started_at ) * 1000 ) );
+
+		/**
+		 * Fires content-free public speech metrics for an external metrics sink.
+		 *
+		 * No transcript, audio, token, IP address, origin, user agent, or session
+		 * identifier is included in this deliberately low-cardinality envelope.
+		 *
+		 * @param array<string,int|string> $metric Safe metric dimensions.
+		 */
+		do_action(
+			'sd_ai_agent_public_speech_metric',
+			array(
+				'operation'       => $operation,
+				'outcome'         => $outcome,
+				'status_code'     => max( 0, $status_code ),
+				'latency_bucket'  => $this->latency_bucket( $latency_ms ),
+				'bytes_bucket'    => $this->bytes_bucket( $audio_bytes ),
+				'duration_bucket' => $this->duration_bucket( $duration_seconds ),
+			)
+		);
+	}
+
+	/**
+	 * Issue one short-lived grant for the exact completed assistant reply.
+	 *
+	 * @return array{grant:string,expires_in:int}|null
+	 */
+	public function issue_synthesis_grant( string $session_uuid, string $token, string $origin, string $reply ): ?array {
+		$config = $this->settings();
+		if ( empty( $config['speech_enabled'] ) ) {
+			return null;
+		}
+
+		$session = get_transient( $this->session_key( $session_uuid ) );
+		if ( ! is_array( $session ) || ! hash_equals( (string) ( $session['origin_hash'] ?? '' ), $this->origin_hash( $origin ) ) ) {
+			return null;
+		}
+
+		$text = $this->speakable_excerpt( $reply, (int) $config['speech_max_tts_characters'] );
+		if ( '' === $text ) {
+			return null;
+		}
+
+		$grant_id = wp_generate_uuid4();
+		$expires  = time() + self::SYNTHESIS_GRANT_TTL;
+		$voice    = 'auto' === $config['speech_voice'] ? SuperdavAiTextToSpeechConversionModel::DEFAULT_VOICE : (string) $config['speech_voice'];
+		$language = isset( $session['speech_locale'] ) && is_string( $session['speech_locale'] ) ? $session['speech_locale'] : '';
+		if ( 'en' === $language ) {
+			$language = 'en-US';
+		}
+		if ( ! in_array( $language, SuperdavAiTextToSpeechConversionModel::SUPPORTED_LANGUAGES, true ) ) {
+			$language = '';
+		}
+
+		$state = array(
+			'grant_id'    => $grant_id,
+			'sid'         => $session_uuid,
+			'token_hash'  => hash( 'sha256', $token ),
+			'origin_hash' => $this->origin_hash( $origin ),
+			'embed_id'    => (string) $config['embed_id'],
+			'text'        => $text,
+			'text_hash'   => hash( 'sha256', $text ),
+			'voice'       => $voice,
+			'language'    => $language,
+			'exp'         => $expires,
+		);
+		set_transient( $this->grant_key( $grant_id ), $state, self::SYNTHESIS_GRANT_TTL );
+
+		$payload = wp_json_encode(
+			array(
+				'gid' => $grant_id,
+				'sid' => $session_uuid,
+				'eid' => (string) $config['embed_id'],
+				'org' => $state['origin_hash'],
+				'txt' => $state['text_hash'],
+				'exp' => $expires,
+			)
+		);
+		if ( false === $payload ) {
+			delete_transient( $this->grant_key( $grant_id ) );
+			return null;
+		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- URL-safe HMAC grant encoding.
+		$body = rtrim( strtr( base64_encode( $payload ), '+/', '-_' ), '=' );
+		$sig  = hash_hmac( 'sha256', self::SYNTHESIS_GRANT_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
+
+		return array(
+			'grant'      => $body . '.' . $sig,
+			'expires_in' => self::SYNTHESIS_GRANT_TTL,
+		);
+	}
+
+	/**
+	 * Consume a one-purpose synthesis grant while the caller holds the session lock.
+	 *
+	 * @return array{text:string,voice:string,language:string}|WP_Error
+	 */
+	public function consume_synthesis_grant( string $grant, string $session_uuid, string $token_hash, string $origin, string $embed_id ): array|WP_Error {
+		$parts = explode( '.', $grant, 2 );
+		if ( 2 !== count( $parts ) ) {
+			return $this->invalid_grant_error();
+		}
+		[ $body, $sig ] = $parts;
+		$expected       = hash_hmac( 'sha256', self::SYNTHESIS_GRANT_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
+		if ( ! hash_equals( $expected, $sig ) ) {
+			return $this->invalid_grant_error();
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes a verified URL-safe grant payload.
+		$decoded = base64_decode( strtr( $body, '-_', '+/' ), true );
+		$data    = is_string( $decoded ) ? json_decode( $decoded, true ) : null;
+		if ( ! is_array( $data ) || ! is_string( $data['gid'] ?? null ) || ! is_string( $data['sid'] ?? null )
+			|| ! is_string( $data['eid'] ?? null ) || ! is_string( $data['org'] ?? null ) || ! is_string( $data['txt'] ?? null )
+			|| empty( $data['exp'] ) || (int) $data['exp'] < time()
+		) {
+			return $this->invalid_grant_error();
+		}
+
+		$key   = $this->grant_key( sanitize_key( $data['gid'] ) );
+		$state = get_transient( $key );
+		if ( ! is_array( $state )
+			|| ! hash_equals( (string) $data['sid'], $session_uuid )
+			|| ! hash_equals( (string) $data['eid'], $embed_id )
+			|| ! hash_equals( (string) $data['org'], $this->origin_hash( $origin ) )
+			|| ! hash_equals( (string) $data['txt'], (string) ( $state['text_hash'] ?? '' ) )
+			|| ! hash_equals( $token_hash, (string) ( $state['token_hash'] ?? '' ) )
+			|| (int) ( $state['exp'] ?? 0 ) < time()
+		) {
+			return $this->invalid_grant_error();
+		}
+
+		delete_transient( $key );
+		return array(
+			'text'     => (string) $state['text'],
+			'voice'    => (string) $state['voice'],
+			'language' => (string) $state['language'],
+		);
+	}
+
+	private function acquire_option_lock( string $key, string $owner, int $expires_at ): bool {
+		$value = array(
+			'owner' => $owner,
+			'exp'   => $expires_at,
+		);
+		if ( add_option( $key, $value, '', false ) ) {
+			return true;
+		}
+
+		$current = get_option( $key );
+		if ( is_array( $current ) && (int) ( $current['exp'] ?? 0 ) < time() ) {
+			delete_option( $key );
+			return add_option( $key, $value, '', false );
+		}
+
+		return false;
+	}
+
+	private function release_option_lock( string $key, string $owner ): void {
+		$current = get_option( $key );
+		if ( is_array( $current ) && hash_equals( $owner, (string) ( $current['owner'] ?? '' ) ) ) {
+			delete_option( $key );
+		}
+	}
+
+	private function origin_hash( string $origin ): string {
+		$parts = wp_parse_url( $origin );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return hash( 'sha256', '' );
+		}
+		$normalized = strtolower( (string) $parts['scheme'] ) . '://' . strtolower( (string) $parts['host'] );
+		if ( isset( $parts['port'] ) ) {
+			$normalized .= ':' . absint( $parts['port'] );
+		}
+
+		return hash( 'sha256', $normalized );
+	}
+
+	private function grant_key( string $grant_id ): string {
+		return 'sd_ai_agent_public_speech_grant_' . md5( $grant_id );
+	}
+
+	private function latency_bucket( int $milliseconds ): string {
+		return match ( true ) {
+			$milliseconds < 250 => 'under_250ms',
+			$milliseconds < 1000 => 'under_1s',
+			$milliseconds < 5000 => 'under_5s',
+			default => 'at_least_5s',
+		};
+	}
+
+	private function bytes_bucket( int $bytes ): string {
+		return match ( true ) {
+			$bytes < 1 => 'not_measured',
+			$bytes <= 65536 => 'up_to_64kb',
+			$bytes <= 262144 => 'up_to_256kb',
+			$bytes <= 1048576 => 'up_to_1mb',
+			default => 'over_1mb',
+		};
+	}
+
+	private function duration_bucket( float $seconds ): string {
+		return match ( true ) {
+			$seconds <= 0 => 'not_measured',
+			$seconds <= 5 => 'up_to_5s',
+			$seconds <= 15 => 'up_to_15s',
+			$seconds <= 30 => 'up_to_30s',
+			default => 'over_30s',
+		};
+	}
+
+	private function speakable_excerpt( string $value, int $maximum ): string {
+		$text = preg_replace( '/```[\s\S]*?```/u', '', $value );
+		$text = is_string( $text ) ? preg_replace( '/`([^`\r\n]+)`/u', '$1', $text ) : '';
+		$text = is_string( $text ) ? preg_replace( '/!\[[^\]]*\]\([^)]+\)/u', '', $text ) : '';
+		$text = is_string( $text ) ? preg_replace( '/\[([^\]]+)\]\([^)]+\)/u', '$1', $text ) : '';
+		$text = is_string( $text ) ? preg_replace( '/^[#>*+\-]\s*/mu', '', $text ) : '';
+		$text = is_string( $text ) ? preg_replace( '/\*{1,3}([^*\r\n]+)\*{1,3}/u', '$1', $text ) : '';
+		$text = is_string( $text ) ? preg_replace( '/_{1,3}([^_\r\n]+)_{1,3}/u', '$1', $text ) : '';
+		$text = html_entity_decode( wp_strip_all_tags( strip_shortcodes( is_string( $text ) ? $text : '' ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$text = preg_replace( '/\s+/u', ' ', trim( $text ) );
+		if ( ! is_string( $text ) || '' === $text || 1 !== preg_match( '/[\p{L}\p{N}]/u', $text ) ) {
+			return '';
+		}
+
+		return function_exists( 'mb_substr' ) ? mb_substr( $text, 0, $maximum, 'UTF-8' ) : substr( $text, 0, $maximum );
+	}
+
+	/**
+	 * Sanitize a mixed public settings list.
+	 *
+	 * @param array<int|string,mixed> $values   Candidate values.
+	 * @param callable(string):string $sanitize Sanitizer callback.
+	 * @return list<string>
+	 */
+	private function sanitize_string_list( array $values, callable $sanitize ): array {
+		$clean = array();
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+			$item = $sanitize( (string) $value );
+			if ( '' !== $item ) {
+				$clean[] = $item;
+			}
+		}
+
+		return $clean;
+	}
+
+	private function invalid_token_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_public_chat_invalid_token', __( 'Invalid public chat token.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+	}
+
+	private function invalid_grant_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_public_speech_invalid_grant', __( 'The speech playback grant is invalid or expired.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+	}
+
+	private function invalid_language_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_speech_language', __( 'The speech language is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+
+	private function speech_busy_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_public_speech_busy', __( 'Another speech request is already running. Please continue with typed chat or try again.', 'superdav-ai-agent' ), array( 'status' => 429 ) );
+	}
+}

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -392,82 +392,90 @@ class Settings {
 	 */
 	public function get_defaults(): array {
 		return array(
-			'default_provider'                     => '',
-			'default_model'                        => '',
-			'max_iterations'                       => 100,
-			'greeting_message'                     => '',
-			'system_prompt'                        => '',
-			'auto_memory'                          => true,
-			'tool_permissions'                     => array(),
-			'temperature'                          => 0.2,
+			'default_provider'                         => '',
+			'default_model'                            => '',
+			'max_iterations'                           => 100,
+			'greeting_message'                         => '',
+			'system_prompt'                            => '',
+			'auto_memory'                              => true,
+			'tool_permissions'                         => array(),
+			'temperature'                              => 0.2,
 			// 0 = auto-resolve per model via Settings::get_max_output_tokens_for_model().
 			// A user-saved positive value overrides the per-model default (clamped to
 			// MAX_OUTPUT_TOKENS_CEILING at request time). See AgentLoop::send_prompt().
-			'max_output_tokens'                    => self::MAX_OUTPUT_TOKENS_AUTO,
-			'context_window_default'               => 128000,
-			'onboarding_complete'                  => false,
-			'knowledge_enabled'                    => true,
-			'knowledge_auto_index'                 => true,
-			'max_history_turns'                    => 20,
+			'max_output_tokens'                        => self::MAX_OUTPUT_TOKENS_AUTO,
+			'context_window_default'                   => 128000,
+			'onboarding_complete'                      => false,
+			'knowledge_enabled'                        => true,
+			'knowledge_auto_index'                     => true,
+			'max_history_turns'                        => 20,
 			// Local input guards. The byte limit is enforced against the final
 			// serialized HTTP body; the token limit bounds retained conversation
 			// history before the provider builder runs.
-			'provider_request_max_bytes'           => ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES,
-			'provider_request_max_tokens'          => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
-			'suggestion_count'                     => 3,
-			'yolo_mode'                            => false,
-			'show_tool_call_details'               => false,
-			'show_on_frontend'                     => true,
-			'public_chat_embed_id'                 => 'docs',
-			'keyboard_shortcut'                    => 'alt+a',
+			'provider_request_max_bytes'               => ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES,
+			'provider_request_max_tokens'              => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
+			'suggestion_count'                         => 3,
+			'yolo_mode'                                => false,
+			'show_tool_call_details'                   => false,
+			'show_on_frontend'                         => true,
+			'public_chat_embed_id'                     => 'docs',
+			'keyboard_shortcut'                        => 'alt+a',
 			// Public docs/customer chat is opt-in and uses a server-controlled,
 			// anonymous-safe execution profile. Browser requests cannot override
 			// provider/model/agent/tool choices in this mode.
-			'public_chat_enabled'                  => false,
-			'public_chat_allowed_origins'          => array(),
-			'public_chat_provider_id'              => '',
-			'public_chat_model_id'                 => '',
-			'public_chat_agent_id'                 => 0,
-			'public_chat_collection_ids'           => array(),
-			'public_chat_allowed_abilities'        => array( 'sd-ai-agent/knowledge-search' ),
-			'public_chat_max_iterations'           => 4,
-			'public_chat_message_max_length'       => 2000,
-			'public_chat_rate_limit_per_min'       => 10,
+			'public_chat_enabled'                      => false,
+			'public_chat_allowed_origins'              => array(),
+			'public_chat_provider_id'                  => '',
+			'public_chat_model_id'                     => '',
+			'public_chat_agent_id'                     => 0,
+			'public_chat_collection_ids'               => array(),
+			'public_chat_allowed_abilities'            => array( 'sd-ai-agent/knowledge-search' ),
+			'public_chat_max_iterations'               => 4,
+			'public_chat_message_max_length'           => 2000,
+			'public_chat_rate_limit_per_min'           => 10,
+			// Public speech is separately opt-in and has stricter fixed abuse budgets
+			// in PublicChatSecurity in addition to these operator-facing ceilings.
+			'public_chat_speech_enabled'               => false,
+			'public_chat_speech_voice'                 => 'auto',
+			'public_chat_speech_max_recording_seconds' => 30,
+			'public_chat_speech_max_tts_characters'    => 1000,
+			'public_chat_speech_voice_mode_enabled'    => false,
+			'public_chat_speech_disclosure'            => '',
 			// Anonymous transcript review is a separate, explicit collection choice.
 			// It is disabled by default so existing public embeds never start retaining
 			// visitor content merely because this plugin is upgraded.
-			'public_chat_review_recording_enabled' => false,
-			'public_chat_review_retention_days'    => 7,
-			'public_chat_review_disclosure'        => '',
+			'public_chat_review_recording_enabled'     => false,
+			'public_chat_review_retention_days'        => 7,
+			'public_chat_review_disclosure'            => '',
 			// 0 disables automatic cleanup; positive values retain trashed chats
 			// for that many days before the daily cleanup permanently deletes them.
-			'chat_trash_retention_days'            => 0,
-			'image_generation_size'                => '1024x1024',
-			'image_generation_quality'             => 'standard',
-			'image_generation_style'               => 'vivid',
+			'chat_trash_retention_days'                => 0,
+			'image_generation_size'                    => '1024x1024',
+			'image_generation_quality'                 => 'standard',
+			'image_generation_style'                   => 'vivid',
 			// White-label / branding settings (t075).
-			'agent_name'                           => '',
-			'brand_primary_color'                  => '',
-			'brand_text_color'                     => '',
-			'brand_logo_url'                       => '',
+			'agent_name'                               => '',
+			'brand_primary_color'                      => '',
+			'brand_text_color'                         => '',
+			'brand_logo_url'                           => '',
 			// Spending limits / budget caps (t110).
-			'budget_daily_cap'                     => 0.0,
-			'budget_monthly_cap'                   => 0.0,
-			'budget_warning_threshold'             => 80,
-			'budget_exceeded_action'               => 'pause',
+			'budget_daily_cap'                         => 0.0,
+			'budget_monthly_cap'                       => 0.0,
+			'budget_warning_threshold'                 => 80,
+			'budget_exceeded_action'                   => 'pause',
 			// Provider trace / debug mode (GH#830).
-			'provider_trace_enabled'               => false,
-			'provider_trace_max_rows'              => 200,
+			'provider_trace_enabled'                   => false,
+			'provider_trace_max_rows'                  => 200,
 			// Prompt caching — provider-side KV-cache opt-in (sd-ai-bjv).
 			// When true, the HttpTraceHandler injects provider-specific
 			// cache markers into outgoing LLM requests (only Anthropic
 			// requires explicit markers today; OpenAI/DeepSeek/etc. cache
 			// automatically). Safe to leave on — workers without cache
 			// support ignore the markers.
-			'prompt_caching_enabled'               => true,
+			'prompt_caching_enabled'                   => true,
 			// Skill auto-update settings (t218).
-			'skill_auto_update'                    => true,
-			'skill_manifest_url'                   => '',
+			'skill_auto_update'                        => true,
+			'skill_manifest_url'                       => '',
 			// Third-party ability visibility mode (sd-ai-3ns / #1405, sd-ai-u21 / #1407).
 			// Controls which abilities are exposed to AI surfaces by AbilityVisibility.
 			// 'legacy'  — opt-out behaviour: everything except ai_hidden is public.
@@ -476,13 +484,13 @@ class Settings {
 			// 'auto'    — full tiered-trust model: namespace allowlist + heuristics.
 			// Default since 1.12.0.
 			// 'strict'  — only meta.mcp.public === true passes. Future use.
-			'third_party_mode'                     => 'auto',
+			'third_party_mode'                         => 'auto',
 
 			// Third-party namespace visibility decisions (sd-ai-0zq / #1406).
 			// Maps namespace slugs to visibility decisions: 'allow', 'block', or 'pending'.
 			// Used by ThirdPartyAbilityNoticeHandler to override the heuristic for
 			// unclassified abilities. Format: { 'namespace-slug': 'allow|block|pending' }
-			'third_party_namespace_decisions'      => array(),
+			'third_party_namespace_decisions'          => array(),
 		);
 	}
 
@@ -1289,6 +1297,26 @@ class Settings {
 		if ( array_key_exists( 'public_chat_review_disclosure', $data ) ) {
 			$disclosure                            = sanitize_textarea_field( (string) $data['public_chat_review_disclosure'] );
 			$data['public_chat_review_disclosure'] = function_exists( 'mb_substr' ) ? mb_substr( $disclosure, 0, 500 ) : substr( $disclosure, 0, 500 );
+		}
+		foreach ( array( 'public_chat_speech_enabled', 'public_chat_speech_voice_mode_enabled' ) as $boolean_key ) {
+			if ( array_key_exists( $boolean_key, $data ) ) {
+				$value                = $data[ $boolean_key ];
+				$data[ $boolean_key ] = true === $value || 1 === $value || '1' === $value || 'true' === $value;
+			}
+		}
+		if ( array_key_exists( 'public_chat_speech_voice', $data ) ) {
+			$voice                            = sanitize_key( (string) $data['public_chat_speech_voice'] );
+			$data['public_chat_speech_voice'] = in_array( $voice, array( 'auto', 'alloy' ), true ) ? $voice : 'auto';
+		}
+		if ( array_key_exists( 'public_chat_speech_max_recording_seconds', $data ) ) {
+			$data['public_chat_speech_max_recording_seconds'] = max( 1, min( 60, (int) $data['public_chat_speech_max_recording_seconds'] ) );
+		}
+		if ( array_key_exists( 'public_chat_speech_max_tts_characters', $data ) ) {
+			$data['public_chat_speech_max_tts_characters'] = max( 1, min( 1000, (int) $data['public_chat_speech_max_tts_characters'] ) );
+		}
+		if ( array_key_exists( 'public_chat_speech_disclosure', $data ) ) {
+			$disclosure                            = sanitize_textarea_field( (string) $data['public_chat_speech_disclosure'] );
+			$data['public_chat_speech_disclosure'] = function_exists( 'mb_substr' ) ? mb_substr( $disclosure, 0, 500 ) : substr( $disclosure, 0, 500 );
 		}
 		if ( array_key_exists( 'chat_trash_retention_days', $data ) ) {
 			$data['chat_trash_retention_days'] = max( 0, min( 365, (int) $data['chat_trash_retention_days'] ) );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -67,6 +67,7 @@ use SdAiAgent\REST\KnowledgeController;
 use SdAiAgent\REST\InstructionsController;
 use SdAiAgent\REST\McpController;
 use SdAiAgent\REST\MemoryController;
+use SdAiAgent\REST\PublicSpeechController;
 use SdAiAgent\REST\RestController;
 use SdAiAgent\REST\SessionController;
 use SdAiAgent\REST\SettingsController;
@@ -139,6 +140,7 @@ use XWP\DI\Decorators\Module;
 		SessionController::class,
 		SettingsController::class,
 		SpeechController::class,
+		PublicSpeechController::class,
 		ConnectorsController::class,
 		CustomerConversationController::class,
 		WebhookController::class,

--- a/includes/REST/PublicSpeechController.php
+++ b/includes/REST/PublicSpeechController.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\REST;
+
+use SdAiAgent\Core\PublicChatSecurity;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Anonymous speech boundary tied to an active public-chat session.
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'public-chat/speech',
+	container: 'sd-ai-agent',
+)]
+final class PublicSpeechController extends XWP_REST_Controller {
+
+	private PublicChatSecurity $security;
+	private SpeechController $speech;
+
+	public function __construct( ?PublicChatSecurity $security = null, ?SpeechController $speech = null ) {
+		$this->security = $security ?? new PublicChatSecurity();
+		$this->speech   = $speech ?? new SpeechController();
+	}
+
+	/** Public routes perform their complete authorization inside each handler. */
+	public function allow_public_request(): bool {
+		return true;
+	}
+
+	/** Transcribe one strict WAV upload for an active public-chat session. */
+	#[REST_Route(
+		route: 'transcriptions',
+		methods: WP_REST_Server::CREATABLE,
+		guard: 'allow_public_request',
+	)]
+	public function handle_transcription( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$started_at       = microtime( true );
+		$audio_bytes      = 0;
+		$duration_seconds = 0.0;
+		$result           = $this->process_transcription( $request, $audio_bytes, $duration_seconds );
+		$this->record_metric( 'transcription', $result, $started_at, $audio_bytes, $duration_seconds );
+
+		return $result;
+	}
+
+	/** Process one public transcription after the telemetry timer starts. */
+	private function process_transcription( WP_REST_Request $request, int &$audio_bytes, float &$duration_seconds ): WP_REST_Response|WP_Error {
+		$fields = $request->get_body_params();
+		if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'token', 'embed_id', 'language' ) ) ) {
+			return $this->invalid_audio_error();
+		}
+
+		$token    = $this->required_string( $fields['token'] ?? null );
+		$embed_id = sanitize_key( $this->required_string( $fields['embed_id'] ?? null ) );
+		if ( '' === $token || '' === $embed_id ) {
+			return $this->invalid_audio_error();
+		}
+
+		$context = $this->security->authorize_session( $request, $token, $embed_id, true );
+		if ( $context instanceof WP_Error ) {
+			return $context;
+		}
+
+		$files = $request->get_file_params();
+		if ( 1 !== count( $files ) || ! isset( $files[ SpeechController::UPLOAD_FIELD ] ) || ! is_array( $files[ SpeechController::UPLOAD_FIELD ] ) ) {
+			return $this->invalid_audio_error();
+		}
+		$upload = $files[ SpeechController::UPLOAD_FIELD ];
+		if ( 'recording.wav' !== ( $upload['name'] ?? null ) || 'audio/wav' !== strtolower( (string) ( $upload['type'] ?? '' ) ) ) {
+			return $this->invalid_audio_error();
+		}
+
+		$language = $this->security->normalize_locale( $fields['language'] ?? null );
+		if ( $language instanceof WP_Error ) {
+			return $language;
+		}
+
+		$rate = $this->security->check_speech_rate_limit( $context['session_uuid'] );
+		if ( true !== $rate ) {
+			return $rate;
+		}
+		$lock = $this->security->acquire_speech_lock( $context['session_uuid'] );
+		if ( $lock instanceof WP_Error ) {
+			return $lock;
+		}
+
+		$config = $this->security->settings();
+		try {
+			$bounded_request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/speech/transcriptions' );
+			$bounded_request->set_body_params( null === $language ? array() : array( 'language' => $language ) );
+			$bounded_request->set_file_params(
+				array(
+					SpeechController::UPLOAD_FIELD => array(
+						'error'    => $upload['error'] ?? null,
+						'tmp_name' => $upload['tmp_name'] ?? null,
+						'name'     => 'recording.wav',
+						'type'     => 'audio/wav',
+					),
+				)
+			);
+			$result = $this->speech->handle_bounded_transcription(
+				$bounded_request,
+				(int) $config['speech_max_audio_bytes'],
+				(int) $config['speech_max_recording_seconds'],
+				function ( int $file_size, float $duration ) use ( $context, &$audio_bytes, &$duration_seconds ): true|WP_Error {
+					$audio_bytes      = $file_size;
+					$duration_seconds = $duration;
+
+					return $this->security->consume_speech_budget(
+						$context['session_uuid'],
+						'transcription',
+						max( 1, (int) ceil( $duration ) )
+					);
+				}
+			);
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+
+			$data = $result->get_data();
+			if ( is_array( $data ) && isset( $data['language'] ) ) {
+				$this->security->update_session_language( $context['session_uuid'], $data['language'] );
+			}
+
+			return $this->security->add_cors( $result, $context['origin'], $config['origins'] );
+		} finally {
+			$this->security->release_speech_lock( $lock );
+		}
+	}
+
+	/** Synthesize only the exact completed assistant text represented by a grant. */
+	#[REST_Route(
+		route: 'synthesis',
+		methods: WP_REST_Server::CREATABLE,
+		guard: 'allow_public_request',
+	)]
+	public function handle_synthesis( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$started_at = microtime( true );
+		$result     = $this->process_synthesis( $request );
+		$this->record_metric( 'synthesis', $result, $started_at );
+
+		return $result;
+	}
+
+	/** Process one public synthesis after the telemetry timer starts. */
+	private function process_synthesis( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$fields = $request->get_json_params();
+		if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'token', 'embed_id', 'grant' ) ) ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$token    = $this->required_string( $fields['token'] ?? null );
+		$embed_id = sanitize_key( $this->required_string( $fields['embed_id'] ?? null ) );
+		$grant    = $this->required_string( $fields['grant'] ?? null );
+		if ( '' === $token || '' === $embed_id || '' === $grant ) {
+			return $this->invalid_synthesis_error();
+		}
+
+		$context = $this->security->authorize_session( $request, $token, $embed_id, true );
+		if ( $context instanceof WP_Error ) {
+			return $context;
+		}
+		$rate = $this->security->check_speech_rate_limit( $context['session_uuid'] );
+		if ( true !== $rate ) {
+			return $rate;
+		}
+		$lock = $this->security->acquire_speech_lock( $context['session_uuid'] );
+		if ( $lock instanceof WP_Error ) {
+			return $lock;
+		}
+
+		$config = $this->security->settings();
+		try {
+			$granted = $this->security->consume_synthesis_grant(
+				$grant,
+				$context['session_uuid'],
+				$context['token_hash'],
+				$context['origin'],
+				$embed_id
+			);
+			if ( $granted instanceof WP_Error ) {
+				return $granted;
+			}
+
+			$budget = $this->security->consume_speech_budget( $context['session_uuid'], 'synthesis', $this->unicode_length( $granted['text'] ) );
+			if ( true !== $budget ) {
+				return $budget;
+			}
+
+			$payload = array(
+				'text'      => $granted['text'],
+				'voice'     => $granted['voice'],
+				'mime_type' => 'audio/mpeg',
+				'speed'     => 1.0,
+			);
+			if ( '' !== $granted['language'] ) {
+				$payload['language'] = $granted['language'];
+			}
+			$bounded_request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/speech/synthesis' );
+			$bounded_request->set_header( 'content-type', 'application/json' );
+			$bounded_request->set_body( (string) wp_json_encode( $payload ) );
+			$result = $this->speech->handle_bounded_synthesis( $bounded_request, (int) $config['speech_max_tts_characters'] );
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+
+			return $this->security->add_cors( $result, $context['origin'], $config['origins'] );
+		} finally {
+			$this->security->release_speech_lock( $lock );
+		}
+	}
+
+	private function record_metric( string $operation, WP_REST_Response|WP_Error $result, float $started_at, int $audio_bytes = 0, float $duration_seconds = 0.0 ): void {
+		$error_data  = $result instanceof WP_Error ? $result->get_error_data() : null;
+		$status_code = $result instanceof WP_REST_Response
+			? $result->get_status()
+			: ( is_array( $error_data ) ? (int) ( $error_data['status'] ?? 500 ) : 500 );
+		$outcome     = $this->metric_outcome( $result, $status_code );
+		$this->security->record_speech_metric( $operation, $outcome, $status_code, $started_at, $audio_bytes, $duration_seconds );
+	}
+
+	private function metric_outcome( WP_REST_Response|WP_Error $result, int $status_code ): string {
+		if ( $result instanceof WP_REST_Response ) {
+			return $status_code >= 200 && $status_code < 300 ? 'success' : 'failed';
+		}
+
+		$code = $result->get_error_code();
+		if ( in_array( $code, array( 'sd_ai_agent_public_chat_origin_forbidden', 'sd_ai_agent_public_chat_invalid_token', 'sd_ai_agent_public_chat_session_expired', 'sd_ai_agent_public_speech_invalid_grant' ), true ) ) {
+			return 'permission_denied';
+		}
+		if ( in_array( $code, array( 'sd_ai_agent_public_chat_rate_limited', 'sd_ai_agent_public_speech_busy', 'sd_ai_agent_public_speech_limit_exceeded', 'sd_ai_agent_audio_too_large', 'sd_ai_agent_audio_too_long' ), true ) ) {
+			return 'limit_denied';
+		}
+		if ( in_array( $code, array( 'sd_ai_agent_public_chat_disabled', 'sd_ai_agent_public_chat_unconfigured', 'sd_ai_agent_public_speech_disabled', 'sd_ai_agent_speech_unavailable', 'sd_ai_agent_speech_unsupported' ), true ) ) {
+			return 'unavailable';
+		}
+
+		return $status_code >= 400 && $status_code < 500 ? 'validation_failed' : 'failed';
+	}
+
+	private function required_string( mixed $value ): string {
+		return is_string( $value ) ? trim( $value ) : '';
+	}
+
+	private function unicode_length( string $value ): int {
+		return function_exists( 'mb_strlen' ) ? mb_strlen( $value, 'UTF-8' ) : (int) preg_match_all( '/./us', $value );
+	}
+
+	private function invalid_audio_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_audio', __( 'The audio recording is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+
+	private function invalid_synthesis_error(): WP_Error {
+		return new WP_Error( 'sd_ai_agent_invalid_speech_text', __( 'The speech request is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+	}
+}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -23,6 +23,7 @@ use SdAiAgent\Core\CostCalculator;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\DurablePlanRunner;
 use SdAiAgent\Core\Export;
+use SdAiAgent\Core\PublicChatSecurity;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Models\ActiveJobRepository;
@@ -65,12 +66,6 @@ final class SessionController {
 	/** Maximum automatic resume attempts for a crashed background job. */
 	private const JOB_AUTO_RESUME_MAX_ATTEMPTS = 2;
 
-	/** Public anonymous chat session TTL in seconds. */
-	private const PUBLIC_CHAT_SESSION_TTL = DAY_IN_SECONDS;
-
-	/** Public anonymous chat HMAC purpose string. */
-	private const PUBLIC_CHAT_TOKEN_PURPOSE = 'public_chat_session_v1';
-
 	/**
 	 * Per-message transport attribution that does not alter conversation meaning.
 	 *
@@ -87,16 +82,19 @@ final class SessionController {
 
 	/** @var Settings Injected settings dependency. */
 	private Settings $settings;
+	private PublicChatSecurity $public_chat_security;
 
 	/**
 	 * Constructor — receives injected dependencies from the DI container.
 	 *
-	 * @param Database      $database  Injected Database service.
-	 * @param Settings|null $settings Injected Settings service.
+	 * @param Database                $database             Injected Database service.
+	 * @param Settings|null           $settings             Injected Settings service.
+	 * @param PublicChatSecurity|null $public_chat_security Shared public authorization service.
 	 */
-	public function __construct( Database $database, ?Settings $settings = null ) {
-		$this->database = $database;
-		$this->settings = $settings ?? Settings::instance();
+	public function __construct( Database $database, ?Settings $settings = null, ?PublicChatSecurity $public_chat_security = null ) {
+		$this->database             = $database;
+		$this->settings             = $settings ?? Settings::instance();
+		$this->public_chat_security = $public_chat_security ?? new PublicChatSecurity( $this->settings );
 	}
 
 	/**
@@ -527,6 +525,16 @@ final class SessionController {
 						'type'     => 'boolean',
 						'default'  => false,
 					),
+					'embed_id'          => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'locale'            => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
 				),
 			)
 		);
@@ -561,12 +569,7 @@ final class SessionController {
 				'callback'            => array( $this, 'handle_public_chat_job_status' ),
 				'permission_callback' => '__return_true',
 				'args'                => array(
-					'id'    => array(
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'token' => array(
+					'id' => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
@@ -815,9 +818,11 @@ final class SessionController {
 	 * @return WP_REST_Response
 	 */
 	public function handle_public_chat_config( WP_REST_Request $request ): WP_REST_Response {
-		$config  = $this->get_public_chat_settings();
-		$origin  = $this->get_public_chat_request_origin( $request );
-		$enabled = ! empty( $config['enabled'] ) && ! empty( $config['collections'] ) && $this->public_origin_is_allowed( $origin, $config['origins'] );
+		$config         = $this->get_public_chat_settings();
+		$origin         = $this->get_public_chat_request_origin( $request );
+		$enabled        = ! empty( $config['enabled'] ) && ! empty( $config['collections'] ) && $this->public_origin_is_allowed( $origin, $config['origins'] );
+		$speech_enabled = $enabled && ! empty( $config['speech_enabled'] );
+		$this->public_chat_security->record_speech_metric( 'availability', $speech_enabled ? 'available' : 'unavailable', 200, microtime( true ) );
 
 		return $this->add_public_chat_cors(
 			new WP_REST_Response(
@@ -830,6 +835,29 @@ final class SessionController {
 						'enabled'        => $enabled && ! empty( $config['review_recording_enabled'] ),
 						'retention_days' => $enabled && ! empty( $config['review_recording_enabled'] ) ? (int) $config['review_retention_days'] : 0,
 						'disclosure'     => $enabled && ! empty( $config['review_recording_enabled'] ) ? (string) $config['review_disclosure'] : '',
+					),
+					'speech'      => array(
+						'enabled'                        => $speech_enabled,
+						'upload_mime_type'               => 'audio/wav',
+						'capture_mime_types'             => array( 'audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus', 'audio/mp4' ),
+						'output_mime_types'              => array( 'audio/mpeg' ),
+						'max_audio_bytes'                => $speech_enabled ? (int) $config['speech_max_audio_bytes'] : 0,
+						'max_recording_duration_seconds' => $speech_enabled ? (int) $config['speech_max_recording_seconds'] : 0,
+						'max_tts_characters'             => $speech_enabled ? (int) $config['speech_max_tts_characters'] : 0,
+						'voice_conversation_enabled'     => $speech_enabled && ! empty( $config['speech_voice_mode_enabled'] ),
+						'disclosure'                     => $speech_enabled ? (string) $config['speech_disclosure'] : '',
+						'labels'                         => array(
+							'listen'       => __( 'Use microphone', 'superdav-ai-agent' ),
+							'stop'         => __( 'Stop', 'superdav-ai-agent' ),
+							'listening'    => __( 'Listening…', 'superdav-ai-agent' ),
+							'transcribing' => __( 'Transcribing…', 'superdav-ai-agent' ),
+							'thinking'     => __( 'Thinking…', 'superdav-ai-agent' ),
+							'speaking'     => __( 'Speaking…', 'superdav-ai-agent' ),
+							'read_aloud'   => __( 'Read aloud', 'superdav-ai-agent' ),
+							'voice_mode'   => __( 'Voice conversation', 'superdav-ai-agent' ),
+							'continue'     => __( 'Allow microphone', 'superdav-ai-agent' ),
+							'fallback'     => __( 'Speech is unavailable. You can continue with typed chat.', 'superdav-ai-agent' ),
+						),
 					),
 				),
 				200
@@ -2183,96 +2211,42 @@ final class SessionController {
 	/**
 	 * Get sanitized public chat settings.
 	 *
-	 * @return array{enabled: bool, origins: list<string>, provider_id: string, model_id: string, agent_id: int, collections: list<string>, abilities: list<string>, iterations: int, message_length: int, rate_limit: int, review_recording_enabled: bool, review_retention_days: int, review_disclosure: string}
+	 * @return array{
+	 *     enabled:bool,
+	 *     origins:list<string>,
+	 *     provider_id:string,
+	 *     model_id:string,
+	 *     agent_id:int,
+	 *     embed_id:string,
+	 *     collections:list<string>,
+	 *     abilities:list<string>,
+	 *     iterations:int,
+	 *     message_length:int,
+	 *     rate_limit:int,
+	 *     review_recording_enabled:bool,
+	 *     review_retention_days:int,
+	 *     review_disclosure:string,
+	 *     speech_enabled:bool,
+	 *     speech_voice:string,
+	 *     speech_max_recording_seconds:int,
+	 *     speech_max_audio_bytes:int,
+	 *     speech_max_tts_characters:int,
+	 *     speech_voice_mode_enabled:bool,
+	 *     speech_disclosure:string
+	 * }
 	 */
 	private function get_public_chat_settings(): array {
-		$settings = Settings::instance()->get();
-		$allowed  = $settings['public_chat_allowed_abilities'] ?? array( 'sd-ai-agent/knowledge-search' );
-		$allowed  = is_array( $allowed ) ? $this->sanitize_public_chat_string_list( $allowed, 'sanitize_text_field' ) : array();
-
-		$collections = $settings['public_chat_collection_ids'] ?? array();
-		$collections = is_array( $collections ) ? $this->sanitize_public_chat_string_list( $collections, 'sanitize_key' ) : array();
-
-		$origins = $settings['public_chat_allowed_origins'] ?? array();
-		$origins = is_array( $origins ) ? $this->sanitize_public_chat_string_list( $origins, 'sanitize_text_field' ) : array();
-
-		$review_retention_days = max( 1, min( 90, (int) ( $settings['public_chat_review_retention_days'] ?? 7 ) ) );
-		$review_disclosure     = sanitize_textarea_field( (string) ( $settings['public_chat_review_disclosure'] ?? '' ) );
-		if ( '' === $review_disclosure ) {
-			$review_disclosure = sprintf(
-				/* translators: %d: maximum number of days an opted-in anonymous chat is retained. */
-				__( 'This conversation may be recorded for quality review and retained for up to %d days.', 'superdav-ai-agent' ),
-				$review_retention_days
-			);
-		}
-
-		return array(
-			'enabled'                  => (bool) ( $settings['public_chat_enabled'] ?? false ),
-			'origins'                  => $origins,
-			'provider_id'              => sanitize_text_field( (string) ( $settings['public_chat_provider_id'] ?? '' ) ),
-			'model_id'                 => sanitize_text_field( (string) ( $settings['public_chat_model_id'] ?? '' ) ),
-			'agent_id'                 => absint( $settings['public_chat_agent_id'] ?? 0 ),
-			'collections'              => $collections,
-			'abilities'                => $allowed,
-			'iterations'               => max( 1, min( 8, (int) ( $settings['public_chat_max_iterations'] ?? 4 ) ) ),
-			'message_length'           => max( 1, min( 8000, (int) ( $settings['public_chat_message_max_length'] ?? 2000 ) ) ),
-			'rate_limit'               => max( 1, min( 60, (int) ( $settings['public_chat_rate_limit_per_min'] ?? 10 ) ) ),
-			'review_recording_enabled' => (bool) ( $settings['public_chat_review_recording_enabled'] ?? false ),
-			'review_retention_days'    => $review_retention_days,
-			'review_disclosure'        => $review_disclosure,
-		);
-	}
-
-	/**
-	 * Sanitize a mixed public-chat list to non-empty strings.
-	 *
-	 * @param array<int|string, mixed> $values   Raw values.
-	 * @param callable(string):string  $sanitize Sanitizer callback.
-	 * @return list<string>
-	 */
-	private function sanitize_public_chat_string_list( array $values, callable $sanitize ): array {
-		$clean = array();
-		foreach ( $values as $value ) {
-			if ( ! is_scalar( $value ) ) {
-				continue;
-			}
-			$item = $sanitize( (string) $value );
-			if ( '' !== $item ) {
-				$clean[] = $item;
-			}
-		}
-
-		return $clean;
+		return $this->public_chat_security->settings();
 	}
 
 	/** Validate public chat is enabled and the request origin is allowed. */
 	private function check_public_chat_available( WP_REST_Request $request ): true|WP_Error {
-		$config = $this->get_public_chat_settings();
-		if ( empty( $config['enabled'] ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_disabled', __( 'Public chat is not enabled.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
-		}
-
-		if ( empty( $config['collections'] ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_unconfigured', __( 'Public chat has no documentation collection configured.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
-		}
-
-		$origin = $this->get_public_chat_request_origin( $request );
-
-		if ( ! $this->public_origin_is_allowed( $origin, $config['origins'] ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_origin_forbidden', __( 'This origin is not allowed to use public chat.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
-
-		return true;
+		return $this->public_chat_security->check_available( $request );
 	}
 
 	/** Resolve the public-chat request origin or referer. */
 	private function get_public_chat_request_origin( WP_REST_Request $request ): string {
-		$origin = (string) $request->get_header( 'origin' );
-		if ( '' === $origin ) {
-			$origin = (string) $request->get_header( 'referer' );
-		}
-
-		return $origin;
+		return $this->public_chat_security->request_origin( $request );
 	}
 
 	/**
@@ -2284,13 +2258,7 @@ final class SessionController {
 	 */
 	// phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is valid PHPStan but not a native PHP type.
 	private function add_public_chat_cors( WP_REST_Response $response, string $origin, array $allowed_origins ): WP_REST_Response {
-		if ( $this->public_origin_is_allowed( $origin, $allowed_origins ) ) {
-			$response->header( 'Access-Control-Allow-Origin', $origin );
-			$response->header( 'Access-Control-Allow-Credentials', 'false' );
-			$response->header( 'Vary', 'Origin' );
-		}
-
-		return $response;
+		return $this->public_chat_security->add_cors( $response, $origin, $allowed_origins );
 	}
 
 	/**
@@ -2301,90 +2269,22 @@ final class SessionController {
 	 */
 	// phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is valid PHPStan but not a native PHP type.
 	private function public_origin_is_allowed( string $origin, array $allowed_origins ): bool {
-		if ( '' === $origin ) {
-			return empty( $allowed_origins );
-		}
-
-		$origin_host = wp_parse_url( $origin, PHP_URL_HOST );
-		$origin_host = is_string( $origin_host ) ? strtolower( $origin_host ) : '';
-		if ( '' === $origin_host ) {
-			return false;
-		}
-
-		if ( empty( $allowed_origins ) ) {
-			$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
-			return is_string( $home_host ) && strtolower( $home_host ) === $origin_host;
-		}
-
-		foreach ( $allowed_origins as $allowed ) {
-			$allowed_host = wp_parse_url( (string) $allowed, PHP_URL_HOST );
-			$allowed_host = is_string( $allowed_host ) ? strtolower( $allowed_host ) : strtolower( (string) $allowed );
-			if ( $origin_host === $allowed_host ) {
-				return true;
-			}
-		}
-
-		return false;
+		return $this->public_chat_security->origin_is_allowed( $origin, $allowed_origins );
 	}
 
 	/** Create a signed opaque public session token. */
-	private function create_public_chat_token( string $session_uuid ): string {
-		$payload = wp_json_encode(
-			array(
-				'sid' => $session_uuid,
-				'exp' => time() + self::PUBLIC_CHAT_SESSION_TTL,
-			)
-		);
-		$payload = false === $payload ? '{}' : $payload;
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- URL-safe token payload encoding, signed by HMAC below.
-		$body = rtrim( strtr( base64_encode( $payload ), '+/', '-_' ), '=' );
-		$sig  = hash_hmac( 'sha256', self::PUBLIC_CHAT_TOKEN_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
-
-		return $body . '.' . $sig;
-	}
-
-	/** Validate and parse a signed public session token. */
-	private function parse_public_chat_token( string $token ): array|WP_Error {
-		$parts = explode( '.', $token, 2 );
-		if ( 2 !== count( $parts ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_invalid_token', __( 'Invalid public chat token.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
-
-		[ $body, $sig ] = $parts;
-		$expected       = hash_hmac( 'sha256', self::PUBLIC_CHAT_TOKEN_PURPOSE . '|' . $body, wp_salt( 'auth' ) );
-		if ( ! hash_equals( $expected, $sig ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_invalid_token', __( 'Invalid public chat token.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding the signed URL-safe token payload.
-		$decoded = base64_decode( strtr( $body, '-_', '+/' ), true );
-		$data    = is_string( $decoded ) ? json_decode( $decoded, true ) : null;
-		if ( ! is_array( $data ) || empty( $data['sid'] ) || ! is_string( $data['sid'] ) || empty( $data['exp'] ) || (int) $data['exp'] < time() ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_invalid_token', __( 'Invalid public chat token.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
-
-		return array(
-			'sid' => sanitize_key( $data['sid'] ),
-			'exp' => (int) $data['exp'],
-		);
+	private function create_public_chat_token( string $session_uuid, string $embed_id, string $origin ): string {
+		return $this->public_chat_security->create_token( $session_uuid, $embed_id, $origin );
 	}
 
 	/** Public session transient key. */
 	private function public_chat_session_key( string $session_uuid ): string {
-		return 'sd_ai_agent_public_chat_' . md5( $session_uuid );
+		return $this->public_chat_security->session_key( $session_uuid );
 	}
 
 	/** Consume a public-chat rate-limit token. */
 	private function check_public_chat_rate_limit( string $session_uuid, int $limit ): true|WP_Error {
-		$ip  = sanitize_text_field( wp_unslash( (string) ( $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0' ) ) );
-		$key = 'sd_ai_agent_public_chat_rate_' . md5( $session_uuid . '|' . $ip . '|' . gmdate( 'YmdHi' ) );
-		$hit = (int) get_transient( $key );
-		if ( $hit >= $limit ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_rate_limited', __( 'Too many public chat messages. Please wait before trying again.', 'superdav-ai-agent' ), array( 'status' => 429 ) );
-		}
-
-		set_transient( $key, $hit + 1, MINUTE_IN_SECONDS + 5 );
-		return true;
+		return $this->public_chat_security->check_rate_limit( $session_uuid, $limit );
 	}
 
 	/** Create an anonymous public chat token/session. */
@@ -2397,9 +2297,18 @@ final class SessionController {
 		$origin            = $this->get_public_chat_request_origin( $request );
 		$consent           = $request->get_param( 'recording_consent' );
 		$recording_consent = true === $consent || 1 === $consent || '1' === $consent || 'true' === $consent;
+		$embed_id          = sanitize_key( self::get_string_param( $request, 'embed_id' ) );
+		$embed_id          = '' !== $embed_id ? $embed_id : (string) $config['embed_id'];
+		if ( '' === $embed_id || $embed_id !== $config['embed_id'] ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_invalid_embed', __( 'The public chat embed is invalid.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+		$locale = $this->public_chat_security->normalize_locale( $request->get_param( 'locale' ) );
+		if ( $locale instanceof WP_Error ) {
+			return $locale;
+		}
 
 		$session_uuid = wp_generate_uuid4();
-		$token        = $this->create_public_chat_token( $session_uuid );
+		$token        = $this->create_public_chat_token( $session_uuid, $embed_id, $origin );
 		$review_id    = '';
 		if ( ! empty( $config['review_recording_enabled'] ) && $recording_consent ) {
 			$candidate_review_id = wp_generate_uuid4();
@@ -2421,18 +2330,21 @@ final class SessionController {
 		set_transient(
 			$this->public_chat_session_key( $session_uuid ),
 			array(
-				'history'    => array(),
-				'review_id'  => $review_id,
-				'created_at' => time(),
+				'history'       => array(),
+				'review_id'     => $review_id,
+				'embed_id'      => $embed_id,
+				'origin_hash'   => $this->public_chat_security->origin_binding( $origin ),
+				'speech_locale' => null === $locale ? '' : $locale,
+				'created_at'    => time(),
 			),
-			self::PUBLIC_CHAT_SESSION_TTL
+			PublicChatSecurity::SESSION_TTL
 		);
 
 		return $this->add_public_chat_cors(
 			new WP_REST_Response(
 				array(
 					'token'      => $token,
-					'expires_in' => self::PUBLIC_CHAT_SESSION_TTL,
+					'expires_in' => PublicChatSecurity::SESSION_TTL,
 				),
 				201
 			),
@@ -2448,19 +2360,15 @@ final class SessionController {
 			return $available;
 		}
 
-		$config = $this->get_public_chat_settings();
-		$origin = $this->get_public_chat_request_origin( $request );
-		$token  = self::get_string_param( $request, 'token' );
-		$parsed = $this->parse_public_chat_token( $token );
-		if ( is_wp_error( $parsed ) ) {
-			return $parsed;
+		$config     = $this->get_public_chat_settings();
+		$origin     = $this->get_public_chat_request_origin( $request );
+		$token      = self::get_string_param( $request, 'token' );
+		$authorized = $this->public_chat_security->authorize_session( $request, $token );
+		if ( $authorized instanceof WP_Error ) {
+			return $authorized;
 		}
-
-		$session_uuid = (string) $parsed['sid'];
-		$session      = get_transient( $this->public_chat_session_key( $session_uuid ) );
-		if ( ! is_array( $session ) ) {
-			return new WP_Error( 'sd_ai_agent_public_chat_session_expired', __( 'Public chat session expired.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
-		}
+		$session_uuid = $authorized['session_uuid'];
+		$session      = $authorized['session'];
 
 		$rate = $this->check_public_chat_rate_limit( $session_uuid, (int) $config['rate_limit'] );
 		if ( true !== $rate ) {
@@ -2548,15 +2456,22 @@ final class SessionController {
 		$config = $this->get_public_chat_settings();
 		$origin = $this->get_public_chat_request_origin( $request );
 
-		$token  = self::get_string_param( $request, 'token' );
-		$parsed = $this->parse_public_chat_token( $token );
-		if ( is_wp_error( $parsed ) ) {
-			return $parsed;
+		$authorization = trim( (string) $request->get_header( 'authorization' ) );
+		$matches       = array();
+		$token         = 1 === preg_match( '/^Bearer\s+(\S+)$/i', $authorization, $matches )
+			? sanitize_text_field( (string) $matches[1] )
+			: '';
+		if ( '' === $token ) {
+			return new WP_Error( 'sd_ai_agent_public_chat_invalid_token', __( 'Invalid public chat token.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
+		}
+		$authorized = $this->public_chat_security->authorize_session( $request, $token );
+		if ( $authorized instanceof WP_Error ) {
+			return $authorized;
 		}
 
 		$job_id = self::get_string_param( $request, 'id' );
 		$job    = get_transient( RestController::JOB_PREFIX . $job_id );
-		if ( ! is_array( $job ) || empty( $job['public_chat'] ) || ( $job['public_session_uuid'] ?? '' ) !== $parsed['sid'] || ( $job['public_token_hash'] ?? '' ) !== hash( 'sha256', $token ) ) {
+		if ( ! is_array( $job ) || empty( $job['public_chat'] ) || ( $job['public_session_uuid'] ?? '' ) !== $authorized['session_uuid'] || ( $job['public_token_hash'] ?? '' ) !== $authorized['token_hash'] ) {
 			return new WP_Error( 'sd_ai_agent_public_chat_job_not_found', __( 'Public chat job not found.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
 		}
 
@@ -2575,6 +2490,13 @@ final class SessionController {
 			$response['history']         = isset( $job['result']['history'] ) && is_array( $job['result']['history'] ) ? ConversationDisplaySanitizer::sanitize_messages( $job['result']['history'] ) : array();
 			$response['tool_calls']      = $job['result']['tool_calls'] ?? array();
 			$response['iterations_used'] = $job['result']['iterations_used'] ?? 0;
+			$grant                       = $this->public_chat_security->issue_synthesis_grant( $authorized['session_uuid'], $token, $origin, (string) $response['reply'] );
+			if ( null !== $grant ) {
+				$response['speech'] = array(
+					'synthesis_grant' => $grant['grant'],
+					'expires_in'      => $grant['expires_in'],
+				);
+			}
 			delete_transient( RestController::JOB_PREFIX . $job_id );
 			ActiveJobRepository::delete( $job_id );
 		} elseif ( 'error' === ( $job['status'] ?? '' ) ) {
@@ -4034,7 +3956,7 @@ final class SessionController {
 				set_transient(
 					$this->public_chat_session_key( (string) $job['public_session_uuid'] ),
 					$public_session,
-					self::PUBLIC_CHAT_SESSION_TTL
+					PublicChatSecurity::SESSION_TTL
 				);
 				$token_usage = isset( $result['token_usage'] ) && is_array( $result['token_usage'] ) ? $result['token_usage'] : array();
 				$handoff     = isset( $result['handoff'] ) && is_array( $result['handoff'] ) ? $result['handoff'] : array();

--- a/includes/REST/SpeechController.php
+++ b/includes/REST/SpeechController.php
@@ -86,7 +86,21 @@ final class SpeechController extends XWP_REST_Controller {
 		guard: 'check_chat_permission',
 	)]
 	public function handle_transcription( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$temporary_path = '';
+		return $this->handle_bounded_transcription(
+			$request,
+			SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES,
+			SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS
+		);
+	}
+
+	/**
+	 * Transcribe one upload under caller-supplied ceilings no broader than the
+	 * authenticated service contract.
+	 */
+	public function handle_bounded_transcription( WP_REST_Request $request, int $max_bytes, int $max_duration_seconds, ?callable $before_transcription = null ): WP_REST_Response|WP_Error {
+		$max_bytes            = max( 1, min( SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES, $max_bytes ) );
+		$max_duration_seconds = max( 1, min( SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS, $max_duration_seconds ) );
+		$temporary_path       = '';
 		try {
 			$files = $request->get_file_params();
 			if ( 1 !== count( $files ) || ! isset( $files[ self::UPLOAD_FIELD ] ) || ! is_array( $files[ self::UPLOAD_FIELD ] ) ) {
@@ -140,7 +154,7 @@ final class SpeechController extends XWP_REST_Controller {
 			if ( false === $file_size || $file_size <= 0 ) {
 				return $this->invalid_audio_error();
 			}
-			if ( $file_size > SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES ) {
+			if ( $file_size > $max_bytes ) {
 				return $this->audio_too_large_error();
 			}
 
@@ -158,7 +172,7 @@ final class SpeechController extends XWP_REST_Controller {
 			if ( null === $duration ) {
 				return $this->invalid_audio_error();
 			}
-			if ( $duration > SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS ) {
+			if ( $duration > $max_duration_seconds ) {
 				return $this->audio_too_long_error();
 			}
 
@@ -171,11 +185,17 @@ final class SpeechController extends XWP_REST_Controller {
 			if ( $capabilities instanceof WP_Error ) {
 				return $capabilities;
 			}
-			if ( $file_size > $capabilities['transcription']['max_bytes'] ) {
+			if ( $file_size > min( $max_bytes, $capabilities['transcription']['max_bytes'] ) ) {
 				return $this->audio_too_large_error();
 			}
-			if ( $duration > $capabilities['transcription']['max_duration_seconds'] ) {
+			if ( $duration > min( $max_duration_seconds, $capabilities['transcription']['max_duration_seconds'] ) ) {
 				return $this->audio_too_long_error();
+			}
+			if ( null !== $before_transcription ) {
+				$allowed = $before_transcription( $file_size, $duration );
+				if ( true !== $allowed ) {
+					return $allowed instanceof WP_Error ? $allowed : $this->speech_unavailable_error();
+				}
 			}
 
 			ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, SuperdavAiTranscriptionClient::MODEL_ID, $session_id );
@@ -204,12 +224,18 @@ final class SpeechController extends XWP_REST_Controller {
 		guard: 'check_chat_permission',
 	)]
 	public function handle_synthesis( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$fields = $request->get_json_params();
+		return $this->handle_bounded_synthesis( $request, self::MAX_SYNTHESIS_CHARACTERS );
+	}
+
+	/** Convert one validated text turn under a stricter caller-supplied ceiling. */
+	public function handle_bounded_synthesis( WP_REST_Request $request, int $max_characters ): WP_REST_Response|WP_Error {
+		$max_characters = max( 1, min( self::MAX_SYNTHESIS_CHARACTERS, $max_characters ) );
+		$fields         = $request->get_json_params();
 		if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'text', 'voice', 'language', 'format', 'mime_type', 'speed', 'session_id' ) ) ) {
 			return $this->invalid_synthesis_error();
 		}
 
-		$text = $this->required_speakable_text( $fields['text'] ?? null );
+		$text = $this->required_speakable_text( $fields['text'] ?? null, $max_characters );
 		if ( $text instanceof WP_Error ) {
 			return $text;
 		}
@@ -532,14 +558,14 @@ final class SpeechController extends XWP_REST_Controller {
 		return $value;
 	}
 
-	private function required_speakable_text( mixed $value ): string|WP_Error {
-		if ( ! is_string( $value ) || 1 !== preg_match( '//u', $value ) || $this->unicode_length( $value ) > self::MAX_SYNTHESIS_CHARACTERS * 4 ) {
+	private function required_speakable_text( mixed $value, int $maximum ): string|WP_Error {
+		if ( ! is_string( $value ) || 1 !== preg_match( '//u', $value ) || $this->unicode_length( $value ) > $maximum * 4 ) {
 			return $this->invalid_synthesis_error();
 		}
 
 		$text = html_entity_decode( wp_strip_all_tags( strip_shortcodes( $value ) ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		$text = preg_replace( '/\s+/u', ' ', trim( $text ) );
-		if ( ! is_string( $text ) || '' === $text || 1 !== preg_match( '/[\p{L}\p{N}]/u', $text ) || $this->unicode_length( $text ) > self::MAX_SYNTHESIS_CHARACTERS ) {
+		if ( ! is_string( $text ) || '' === $text || 1 !== preg_match( '/[\p{L}\p{N}]/u', $text ) || $this->unicode_length( $text ) > $maximum ) {
 			return $this->invalid_synthesis_error();
 		}
 

--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -149,7 +149,11 @@ describe( 'embed widget', () => {
 			url.endsWith( '/public-chat/session' )
 		);
 		expect( sessionRequest[ 1 ].body ).toBe(
-			JSON.stringify( { recording_consent: false } )
+			JSON.stringify( {
+				recording_consent: false,
+				embed_id: '',
+				locale: 'en',
+			} )
 		);
 	} );
 
@@ -189,7 +193,11 @@ describe( 'embed widget', () => {
 			url.endsWith( '/public-chat/session' )
 		);
 		expect( sessionRequest[ 1 ].body ).toBe(
-			JSON.stringify( { recording_consent: true } )
+			JSON.stringify( {
+				recording_consent: true,
+				embed_id: '',
+				locale: 'en',
+			} )
 		);
 		expect(
 			root.querySelector( '.sdaa-embed__recording-choice' )
@@ -341,5 +349,290 @@ describe( 'embed widget', () => {
 		expect( container.textContent ).toContain( 'wp_config_value' );
 		expect( container.textContent ).toContain( 'some_snake_case' );
 		expect( container.textContent ).toContain( 'word*star*word' );
+	} );
+
+	test( 'keeps public polling tokens out of the URL', async () => {
+		const client = module.createPublicClient( {
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+		} );
+
+		await client.poll( 'job-id', 'session-token' );
+
+		expect( global.fetch ).toHaveBeenLastCalledWith(
+			'https://example.test/wp-json/sd-ai-agent/v1/public-chat/job/job-id',
+			expect.objectContaining( {
+				credentials: 'omit',
+				headers: expect.objectContaining( {
+					Authorization: 'Bearer session-token',
+				} ),
+			} )
+		);
+		expect( global.fetch.mock.calls.at( -1 )[ 0 ] ).not.toContain(
+			'session-token'
+		);
+	} );
+
+	test( 'shows disclosure before requesting the microphone and releases capture on close', async () => {
+		const mediaDevicesDescriptor = Object.getOwnPropertyDescriptor(
+			navigator,
+			'mediaDevices'
+		);
+		const OriginalMediaRecorder = global.MediaRecorder;
+		const OriginalAudioContext = global.AudioContext;
+		const track = { stop: jest.fn() };
+		const getUserMedia = jest.fn().mockResolvedValue( {
+			getTracks: () => [ track ],
+		} );
+		class MockMediaRecorder {
+			constructor() {
+				this.state = 'inactive';
+			}
+
+			start() {
+				this.state = 'recording';
+			}
+
+			stop() {
+				this.state = 'inactive';
+				this.onstop?.();
+			}
+		}
+		MockMediaRecorder.isTypeSupported = jest.fn().mockReturnValue( true );
+
+		Object.defineProperty( navigator, 'mediaDevices', {
+			configurable: true,
+			value: { getUserMedia },
+		} );
+		global.MediaRecorder = MockMediaRecorder;
+		global.AudioContext = jest.fn();
+		global.fetch = jest.fn( ( url ) =>
+			Promise.resolve( {
+				ok: true,
+				json: () =>
+					Promise.resolve(
+						url.endsWith( '/public-chat/config' )
+							? {
+									enabled: true,
+									speech: {
+										enabled: true,
+										capture_mime_types: [ 'audio/webm' ],
+										disclosure:
+											'Audio is sent for transcription.',
+										max_audio_bytes: 1000,
+										max_recording_duration_seconds: 10,
+										voice_conversation_enabled: false,
+									},
+							  }
+							: { token: 'public-token' }
+					),
+			} )
+		);
+
+		try {
+			const root = module.mountEmbed( {
+				...module.resolveConfig( null, {} ),
+				apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+				mount: '#mount',
+			} );
+			await flushRequests();
+
+			const disclosure = root.querySelector(
+				'.sd-ai-agent-embed-speech-disclosure'
+			);
+			const consent = root.querySelector(
+				'.sd-ai-agent-embed-speech-consent'
+			);
+			expect( disclosure.hidden ).toBe( false );
+			expect( disclosure.textContent ).toContain(
+				'Audio is sent for transcription.'
+			);
+			expect( getUserMedia ).not.toHaveBeenCalled();
+
+			consent.click();
+			await flushRequests();
+			expect( getUserMedia ).toHaveBeenCalledTimes( 1 );
+			expect(
+				root.querySelector( '.sd-ai-agent-embed-microphone' ).hidden
+			).toBe( false );
+
+			root.querySelector( '.sdaa-embed__close' ).click();
+			expect( track.stop ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			if ( mediaDevicesDescriptor ) {
+				Object.defineProperty(
+					navigator,
+					'mediaDevices',
+					mediaDevicesDescriptor
+				);
+			} else {
+				delete navigator.mediaDevices;
+			}
+			global.MediaRecorder = OriginalMediaRecorder;
+			global.AudioContext = OriginalAudioContext;
+		}
+	} );
+
+	test( 'returns voice mode to idle after playback and requires a fresh microphone gesture', async () => {
+		const mediaDevicesDescriptor = Object.getOwnPropertyDescriptor(
+			navigator,
+			'mediaDevices'
+		);
+		const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+			URL,
+			'createObjectURL'
+		);
+		const revokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+			URL,
+			'revokeObjectURL'
+		);
+		const OriginalMediaRecorder = global.MediaRecorder;
+		const OriginalAudioContext = global.AudioContext;
+		const OriginalAudio = global.Audio;
+		const tracks = [];
+		const getUserMedia = jest.fn().mockImplementation( () => {
+			const track = { stop: jest.fn() };
+			tracks.push( track );
+			return Promise.resolve( { getTracks: () => [ track ] } );
+		} );
+		class MockMediaRecorder {
+			constructor() {
+				this.state = 'inactive';
+			}
+
+			start() {
+				this.state = 'recording';
+			}
+
+			stop() {
+				this.state = 'inactive';
+				this.onstop?.();
+			}
+		}
+		MockMediaRecorder.isTypeSupported = jest.fn().mockReturnValue( true );
+		const audio = {
+			pause: jest.fn(),
+			play: jest.fn().mockResolvedValue( undefined ),
+			removeAttribute: jest.fn(),
+		};
+		const createObjectURL = jest.fn().mockReturnValue( 'blob:reply' );
+		const revokeObjectURL = jest.fn();
+
+		Object.defineProperty( navigator, 'mediaDevices', {
+			configurable: true,
+			value: { getUserMedia },
+		} );
+		Object.defineProperty( URL, 'createObjectURL', {
+			configurable: true,
+			value: createObjectURL,
+		} );
+		Object.defineProperty( URL, 'revokeObjectURL', {
+			configurable: true,
+			value: revokeObjectURL,
+		} );
+		global.MediaRecorder = MockMediaRecorder;
+		global.AudioContext = jest.fn();
+		global.Audio = jest.fn( () => audio );
+		global.fetch = jest.fn( ( url ) => {
+			let data;
+			if ( url.endsWith( '/public-chat/config' ) ) {
+				data = {
+					enabled: true,
+					speech: {
+						enabled: true,
+						capture_mime_types: [ 'audio/webm' ],
+						disclosure: 'Audio is sent for transcription.',
+						max_audio_bytes: 1000,
+						max_recording_duration_seconds: 10,
+						voice_conversation_enabled: true,
+					},
+				};
+			} else if ( url.endsWith( '/public-chat/session' ) ) {
+				data = { token: 'public-token' };
+			} else if ( url.endsWith( '/public-chat/run' ) ) {
+				data = {
+					reply: 'Spoken reply.',
+					speech: { synthesis_grant: 'reply-grant' },
+					status: 'complete',
+				};
+			} else {
+				data = { audio: 'YQ==', mime_type: 'audio/mpeg' };
+			}
+
+			return Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( data ),
+			} );
+		} );
+
+		try {
+			const root = module.mountEmbed( {
+				...module.resolveConfig( null, {} ),
+				apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+				mount: '#mount',
+			} );
+			root.querySelector( '.sdaa-embed__launcher' ).click();
+			await flushRequests();
+			root.querySelector( '.sd-ai-agent-embed-speech-consent' ).click();
+			await flushRequests();
+			expect( getUserMedia ).toHaveBeenCalledTimes( 1 );
+
+			const voiceMode = root.querySelector(
+				'.sd-ai-agent-embed-voice-mode input'
+			);
+			voiceMode.checked = true;
+			root.querySelector( '.sd-ai-agent-embed-microphone' ).click();
+			await flushRequests();
+
+			const input = root.querySelector( '.sdaa-embed__input' );
+			input.value = 'Typed voice-mode turn';
+			root.querySelector( '.sdaa-embed__form' ).dispatchEvent(
+				new Event( 'submit', { bubbles: true, cancelable: true } )
+			);
+			await flushRequests();
+			expect( audio.play ).toHaveBeenCalledTimes( 1 );
+			expect( getUserMedia ).toHaveBeenCalledTimes( 1 );
+
+			audio.onended();
+			await flushRequests();
+			expect( revokeObjectURL ).toHaveBeenCalledWith( 'blob:reply' );
+			expect( getUserMedia ).toHaveBeenCalledTimes( 1 );
+
+			root.querySelector( '.sdaa-embed__close' ).click();
+			expect( tracks ).toHaveLength( 1 );
+			expect(
+				tracks.every( ( track ) => track.stop.mock.calls.length > 0 )
+			).toBe( true );
+		} finally {
+			if ( mediaDevicesDescriptor ) {
+				Object.defineProperty(
+					navigator,
+					'mediaDevices',
+					mediaDevicesDescriptor
+				);
+			} else {
+				delete navigator.mediaDevices;
+			}
+			if ( createObjectUrlDescriptor ) {
+				Object.defineProperty(
+					URL,
+					'createObjectURL',
+					createObjectUrlDescriptor
+				);
+			} else {
+				delete URL.createObjectURL;
+			}
+			if ( revokeObjectUrlDescriptor ) {
+				Object.defineProperty(
+					URL,
+					'revokeObjectURL',
+					revokeObjectUrlDescriptor
+				);
+			} else {
+				delete URL.revokeObjectURL;
+			}
+			global.MediaRecorder = OriginalMediaRecorder;
+			global.AudioContext = OriginalAudioContext;
+			global.Audio = OriginalAudio;
+		}
 	} );
 } );

--- a/src/embed-widget/index.js
+++ b/src/embed-widget/index.js
@@ -13,6 +13,11 @@ import {
 	CREDIT_EXHAUSTED_REASON,
 	PURCHASE_CREDITS_ACTION,
 } from '../utils/superdav-credit-notice';
+import {
+	base64ToBlob,
+	recordingToWav,
+	selectRecordingMimeType,
+} from '../utils/speech-core';
 
 const DEFAULTS = {
 	apiBase: '',
@@ -33,6 +38,10 @@ const STRINGS = {
 	open: 'Open docs chat',
 	close: 'Close',
 	thinking: 'Thinking…',
+	listening: 'Listening…',
+	transcribing: 'Transcribing…',
+	speaking: 'Speaking…',
+	speechFallback: 'Speech is unavailable. You can continue with typed chat.',
 };
 
 const TRAILING_URL_PUNCTUATION = /[.,;:!?'")\]]+$/;
@@ -485,12 +494,14 @@ export function renderAccountActionNotice( item, notice ) {
  */
 export function createPublicClient( config ) {
 	const request = async ( path, options = {} ) => {
+		const isFormData =
+			typeof FormData !== 'undefined' && options.body instanceof FormData;
 		const response = await fetch( endpoint( config.apiBase, path ), {
 			...options,
 			credentials: 'omit',
 			headers: {
 				Accept: 'application/json',
-				'Content-Type': 'application/json',
+				...( isFormData ? {} : { 'Content-Type': 'application/json' } ),
 				...( options.headers || {} ),
 			},
 		} );
@@ -503,28 +514,54 @@ export function createPublicClient( config ) {
 
 	return {
 		config: () => request( '/public-chat/config', { method: 'GET' } ),
-		session: ( recordingConsent = false ) =>
+		session: ( recordingConsent = false, locale = '' ) =>
 			request( '/public-chat/session', {
 				method: 'POST',
 				body: JSON.stringify( {
 					recording_consent: recordingConsent,
+					embed_id: config.embedId,
+					locale,
 				} ),
 			} ),
-		send: ( message, sessionToken ) =>
+		send: ( message, sessionToken, signal ) =>
 			request( '/public-chat/run', {
 				method: 'POST',
 				body: JSON.stringify( {
 					message,
 					token: sessionToken,
 				} ),
+				signal,
 			} ),
-		poll: ( jobId, sessionToken ) =>
-			request(
-				`/public-chat/job/${ encodeURIComponent(
-					jobId
-				) }?token=${ encodeURIComponent( sessionToken ) }`,
-				{ method: 'GET' }
-			),
+		poll: ( jobId, sessionToken, signal ) =>
+			request( `/public-chat/job/${ encodeURIComponent( jobId ) }`, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${ sessionToken }` },
+				signal,
+			} ),
+		transcribe: ( recording, sessionToken, language, signal ) => {
+			const body = new FormData();
+			body.append( 'audio', recording, 'recording.wav' );
+			body.append( 'token', sessionToken );
+			body.append( 'embed_id', config.embedId );
+			if ( language ) {
+				body.append( 'language', language );
+			}
+			return request( '/public-chat/speech/transcriptions', {
+				method: 'POST',
+				body,
+				signal,
+			} );
+		},
+		synthesize: ( grant, sessionToken, signal ) =>
+			request( '/public-chat/speech/synthesis', {
+				method: 'POST',
+				body: JSON.stringify( {
+					embed_id: config.embedId,
+					grant,
+					token: sessionToken,
+				} ),
+				signal,
+			} ),
 	};
 }
 
@@ -551,8 +588,15 @@ export function mountEmbed( config ) {
 				<button class="sdaa-embed__close" type="button">${ STRINGS.close }</button>
 			</header>
 			<div class="sdaa-embed__messages"></div>
+			<div class="sd-ai-agent-embed-speech-disclosure" hidden></div>
+			<label class="sd-ai-agent-embed-voice-mode" hidden>
+				<input type="checkbox" />
+				<span>Voice conversation</span>
+			</label>
+			<div class="sd-ai-agent-embed-speech-status" role="status" aria-live="polite"></div>
 			<form class="sdaa-embed__form">
 				<textarea class="sdaa-embed__input" rows="1" autocomplete="off" placeholder="${ STRINGS.placeholder }"></textarea>
+				<button class="sd-ai-agent-embed-microphone" type="button" hidden aria-pressed="false">Use microphone</button>
 				<button class="sdaa-embed__send" type="submit">${ STRINGS.send }</button>
 			</form>
 		</section>`;
@@ -569,13 +613,200 @@ export function mountEmbed( config ) {
 	const form = root.querySelector( '.sdaa-embed__form' );
 	const input = root.querySelector( '.sdaa-embed__input' );
 	const sendButton = form.querySelector( '.sdaa-embed__send' );
+	const microphoneButton = form.querySelector(
+		'.sd-ai-agent-embed-microphone'
+	);
+	const speechDisclosure = root.querySelector(
+		'.sd-ai-agent-embed-speech-disclosure'
+	);
+	const speechStatus = root.querySelector(
+		'.sd-ai-agent-embed-speech-status'
+	);
+	const voiceModeControl = root.querySelector(
+		'.sd-ai-agent-embed-voice-mode'
+	);
+	const voiceModeInput = voiceModeControl.querySelector( 'input' );
 	let sessionToken = '';
+	let serverSpeech = null;
+	let pendingSpeechConfig = null;
+	let speechLocale = config.locale || globalThis.navigator?.language || '';
+	let microphoneConsent = false;
+	let recorderTurn = null;
+	let playback = null;
+	let chatAbort = null;
+	let speechAbort = null;
+	const activeTimers = new Set();
 	input.disabled = true;
 	sendButton.disabled = true;
 
 	const autosizeInput = () => {
 		input.style.height = 'auto';
 		input.style.height = `${ input.scrollHeight }px`;
+	};
+
+	const speechLabel = ( key, fallback ) =>
+		serverSpeech?.labels?.[ key ] || fallback;
+
+	const setSpeechStatus = ( value = '' ) => {
+		speechStatus.textContent = value;
+	};
+
+	const clearTimers = () => {
+		activeTimers.forEach( ( timer ) => clearTimeout( timer ) );
+		activeTimers.clear();
+	};
+
+	const wait = ( milliseconds, signal ) =>
+		new Promise( ( resolve, reject ) => {
+			const timer = setTimeout( () => {
+				activeTimers.delete( timer );
+				resolve();
+			}, milliseconds );
+			activeTimers.add( timer );
+			signal?.addEventListener(
+				'abort',
+				() => {
+					clearTimeout( timer );
+					activeTimers.delete( timer );
+					reject( new DOMException( 'Aborted', 'AbortError' ) );
+				},
+				{ once: true }
+			);
+		} );
+
+	const releasePlayback = () => {
+		if ( ! playback ) {
+			return;
+		}
+		playback.audio.onended = null;
+		playback.audio.onerror = null;
+		playback.audio.pause();
+		playback.audio.removeAttribute( 'src' );
+		URL.revokeObjectURL( playback.url );
+		if ( playback.button ) {
+			playback.button.disabled = true;
+			playback.button.textContent = speechLabel(
+				'read_aloud',
+				'Read aloud'
+			);
+			playback.button.setAttribute( 'aria-pressed', 'false' );
+		}
+		playback = null;
+		setSpeechStatus();
+	};
+
+	const stopPlayback = () => {
+		speechAbort?.abort();
+		speechAbort = null;
+		releasePlayback();
+	};
+
+	const releaseRecorder = ( turn, discard = false ) => {
+		if ( ! turn ) {
+			return;
+		}
+		if ( turn.timeout ) {
+			clearTimeout( turn.timeout );
+			activeTimers.delete( turn.timeout );
+			turn.timeout = null;
+		}
+		turn.stream?.getTracks().forEach( ( track ) => track.stop() );
+		if ( discard ) {
+			turn.cancelled = true;
+			turn.chunks = [];
+		}
+		if ( recorderTurn === turn ) {
+			recorderTurn = null;
+			microphoneButton.setAttribute( 'aria-pressed', 'false' );
+			microphoneButton.textContent = speechLabel(
+				'listen',
+				'Use microphone'
+			);
+		}
+	};
+
+	const cancelRecorder = () => {
+		const turn = recorderTurn;
+		if ( ! turn ) {
+			return;
+		}
+		turn.cancelled = true;
+		turn.chunks = [];
+		if ( turn.recorder.state !== 'inactive' ) {
+			turn.recorder.stop();
+		} else {
+			releaseRecorder( turn, true );
+		}
+		setSpeechStatus();
+	};
+
+	const stopAll = () => {
+		chatAbort?.abort();
+		chatAbort = null;
+		stopPlayback();
+		cancelRecorder();
+		clearTimers();
+	};
+
+	const playGrant = async ( grant, button ) => {
+		if ( playback ) {
+			stopPlayback();
+			return;
+		}
+		if ( ! grant || ! sessionToken ) {
+			return;
+		}
+
+		speechAbort?.abort();
+		speechAbort = new AbortController();
+		button.disabled = true;
+		setSpeechStatus( speechLabel( 'speaking', STRINGS.speaking ) );
+		try {
+			const result = await client.synthesize(
+				grant,
+				sessionToken,
+				speechAbort.signal
+			);
+			const blob = base64ToBlob( result.audio, result.mime_type );
+			const url = URL.createObjectURL( blob );
+			const audio = new Audio( url );
+			playback = { audio, button, url };
+			button.disabled = false;
+			button.textContent = speechLabel( 'stop', 'Stop' );
+			button.setAttribute( 'aria-pressed', 'true' );
+			audio.onended = releasePlayback;
+			audio.onerror = () => {
+				releasePlayback();
+				setSpeechStatus(
+					speechLabel( 'fallback', STRINGS.speechFallback )
+				);
+			};
+			await audio.play();
+		} catch ( error ) {
+			if ( error?.name !== 'AbortError' ) {
+				setSpeechStatus(
+					speechLabel( 'fallback', STRINGS.speechFallback )
+				);
+			}
+			button.disabled = true;
+			releasePlayback();
+		} finally {
+			speechAbort = null;
+		}
+	};
+
+	const addReadAloudControl = ( item, grant ) => {
+		if ( ! serverSpeech?.enabled || ! grant ) {
+			return null;
+		}
+		const button = document.createElement( 'button' );
+		button.type = 'button';
+		button.className = 'sd-ai-agent-embed-read-aloud';
+		button.textContent = speechLabel( 'read_aloud', 'Read aloud' );
+		button.setAttribute( 'aria-pressed', 'false' );
+		button.addEventListener( 'click', () => playGrant( grant, button ) );
+		item.appendChild( button );
+		return button;
 	};
 
 	const setMessageContent = ( item, role, text ) => {
@@ -597,6 +828,187 @@ export function mountEmbed( config ) {
 		return item;
 	};
 
+	const finishRecording = async ( turn ) => {
+		const chunks = turn.chunks;
+		turn.chunks = [];
+		releaseRecorder( turn );
+		if ( turn.cancelled || ! chunks.length ) {
+			return;
+		}
+
+		setSpeechStatus( speechLabel( 'transcribing', STRINGS.transcribing ) );
+		speechAbort?.abort();
+		speechAbort = new AbortController();
+		try {
+			const recording = new Blob( chunks, { type: turn.mimeType } );
+			const wav = await recordingToWav(
+				recording,
+				Number( serverSpeech.max_audio_bytes )
+			);
+			const result = await client.transcribe(
+				wav,
+				sessionToken,
+				speechLocale,
+				speechAbort.signal
+			);
+			if ( result?.language ) {
+				speechLocale = result.language;
+			}
+			input.value = result?.text || '';
+			autosizeInput();
+			if ( input.value && voiceModeInput.checked ) {
+				form.requestSubmit?.();
+			} else {
+				input.focus();
+			}
+			setSpeechStatus();
+		} catch ( error ) {
+			if ( error?.name !== 'AbortError' ) {
+				setSpeechStatus(
+					error?.message ||
+						speechLabel( 'fallback', STRINGS.speechFallback )
+				);
+			}
+		} finally {
+			speechAbort = null;
+		}
+	};
+
+	const startRecording = async () => {
+		if ( recorderTurn ) {
+			if ( recorderTurn.recorder.state !== 'inactive' ) {
+				recorderTurn.recorder.stop();
+			}
+			return;
+		}
+		if (
+			! microphoneConsent ||
+			! serverSpeech?.enabled ||
+			! sessionToken
+		) {
+			return;
+		}
+		stopPlayback();
+		const mimeType = selectRecordingMimeType(
+			serverSpeech.capture_mime_types
+		);
+		if ( ! mimeType ) {
+			setSpeechStatus(
+				speechLabel( 'fallback', STRINGS.speechFallback )
+			);
+			return;
+		}
+
+		setSpeechStatus( speechLabel( 'listening', STRINGS.listening ) );
+		try {
+			const stream = await navigator.mediaDevices.getUserMedia( {
+				audio: {
+					autoGainControl: true,
+					echoCancellation: true,
+					noiseSuppression: true,
+				},
+			} );
+			const recorder = new MediaRecorder( stream, { mimeType } );
+			const turn = {
+				cancelled: false,
+				chunks: [],
+				mimeType,
+				recorder,
+				stream,
+				timeout: null,
+				totalBytes: 0,
+			};
+			recorderTurn = turn;
+			microphoneButton.setAttribute( 'aria-pressed', 'true' );
+			microphoneButton.textContent = speechLabel( 'stop', 'Stop' );
+			recorder.ondataavailable = ( event ) => {
+				if ( turn.cancelled || ! event.data?.size ) {
+					return;
+				}
+				turn.chunks.push( event.data );
+				turn.totalBytes += event.data.size;
+				if (
+					turn.totalBytes > Number( serverSpeech.max_audio_bytes ) &&
+					recorder.state !== 'inactive'
+				) {
+					turn.cancelled = true;
+					recorder.stop();
+					setSpeechStatus(
+						speechLabel( 'fallback', STRINGS.speechFallback )
+					);
+				}
+			};
+			recorder.onerror = () => {
+				releaseRecorder( turn, true );
+				setSpeechStatus(
+					speechLabel( 'fallback', STRINGS.speechFallback )
+				);
+			};
+			recorder.onstop = () => finishRecording( turn );
+			recorder.start( 250 );
+			turn.timeout = setTimeout(
+				() => {
+					activeTimers.delete( turn.timeout );
+					turn.timeout = null;
+					if ( recorder.state !== 'inactive' ) {
+						recorder.stop();
+					}
+				},
+				Number( serverSpeech.max_recording_duration_seconds ) * 1000
+			);
+			activeTimers.add( turn.timeout );
+		} catch ( error ) {
+			setSpeechStatus(
+				error?.name === 'NotAllowedError'
+					? 'Microphone permission was denied. You can continue with typed chat.'
+					: speechLabel( 'fallback', STRINGS.speechFallback )
+			);
+		}
+	};
+
+	const configureSpeech = ( speech ) => {
+		serverSpeech = speech?.enabled ? speech : null;
+		const supported = Boolean(
+			serverSpeech &&
+				navigator.mediaDevices?.getUserMedia &&
+				typeof MediaRecorder !== 'undefined' &&
+				( globalThis.AudioContext || globalThis.webkitAudioContext ) &&
+				selectRecordingMimeType( serverSpeech.capture_mime_types )
+		);
+		if ( ! supported ) {
+			return;
+		}
+
+		speechDisclosure.hidden = false;
+		const disclosure = document.createElement( 'p' );
+		disclosure.textContent = serverSpeech.disclosure;
+		const consentButton = document.createElement( 'button' );
+		consentButton.type = 'button';
+		consentButton.className = 'sd-ai-agent-embed-speech-consent';
+		consentButton.textContent = speechLabel(
+			'continue',
+			'Allow microphone'
+		);
+		consentButton.addEventListener( 'click', () => {
+			microphoneConsent = true;
+			consentButton.remove();
+			microphoneButton.hidden = false;
+			if ( serverSpeech.voice_conversation_enabled ) {
+				voiceModeControl.hidden = false;
+				voiceModeControl.querySelector( 'span' ).textContent =
+					speechLabel( 'voice_mode', 'Voice conversation' );
+			}
+			startRecording();
+		} );
+		speechDisclosure.append( disclosure, consentButton );
+		microphoneButton.textContent = speechLabel(
+			'listen',
+			'Use microphone'
+		);
+	};
+
+	microphoneButton.addEventListener( 'click', startRecording );
+
 	autosizeInput();
 
 	const setUnavailable = ( message = STRINGS.unavailable ) => {
@@ -608,7 +1020,10 @@ export function mountEmbed( config ) {
 
 	const startSession = async ( recordingConsent, choice ) => {
 		try {
-			const session = await client.session( recordingConsent );
+			const session = await client.session(
+				recordingConsent,
+				speechLocale
+			);
 			sessionToken = session?.token || '';
 			if ( ! sessionToken ) {
 				setUnavailable();
@@ -619,6 +1034,7 @@ export function mountEmbed( config ) {
 			input.disabled = false;
 			sendButton.disabled = false;
 			addMessage( 'assistant', config.greeting );
+			configureSpeech( pendingSpeechConfig );
 			if ( ! panel.hidden ) {
 				input.focus();
 			}
@@ -683,6 +1099,7 @@ export function mountEmbed( config ) {
 				return;
 			}
 
+			pendingSpeechConfig = serverConfig?.speech || null;
 			if ( serverConfig?.recording?.enabled ) {
 				addRecordingChoice( serverConfig.recording );
 				return;
@@ -698,10 +1115,13 @@ export function mountEmbed( config ) {
 		launcher.setAttribute( 'aria-expanded', expanded ? 'true' : 'false' );
 		if ( expanded ) {
 			input.focus();
+		} else {
+			stopAll();
 		}
 	} );
 
 	close.addEventListener( 'click', () => {
+		stopAll();
 		panel.hidden = true;
 		launcher.setAttribute( 'aria-expanded', 'false' );
 	} );
@@ -733,8 +1153,17 @@ export function mountEmbed( config ) {
 		autosizeInput();
 		addMessage( 'user', message );
 		const pending = addMessage( 'assistant', STRINGS.thinking );
+		if ( voiceModeInput.checked ) {
+			setSpeechStatus( speechLabel( 'thinking', STRINGS.thinking ) );
+		}
+		chatAbort?.abort();
+		chatAbort = new AbortController();
 		try {
-			const run = await client.send( message, sessionToken );
+			const run = await client.send(
+				message,
+				sessionToken,
+				chatAbort.signal
+			);
 			let status = run;
 			for ( let attempt = 0; attempt < 60; attempt += 1 ) {
 				if (
@@ -743,8 +1172,12 @@ export function mountEmbed( config ) {
 				) {
 					break;
 				}
-				await new Promise( ( resolve ) => setTimeout( resolve, 1500 ) );
-				status = await client.poll( run.job_id, sessionToken );
+				await wait( 1500, chatAbort.signal );
+				status = await client.poll(
+					run.job_id,
+					sessionToken,
+					chatAbort.signal
+				);
 			}
 			if ( status.status !== 'complete' ) {
 				if ( status?.diagnostic?.reason === CREDIT_EXHAUSTED_REASON ) {
@@ -765,12 +1198,39 @@ export function mountEmbed( config ) {
 				'assistant',
 				status.reply || STRINGS.unavailable
 			);
+			const readAloud = addReadAloudControl(
+				pending,
+				status?.speech?.synthesis_grant
+			);
+			if ( voiceModeInput.checked && readAloud ) {
+				await playGrant( status.speech.synthesis_grant, readAloud );
+			} else {
+				setSpeechStatus();
+			}
 		} catch ( error ) {
+			if ( error?.name === 'AbortError' ) {
+				pending.remove();
+				return;
+			}
 			setMessageContent(
 				pending,
 				'assistant',
 				error.message || STRINGS.unavailable
 			);
+			setSpeechStatus(
+				voiceModeInput.checked
+					? speechLabel( 'fallback', STRINGS.speechFallback )
+					: ''
+			);
+		} finally {
+			chatAbort = null;
+		}
+	} );
+
+	window.addEventListener( 'pagehide', stopAll );
+	document.addEventListener( 'visibilitychange', () => {
+		if ( document.hidden ) {
+			stopAll();
 		}
 	} );
 

--- a/src/embed-widget/style.css
+++ b/src/embed-widget/style.css
@@ -64,6 +64,59 @@
 	border-bottom: 1px solid var(--sdaa-embed-border);
 }
 
+.sd-ai-agent-embed-speech-disclosure,
+.sd-ai-agent-embed-voice-mode,
+.sd-ai-agent-embed-speech-status {
+	padding: 8px 12px;
+	border-top: 1px solid var(--sdaa-embed-border);
+	background: var(--sdaa-embed-surface);
+	color: var(--sdaa-embed-muted);
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.sd-ai-agent-embed-speech-disclosure[hidden],
+.sd-ai-agent-embed-voice-mode[hidden] {
+	display: none;
+}
+
+.sd-ai-agent-embed-speech-disclosure p {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-embed-speech-consent,
+.sd-ai-agent-embed-microphone,
+.sd-ai-agent-embed-read-aloud {
+	padding: 6px 10px;
+	border: 1px solid var(--sdaa-embed-border);
+	border-radius: 999px;
+	background: var(--sdaa-embed-surface);
+	color: var(--sdaa-embed-text);
+	cursor: pointer;
+	font: inherit;
+}
+
+.sd-ai-agent-embed-microphone[aria-pressed="true"],
+.sd-ai-agent-embed-read-aloud[aria-pressed="true"] {
+	border-color: #d63638;
+	color: #d63638;
+}
+
+.sd-ai-agent-embed-voice-mode {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.sd-ai-agent-embed-speech-status:empty {
+	display: none;
+}
+
+.sd-ai-agent-embed-read-aloud {
+	display: block;
+	margin-top: 8px;
+}
+
 .sdaa-embed__form {
 	align-items: flex-end;
 	border-top: 1px solid var(--sdaa-embed-border);

--- a/src/utils/speech-core.js
+++ b/src/utils/speech-core.js
@@ -1,0 +1,199 @@
+/** Framework-free speech helpers shared by authenticated and static clients. */
+
+export const BROWSER_RECORDING_MIME_TYPES = [
+	'audio/webm;codecs=opus',
+	'audio/webm',
+	'audio/ogg;codecs=opus',
+	'audio/mp4',
+];
+
+export const isManagedAudioPlaybackSupported =
+	typeof Audio !== 'undefined' &&
+	typeof URL !== 'undefined' &&
+	typeof URL.createObjectURL === 'function';
+
+export const isBrowserSpeechSynthesisSupported =
+	typeof globalThis.speechSynthesis !== 'undefined' &&
+	typeof globalThis.SpeechSynthesisUtterance !== 'undefined';
+
+/**
+ * Select a MediaRecorder input that can be converted to the managed WAV contract.
+ * @param {string[]} acceptedMimeTypes Service-compatible capture MIME types.
+ * @return {string} Selected browser recording MIME type.
+ */
+export const selectRecordingMimeType = ( acceptedMimeTypes = [] ) => {
+	if ( typeof MediaRecorder === 'undefined' ) {
+		return '';
+	}
+	const candidates = acceptedMimeTypes.some( ( candidate ) =>
+		candidate.toLowerCase().startsWith( 'audio/wav' )
+	)
+		? BROWSER_RECORDING_MIME_TYPES
+		: acceptedMimeTypes;
+
+	return (
+		candidates.find( ( candidate ) =>
+			MediaRecorder.isTypeSupported?.( candidate )
+		) || ''
+	);
+};
+
+/**
+ * Convert Markdown response content into bounded speech-ready text.
+ * @param {string} text Raw response content.
+ * @return {string} Plain speech-ready text.
+ */
+export const toSpeakableText = ( text ) =>
+	text
+		.replace( /```[\s\S]*?```/g, '' )
+		.replace( /`([^`]+)`/g, '$1' )
+		.replace( /!\[[^\]]*\]\([^)]+\)/g, '' )
+		.replace( /\[([^\]]+)\]\([^)]+\)/g, '$1' )
+		.replace( /^[#>*\-+]\s*/gm, '' )
+		.replace( /\*{1,3}([^*]+)\*{1,3}/g, '$1' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+
+/**
+ * Split text at sentence boundaries without splitting Unicode units.
+ * @param {string} text  Input text.
+ * @param {number} limit Maximum code points per chunk.
+ * @return {string[]} Bounded speech chunks.
+ */
+export const chunkSpeechText = ( text, limit ) => {
+	if ( ! Number.isFinite( limit ) || limit < 1 ) {
+		return [];
+	}
+	const chunks = [];
+	let remaining = Array.from( text );
+	while ( remaining.length ) {
+		let end = Math.min( limit, remaining.length );
+		if ( end < remaining.length ) {
+			for ( let index = end - 2; index > 0; index-- ) {
+				if (
+					/[.!?]/.test( remaining[ index ] ) &&
+					/\s/.test( remaining[ index + 1 ] )
+				) {
+					end = index + 2;
+					break;
+				}
+			}
+		}
+		chunks.push( remaining.slice( 0, end ).join( '' ).trim() );
+		remaining = remaining.slice( end );
+	}
+	return chunks.filter( Boolean );
+};
+
+/**
+ * Decode managed inline audio without persisting it.
+ * @param {string} value    Base64-encoded audio.
+ * @param {string} mimeType Validated audio MIME type.
+ * @return {Blob} Temporary audio blob.
+ */
+export const base64ToBlob = ( value, mimeType ) => {
+	if ( typeof value !== 'string' || ! value ) {
+		throw new Error( 'The speech service returned invalid audio.' );
+	}
+	const decoded = globalThis.atob( value );
+	const bytes = new Uint8Array( decoded.length );
+	for ( let index = 0; index < decoded.length; index++ ) {
+		bytes[ index ] = decoded.charCodeAt( index );
+	}
+	return new Blob( [ bytes ], { type: mimeType } );
+};
+
+const writeAscii = ( view, offset, value ) => {
+	for ( let index = 0; index < value.length; index++ ) {
+		view.setUint8( offset + index, value.charCodeAt( index ) );
+	}
+};
+
+/**
+ * Encode decoded browser audio as bounded 16 kHz mono PCM WAV.
+ * @param {AudioBuffer} audioBuffer Decoded browser audio.
+ * @param {number}      maxBytes    Maximum encoded size.
+ * @return {Blob} Strict PCM WAV recording.
+ */
+export const encodeAudioBufferToWav = ( audioBuffer, maxBytes = 0 ) => {
+	const targetRate = Math.min( 16000, audioBuffer.sampleRate );
+	const frameCount = Math.max(
+		1,
+		Math.floor( audioBuffer.duration * targetRate )
+	);
+	const byteLength = 44 + frameCount * 2;
+	if ( maxBytes > 0 && byteLength > maxBytes ) {
+		throw new Error( 'The recording reached the service limit.' );
+	}
+
+	const output = new ArrayBuffer( byteLength );
+	const view = new DataView( output );
+	writeAscii( view, 0, 'RIFF' );
+	view.setUint32( 4, byteLength - 8, true );
+	writeAscii( view, 8, 'WAVE' );
+	writeAscii( view, 12, 'fmt ' );
+	view.setUint32( 16, 16, true );
+	view.setUint16( 20, 1, true );
+	view.setUint16( 22, 1, true );
+	view.setUint32( 24, targetRate, true );
+	view.setUint32( 28, targetRate * 2, true );
+	view.setUint16( 32, 2, true );
+	view.setUint16( 34, 16, true );
+	writeAscii( view, 36, 'data' );
+	view.setUint32( 40, frameCount * 2, true );
+
+	const channels = Array.from(
+		{ length: audioBuffer.numberOfChannels },
+		( _, channel ) => audioBuffer.getChannelData( channel )
+	);
+	const sourceRate = audioBuffer.sampleRate;
+	for ( let frame = 0; frame < frameCount; frame++ ) {
+		const sourcePosition = ( frame * sourceRate ) / targetRate;
+		const lower = Math.min(
+			audioBuffer.length - 1,
+			Math.floor( sourcePosition )
+		);
+		const upper = Math.min( audioBuffer.length - 1, lower + 1 );
+		const fraction = sourcePosition - lower;
+		let sample = 0;
+		channels.forEach( ( channel ) => {
+			sample +=
+				channel[ lower ] +
+				( channel[ upper ] - channel[ lower ] ) * fraction;
+		} );
+		sample = Math.max( -1, Math.min( 1, sample / channels.length ) );
+		view.setInt16(
+			44 + frame * 2,
+			sample < 0 ? sample * 0x8000 : sample * 0x7fff,
+			true
+		);
+	}
+
+	return new Blob( [ output ], { type: 'audio/wav' } );
+};
+
+/**
+ * Convert a MediaRecorder payload to the managed strict WAV format.
+ * @param {Blob}   recording MediaRecorder output.
+ * @param {number} maxBytes  Maximum encoded size.
+ * @return {Promise<Blob>} Strict PCM WAV recording.
+ */
+export const recordingToWav = async ( recording, maxBytes = 0 ) => {
+	const AudioContextClass =
+		globalThis.AudioContext || globalThis.webkitAudioContext;
+	if ( ! AudioContextClass ) {
+		throw new Error(
+			'This browser cannot prepare audio for transcription.'
+		);
+	}
+
+	const context = new AudioContextClass();
+	try {
+		const decoded = await context.decodeAudioData(
+			await recording.arrayBuffer()
+		);
+		return encodeAudioBufferToWav( decoded, maxBytes );
+	} finally {
+		await context.close?.();
+	}
+};

--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -3,16 +3,19 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
+export {
+	base64ToBlob,
+	BROWSER_RECORDING_MIME_TYPES,
+	chunkSpeechText,
+	encodeAudioBufferToWav,
+	isBrowserSpeechSynthesisSupported,
+	isManagedAudioPlaybackSupported,
+	recordingToWav,
+	selectRecordingMimeType,
+	toSpeakableText,
+} from './speech-core';
+
 let capabilitiesRequest = null;
-
-export const isManagedAudioPlaybackSupported =
-	typeof Audio !== 'undefined' &&
-	typeof URL !== 'undefined' &&
-	typeof URL.createObjectURL === 'function';
-
-export const isBrowserSpeechSynthesisSupported =
-	typeof globalThis.speechSynthesis !== 'undefined' &&
-	typeof globalThis.SpeechSynthesisUtterance !== 'undefined';
 
 /**
  * Load the authenticated speech contract once for the current page lifecycle.
@@ -46,170 +49,4 @@ export const loadSpeechCapabilities = async ( { force = false } = {} ) => {
 /** Clear page-local capability state, primarily after authentication changes. */
 export const resetSpeechCapabilities = () => {
 	capabilitiesRequest = null;
-};
-
-/**
- * Convert Markdown response content into bounded speech-ready text.
- *
- * @param {string} text Raw response content.
- * @return {string} Plain text without code payloads.
- */
-export const toSpeakableText = ( text ) =>
-	text
-		.replace( /```[\s\S]*?```/g, '' )
-		.replace( /`([^`]+)`/g, '$1' )
-		.replace( /!\[[^\]]*\]\([^)]+\)/g, '' )
-		.replace( /\[([^\]]+)\]\([^)]+\)/g, '$1' )
-		.replace( /^[#>*\-+]\s*/gm, '' )
-		.replace( /\*{1,3}([^*]+)\*{1,3}/g, '$1' )
-		.replace( /\s+/g, ' ' )
-		.trim();
-
-/**
- * Split a string at sentence/word boundaries without splitting Unicode units.
- *
- * @param {string} text  Input text.
- * @param {number} limit Maximum code points per chunk.
- * @return {string[]} Bounded chunks.
- */
-export const chunkSpeechText = ( text, limit ) => {
-	if ( ! Number.isFinite( limit ) || limit < 1 ) {
-		return [];
-	}
-	const characters = Array.from( text );
-	const chunks = [];
-	let remaining = characters;
-	while ( remaining.length ) {
-		let end = Math.min( limit, remaining.length );
-		if ( end < remaining.length ) {
-			for ( let index = end - 2; index > 0; index-- ) {
-				if (
-					/[.!?]/.test( remaining[ index ] ) &&
-					/\s/.test( remaining[ index + 1 ] )
-				) {
-					end = index + 2;
-					break;
-				}
-			}
-		}
-		chunks.push( remaining.slice( 0, end ).join( '' ).trim() );
-		remaining = remaining.slice( end );
-	}
-	return chunks.filter( Boolean );
-};
-
-/**
- * Decode a managed inline-audio response without persisting it.
- *
- * @param {string} value    Base64-encoded audio.
- * @param {string} mimeType Validated response MIME type.
- * @return {Blob} Temporary audio payload.
- */
-export const base64ToBlob = ( value, mimeType ) => {
-	if ( typeof value !== 'string' || ! value ) {
-		throw new Error( 'The speech service returned invalid audio.' );
-	}
-	const decoded = globalThis.atob( value );
-	const bytes = new Uint8Array( decoded.length );
-	for ( let index = 0; index < decoded.length; index++ ) {
-		bytes[ index ] = decoded.charCodeAt( index );
-	}
-	return new Blob( [ bytes ], { type: mimeType } );
-};
-
-const writeAscii = ( view, offset, value ) => {
-	for ( let index = 0; index < value.length; index++ ) {
-		view.setUint8( offset + index, value.charCodeAt( index ) );
-	}
-};
-
-/**
- * Encode decoded browser audio as bounded 16 kHz mono PCM WAV.
- *
- * @param {AudioBuffer} audioBuffer Decoded browser audio.
- * @param {number}      maxBytes    Maximum encoded size.
- * @return {Blob} PCM WAV recording.
- */
-export const encodeAudioBufferToWav = ( audioBuffer, maxBytes = 0 ) => {
-	const targetRate = Math.min( 16000, audioBuffer.sampleRate );
-	const frameCount = Math.max(
-		1,
-		Math.floor( audioBuffer.duration * targetRate )
-	);
-	const byteLength = 44 + frameCount * 2;
-	if ( maxBytes > 0 && byteLength > maxBytes ) {
-		throw new Error( 'The recording reached the service limit.' );
-	}
-
-	const output = new ArrayBuffer( byteLength );
-	const view = new DataView( output );
-	writeAscii( view, 0, 'RIFF' );
-	view.setUint32( 4, byteLength - 8, true );
-	writeAscii( view, 8, 'WAVE' );
-	writeAscii( view, 12, 'fmt ' );
-	view.setUint32( 16, 16, true );
-	view.setUint16( 20, 1, true );
-	view.setUint16( 22, 1, true );
-	view.setUint32( 24, targetRate, true );
-	view.setUint32( 28, targetRate * 2, true );
-	view.setUint16( 32, 2, true );
-	view.setUint16( 34, 16, true );
-	writeAscii( view, 36, 'data' );
-	view.setUint32( 40, frameCount * 2, true );
-
-	const channels = Array.from(
-		{ length: audioBuffer.numberOfChannels },
-		( _, channel ) => audioBuffer.getChannelData( channel )
-	);
-	const sourceRate = audioBuffer.sampleRate;
-	for ( let frame = 0; frame < frameCount; frame++ ) {
-		const sourcePosition = ( frame * sourceRate ) / targetRate;
-		const lower = Math.min(
-			audioBuffer.length - 1,
-			Math.floor( sourcePosition )
-		);
-		const upper = Math.min( audioBuffer.length - 1, lower + 1 );
-		const fraction = sourcePosition - lower;
-		let sample = 0;
-		channels.forEach( ( channel ) => {
-			sample +=
-				channel[ lower ] +
-				( channel[ upper ] - channel[ lower ] ) * fraction;
-		} );
-		sample = Math.max( -1, Math.min( 1, sample / channels.length ) );
-		view.setInt16(
-			44 + frame * 2,
-			sample < 0 ? sample * 0x8000 : sample * 0x7fff,
-			true
-		);
-	}
-
-	return new Blob( [ output ], { type: 'audio/wav' } );
-};
-
-/**
- * Convert a browser MediaRecorder payload to the service's strict WAV format.
- *
- * @param {Blob}   recording Recording captured by MediaRecorder.
- * @param {number} maxBytes  Maximum encoded request size.
- * @return {Promise<Blob>} Strict PCM WAV payload.
- */
-export const recordingToWav = async ( recording, maxBytes = 0 ) => {
-	const AudioContextClass =
-		globalThis.AudioContext || globalThis.webkitAudioContext;
-	if ( ! AudioContextClass ) {
-		throw new Error(
-			'This browser cannot prepare audio for transcription.'
-		);
-	}
-
-	const context = new AudioContextClass();
-	try {
-		const decoded = await context.decodeAudioData(
-			await recording.arrayBuffer()
-		);
-		return encodeAudioBufferToWav( decoded, maxBytes );
-	} finally {
-		await context.close?.();
-	}
 };

--- a/tests/SdAiAgent/REST/PublicChatControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicChatControllerTest.php
@@ -64,6 +64,10 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 	private function dispatch( string $method, string $route, array $params = array(), string $origin = 'https://docs.example.test' ) {
 		$request = new WP_REST_Request( $method, $route );
 		$request->set_header( 'Origin', $origin );
+		if ( 'GET' === $method && isset( $params['token'] ) ) {
+			$request->set_header( 'Authorization', 'Bearer ' . (string) $params['token'] );
+			unset( $params['token'] );
+		}
 		if ( in_array( $method, array( 'POST', 'PATCH', 'PUT' ), true ) ) {
 			$request->set_header( 'Content-Type', 'application/json' );
 			$request->set_body( wp_json_encode( $params ) );
@@ -107,6 +111,11 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/public-chat/config' );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertFalse( $response->get_data()['enabled'] );
+		$this->assertFalse( $response->get_data()['speech']['enabled'] );
+		$this->assertSame( 0, $response->get_data()['speech']['max_audio_bytes'] );
+		$this->assertSame( 0, $response->get_data()['speech']['max_recording_duration_seconds'] );
+		$this->assertSame( 0, $response->get_data()['speech']['max_tts_characters'] );
+		$this->assertArrayNotHasKey( 'voice', $response->get_data()['speech'] );
 
 		$this->enable_public_chat();
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/public-chat/config', array(), 'https://evil.example.test' );

--- a/tests/SdAiAgent/REST/PublicSpeechControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicSpeechControllerTest.php
@@ -1,0 +1,465 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Core\PublicChatSecurity;
+use SdAiAgent\Core\Settings;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\REST\PublicSpeechController;
+use SdAiAgent\REST\SpeechController;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/** Covers the anonymous speech session, upload, grant, and replay boundaries. */
+final class PublicSpeechControllerTest extends WP_UnitTestCase {
+
+	private WP_REST_Server $server;
+	private HttpTransporterInterface $original_transporter;
+	private PublicSpeechTransporter $transporter;
+	private PublicChatSecurity $security;
+	private PublicSpeechController $controller;
+
+	public function set_up(): void {
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		parent::set_up();
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		( new SuperdavAiProviderHandler() )->register_provider();
+		$registry                   = AiClient::defaultRegistry();
+		$this->original_transporter = $registry->getHttpTransporter();
+		$this->transporter          = new PublicSpeechTransporter();
+		$registry->setHttpTransporter( $this->transporter );
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'public-speech-test-token', false );
+
+		Settings::instance()->update(
+			array(
+				'public_chat_enabled'                      => true,
+				'public_chat_speech_enabled'               => true,
+				'public_chat_speech_max_recording_seconds' => 30,
+				'public_chat_speech_max_tts_characters'    => 500,
+				'public_chat_allowed_origins'              => array( 'https://docs.example.test' ),
+				'public_chat_embed_id'                     => 'docs',
+				'public_chat_collection_ids'               => array( 'docs' ),
+			)
+		);
+		$this->security   = new PublicChatSecurity();
+		$speech          = new SpeechController( null, null, static fn( string $path ): bool => is_file( $path ) );
+		$this->controller = new PublicSpeechController( $this->security, $speech );
+	}
+
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		AiClient::defaultRegistry()->setHttpTransporter( $this->original_transporter );
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( Settings::OPTION_NAME );
+		parent::tear_down();
+	}
+
+	/** Public speech routes are separate from the authenticated speech routes. */
+	public function test_registers_focused_public_speech_routes(): void {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/public-chat/speech/transcriptions', $routes );
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/public-chat/speech/synthesis', $routes );
+	}
+
+	/** An allowlisted visitor can transcribe one strict bounded WAV without attachment persistence. */
+	public function test_transcribes_session_bound_recording_without_creating_attachment(): void {
+		$token = $this->create_session_token();
+		$path  = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+		$before_attachments = wp_count_attachments()->inherit ?? 0;
+
+		$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 'Synthetic public transcript', $result->get_data()['text'] );
+		$this->assertSame( 'en-US', $result->get_data()['language'] );
+		$this->assertFileDoesNotExist( $path );
+		$this->assertSame( 1, $this->transporter->request_count_for( '/audio/transcriptions' ) );
+		$this->assertSame( $before_attachments, wp_count_attachments()->inherit ?? 0 );
+		$this->assertStringNotContainsString( 'public-speech-test-token', (string) wp_json_encode( $result->get_data() ) );
+	}
+
+	/** The public duration ceiling rejects locally before capability or transcription spend. */
+	public function test_rejects_recording_over_public_duration_before_upstream_spend(): void {
+		Settings::instance()->update( array( 'public_chat_speech_max_recording_seconds' => 1 ) );
+		$token  = $this->create_session_token();
+		$sid    = $this->session_uuid( $token );
+		$path   = $this->write_temporary_audio( $this->valid_wav( 2.0, 8000 ) );
+		$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_audio_too_long', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $path );
+		$this->assertCount( 0, $this->transporter->requests );
+		$this->assertFalse( get_transient( 'sd_ai_agent_public_speech_seconds_' . md5( $sid ) ) );
+	}
+
+	/** Metrics expose only low-cardinality operational dimensions. */
+	public function test_emits_content_free_public_speech_metrics(): void {
+		$metrics  = array();
+		$listener = static function ( array $metric ) use ( &$metrics ): void {
+			$metrics[] = $metric;
+		};
+		add_action( 'sd_ai_agent_public_speech_metric', $listener );
+
+		try {
+			$token  = $this->create_session_token();
+			$path   = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+			$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+			$this->assertInstanceOf( WP_REST_Response::class, $result );
+		} finally {
+			remove_action( 'sd_ai_agent_public_speech_metric', $listener );
+		}
+
+		$this->assertCount( 1, $metrics );
+		$this->assertSame( 'transcription', $metrics[0]['operation'] );
+		$this->assertSame( 'success', $metrics[0]['outcome'] );
+		$this->assertSame( 'up_to_64kb', $metrics[0]['bytes_bucket'] );
+		$this->assertSame( 'up_to_5s', $metrics[0]['duration_bucket'] );
+		$encoded = (string) wp_json_encode( $metrics[0] );
+		$this->assertStringNotContainsString( 'Synthetic public transcript', $encoded );
+		$this->assertStringNotContainsString( 'public-speech-test-token', $encoded );
+		$this->assertStringNotContainsString( $token, $encoded );
+	}
+
+	/** Origin and embed bindings reject a copied token before audio processing. */
+	public function test_rejects_token_from_wrong_origin_or_embed(): void {
+		$token = $this->create_session_token();
+		$path  = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+
+		$request = $this->transcription_request( $token, $path, 'https://other.example.test' );
+		$result  = $this->controller->handle_transcription( $request );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_public_chat_origin_forbidden', $result->get_error_code() );
+		$this->assertFileExists( $path );
+		wp_delete_file( $path );
+
+		$path    = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+		$request = $this->transcription_request( $token, $path );
+		$request->set_body_params(
+			array(
+				'token'    => $token,
+				'embed_id' => 'other',
+				'language' => 'en-US',
+			)
+		);
+		$result = $this->controller->handle_transcription( $request );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_public_chat_invalid_token', $result->get_error_code() );
+		wp_delete_file( $path );
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** Missing origins and uncontrolled upload shapes fail before audio processing. */
+	public function test_rejects_missing_origin_invalid_magic_and_oversize_audio_before_spend(): void {
+		$token = $this->create_session_token();
+		$path  = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+
+		$request = $this->transcription_request( $token, $path, '' );
+		$result  = $this->controller->handle_transcription( $request );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_public_chat_origin_forbidden', $result->get_error_code() );
+		$this->assertFileExists( $path );
+		wp_delete_file( $path );
+
+		$path   = $this->write_temporary_audio( 'not a wav recording' );
+		$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_invalid_audio', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $path );
+
+		$maximum = (int) $this->security->settings()['speech_max_audio_bytes'];
+		$path    = $this->write_temporary_audio( str_repeat( "\0", $maximum + 1 ) );
+		$result  = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_audio_too_large', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $path );
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** Anonymous request-rate and concurrency controls reject before upstream spend. */
+	public function test_enforces_public_speech_rate_and_concurrency_limits(): void {
+		$token = $this->create_session_token();
+		$sid   = $this->session_uuid( $token );
+		for ( $attempt = 0; $attempt < 4; ++$attempt ) {
+			$this->assertTrue( $this->security->check_speech_rate_limit( $sid ) );
+		}
+
+		$path   = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+		$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_public_chat_rate_limited', $result->get_error_code() );
+		$this->assertFileExists( $path );
+		wp_delete_file( $path );
+
+		$token = $this->create_session_token();
+		$sid   = $this->session_uuid( $token );
+		$lock  = $this->security->acquire_speech_lock( $sid );
+		$this->assertIsArray( $lock );
+		try {
+			$path   = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+			$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertSame( 'sd_ai_agent_public_speech_busy', $result->get_error_code() );
+			$this->assertFileExists( $path );
+			wp_delete_file( $path );
+		} finally {
+			$this->security->release_speech_lock( $lock );
+		}
+		$this->assertCount( 0, $this->transporter->requests );
+	}
+
+	/** A completed reply grant synthesizes once and cannot become an arbitrary text proxy. */
+	public function test_synthesizes_only_granted_assistant_reply_once(): void {
+		$token = $this->create_session_token();
+		$sid   = $this->session_uuid( $token );
+		$grant = $this->security->issue_synthesis_grant( $sid, $token, 'https://docs.example.test', 'Read **this answer**.' );
+		$this->assertIsArray( $grant );
+
+		$result = $this->controller->handle_synthesis( $this->synthesis_request( $token, $grant['grant'] ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( base64_encode( 'public-synthetic-audio' ), $result->get_data()['audio'] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Verifies explicit inline audio.
+		$this->assertSame( 1, $this->transporter->request_count_for( '/audio/speech' ) );
+		$request = $this->transporter->last_request_for( '/audio/speech' );
+		$this->assertNotNull( $request );
+		$this->assertSame( 'Read this answer.', $request->getData()['input'] ?? null );
+
+		$replay = $this->controller->handle_synthesis( $this->synthesis_request( $token, $grant['grant'] ) );
+		$this->assertInstanceOf( WP_Error::class, $replay );
+		$this->assertSame( 'sd_ai_agent_public_speech_invalid_grant', $replay->get_error_code() );
+		$this->assertSame( 1, $this->transporter->request_count_for( '/audio/speech' ) );
+
+		$arbitrary = $this->synthesis_request( $token, $grant['grant'] );
+		$arbitrary->set_body(
+			(string) wp_json_encode(
+				array(
+					'token'    => $token,
+					'embed_id' => 'docs',
+					'grant'    => $grant['grant'],
+					'text'     => 'Convert arbitrary visitor text.',
+				)
+			)
+		);
+		$rejected = $this->controller->handle_synthesis( $arbitrary );
+		$this->assertInstanceOf( WP_Error::class, $rejected );
+		$this->assertSame( 'sd_ai_agent_invalid_speech_text', $rejected->get_error_code() );
+	}
+
+	/** Missing/expired grants and exhausted session spend fail before synthesis. */
+	public function test_rejects_missing_expired_and_over_budget_synthesis(): void {
+		$token   = $this->create_session_token();
+		$missing = $this->controller->handle_synthesis( $this->synthesis_request( $token, '' ) );
+		$this->assertInstanceOf( WP_Error::class, $missing );
+		$this->assertSame( 'sd_ai_agent_invalid_speech_text', $missing->get_error_code() );
+
+		$sid   = $this->session_uuid( $token );
+		$grant = $this->security->issue_synthesis_grant( $sid, $token, 'https://docs.example.test', 'An expiring reply.' );
+		$this->assertIsArray( $grant );
+		$grant_key = $this->synthesis_grant_key( $grant['grant'] );
+		$state     = get_transient( $grant_key );
+		$this->assertIsArray( $state );
+		$state['exp'] = time() - 1;
+		set_transient( $grant_key, $state, MINUTE_IN_SECONDS );
+		$expired = $this->controller->handle_synthesis( $this->synthesis_request( $token, $grant['grant'] ) );
+		$this->assertInstanceOf( WP_Error::class, $expired );
+		$this->assertSame( 'sd_ai_agent_public_speech_invalid_grant', $expired->get_error_code() );
+		delete_transient( $grant_key );
+
+		$token = $this->create_session_token();
+		$sid   = $this->session_uuid( $token );
+		$this->assertTrue( $this->security->consume_speech_budget( $sid, 'synthesis', 10000 ) );
+		$grant = $this->security->issue_synthesis_grant( $sid, $token, 'https://docs.example.test', 'A reply after the budget is exhausted.' );
+		$this->assertIsArray( $grant );
+		$limited = $this->controller->handle_synthesis( $this->synthesis_request( $token, $grant['grant'] ) );
+		$this->assertInstanceOf( WP_Error::class, $limited );
+		$this->assertSame( 'sd_ai_agent_public_speech_limit_exceeded', $limited->get_error_code() );
+		$this->assertSame( 0, $this->transporter->request_count_for( '/audio/speech' ) );
+
+		delete_transient( 'sd_ai_agent_public_speech_characters_' . md5( $sid ) );
+		delete_transient( 'sd_ai_agent_public_speech_site_characters_' . gmdate( 'Ymd' ) );
+	}
+
+	/** Disabling speech invalidates existing session use before managed spend. */
+	public function test_speech_disable_is_immediate(): void {
+		$token = $this->create_session_token();
+		Settings::instance()->update( array( 'public_chat_speech_enabled' => false ) );
+		$path   = $this->write_temporary_audio( $this->valid_wav( 0.1 ) );
+		$result = $this->controller->handle_transcription( $this->transcription_request( $token, $path ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_public_speech_disabled', $result->get_error_code() );
+		$this->assertCount( 0, $this->transporter->requests );
+		wp_delete_file( $path );
+	}
+
+	private function create_session_token(): string {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/public-chat/session' );
+		$request->set_header( 'Origin', 'https://docs.example.test' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( array( 'embed_id' => 'docs', 'locale' => 'en-US' ) ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+		return (string) $response->get_data()['token'];
+	}
+
+	private function transcription_request( string $token, string $path, string $origin = 'https://docs.example.test' ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/public-chat/speech/transcriptions' );
+		$request->set_header( 'Origin', $origin );
+		$request->set_body_params(
+			array(
+				'token'    => $token,
+				'embed_id' => 'docs',
+				'language' => 'en-US',
+			)
+		);
+		$request->set_file_params(
+			array(
+				SpeechController::UPLOAD_FIELD => array(
+					'error'    => UPLOAD_ERR_OK,
+					'tmp_name' => $path,
+					'name'     => 'recording.wav',
+					'type'     => 'audio/wav',
+				),
+			)
+		);
+		return $request;
+	}
+
+	private function synthesis_request( string $token, string $grant ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/public-chat/speech/synthesis' );
+		$request->set_header( 'Origin', 'https://docs.example.test' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			(string) wp_json_encode(
+				array(
+					'token'    => $token,
+					'embed_id' => 'docs',
+					'grant'    => $grant,
+				)
+			)
+		);
+		return $request;
+	}
+
+	private function session_uuid( string $token ): string {
+		$parsed = $this->security->parse_token( $token );
+		$this->assertIsArray( $parsed );
+		return (string) $parsed['sid'];
+	}
+
+	/** Resolve the private transient key represented by a signed test grant. */
+	private function synthesis_grant_key( string $grant ): string {
+		$body    = explode( '.', $grant, 2 )[0];
+		$decoded = base64_decode( strtr( $body, '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes a signed test fixture.
+		$this->assertIsString( $decoded );
+		$data = json_decode( $decoded, true );
+		$this->assertIsArray( $data );
+		$this->assertIsString( $data['gid'] ?? null );
+
+		return 'sd_ai_agent_public_speech_grant_' . md5( $data['gid'] );
+	}
+
+	private function write_temporary_audio( string $audio ): string {
+		$path = wp_tempnam( 'sd-ai-agent-public-speech-test.wav' );
+		$this->assertIsString( $path );
+		$this->assertNotFalse( file_put_contents( $path, $audio ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Creates an isolated synthetic fixture.
+		return $path;
+	}
+
+	/** Return a mono 16-bit PCM WAV fixture. */
+	private function valid_wav( float $seconds, int $sample_rate = 16000 ): string {
+		$byte_rate = $sample_rate * 2;
+		$data      = str_repeat( "\0", (int) ( $byte_rate * $seconds ) );
+		$fmt       = pack( 'vvVVvv', 1, 1, $sample_rate, $byte_rate, 2, 16 );
+		return 'RIFF' . pack( 'V', 36 + strlen( $data ) ) . 'WAVEfmt ' . pack( 'V', 16 ) . $fmt . 'data' . pack( 'V', strlen( $data ) ) . $data;
+	}
+}
+
+/** Deterministic managed-service responses for public speech tests. */
+final class PublicSpeechTransporter implements HttpTransporterInterface {
+
+	/** @var list<Request> */
+	public array $requests = array();
+
+	public function send( Request $request, ?RequestOptions $options = null ): Response {
+		unset( $options );
+		$this->requests[] = $request;
+		$uri              = $request->getUri();
+		if ( str_ends_with( $uri, '/audio/capabilities' ) ) {
+			return $this->json_response(
+				array(
+					'text_to_speech' => array(
+						'model'                => 'superdav-tts',
+						'output_formats'       => array( 'mp3' ),
+						'max_input_characters' => 4096,
+						'speed'                => array( 'minimum' => 0.25, 'maximum' => 4 ),
+						'voices'               => array( array( 'id' => 'alloy', 'name' => 'Alloy', 'locales' => array( 'en-US' ) ) ),
+					),
+					'transcription'  => array(
+						'model'                        => 'superdav-transcribe',
+						'accepted_input_mime_types'    => array( 'audio/wav' ),
+						'max_bytes'                    => 10 * 1024 * 1024,
+						'max_duration_seconds'         => 1500,
+						'response_formats'             => array( 'json' ),
+						'automatic_language_detection' => true,
+					),
+				)
+			);
+		}
+		if ( str_ends_with( $uri, '/models' ) ) {
+			return $this->json_response(
+				array(
+					'object' => 'list',
+					'data'   => array( array( 'id' => 'superdav-tts', 'name' => 'Speech', 'capabilities' => array( 'text_to_speech_conversion' => true ) ) ),
+				)
+			);
+		}
+		if ( str_ends_with( $uri, '/audio/transcriptions' ) ) {
+			return $this->json_response(
+				array(
+					'text'       => 'Synthetic public transcript',
+					'language'   => 'en-US',
+					'duration'   => 0.1,
+					'request_id' => 'public-transcription-request',
+				)
+			);
+		}
+		if ( str_ends_with( $uri, '/audio/speech' ) ) {
+			return new Response( 200, array( 'content-type' => 'audio/mpeg' ), 'public-synthetic-audio' );
+		}
+
+		throw new \RuntimeException( 'Unexpected public speech test request.' );
+	}
+
+	public function request_count_for( string $suffix ): int {
+		return count( array_filter( $this->requests, static fn( Request $request ): bool => str_ends_with( $request->getUri(), $suffix ) ) );
+	}
+
+	public function last_request_for( string $suffix ): ?Request {
+		$matches = array_values( array_filter( $this->requests, static fn( Request $request ): bool => str_ends_with( $request->getUri(), $suffix ) ) );
+		return array() === $matches ? null : $matches[ count( $matches ) - 1 ];
+	}
+
+	/** @param array<string,mixed> $data */
+	private function json_response( array $data ): Response {
+		return new Response( 200, array( 'content-type' => 'application/json' ), (string) wp_json_encode( $data ) );
+	}
+}

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -108,6 +108,10 @@ class RestControllerTest extends WP_UnitTestCase {
 	 */
 	private function dispatch( string $method, string $route, array $params = [] ) {
 		$request = new WP_REST_Request( $method, $route );
+		if ( 'GET' === $method && str_contains( $route, '/public-chat/job/' ) && isset( $params['token'] ) ) {
+			$request->set_header( 'Authorization', 'Bearer ' . (string) $params['token'] );
+			unset( $params['token'] );
+		}
 
 		if ( in_array( $method, [ 'POST', 'PATCH', 'PUT' ], true ) ) {
 			// Use JSON body — WP REST parses it for both get_param() (route arg


### PR DESCRIPTION
## Summary

- add dedicated anonymous transcription and synthesis routes bound to the existing public-chat origin, embed, session, and token contract
- enforce strict WAV validation, short-lived one-use reply grants, request/concurrency/spend limits, content-free metrics, and immediate site disablement
- add opt-in push-to-talk, read-aloud, and turn-based voice mode to the dependency-free static embed with disclosure-first consent and complete resource cleanup
- document the public speech trust boundary, retention behavior, limits, locale flow, fallbacks, and operator controls

## Security and acceptance evidence

- `PublicChatSecurity` signs session tokens and synthesis grants with purpose-specific HMACs and binds them to session, embed, normalized origin, token hash, text hash, voice/locale, and expiry.
- Public synthesis accepts no caller text/model/voice/format options; it consumes the exact server-stored assistant reply once.
- Public transcription accepts exactly one `recording.wav` / `audio/wav` upload and reuses the authenticated controller's provenance, size, MIME, WAV-header, duration, timeout, response, and cleanup checks under stricter anonymous ceilings.
- Focused PHPUnit proves allowed success, missing/forbidden origin, invalid embed, disabled speech, invalid magic, oversize bytes/duration, rate/concurrency/spend denial, missing/expired/replayed grants, arbitrary synthesis denial, secret-free metrics/responses, temporary-file cleanup, and zero Media Library attachments.
- Embed Jest proves disclosure precedes microphone access, public tokens stay out of URLs, capture/playback cleanup runs on close, and voice mode requires a fresh gesture after each turn.

## Worker self-verification
- PHPUnit: Tests: 4359, Assertions: 20145, Errors: 0, Failures: 0, Skipped: 137, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Additional verification

- Focused public REST: `31 tests, 299 assertions`
- Focused public settings: `42 tests, 145 assertions`
- Embed Jest: `15 tests passed`
- `git diff --check`: clean

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — activated the exact worktree build in an isolated WordPress 7.0 / PHP 8.2 `wp-env` instance, confirmed both public speech routes were registered, confirmed caller-controlled synthesis text was rejected with `sd_ai_agent_invalid_speech_text`, and confirmed a disabled public-chat transcription request failed closed.
- Focused Playwright: `9 passed` for `tests/e2e/text-to-speech.spec.js` against the isolated worktree runtime. One assertion timed out on the first run; the exact assertion passed alone and the complete nine-test file then passed cleanly.

Resolves #2648

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 1d 13h and 8,943,763 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional speech capabilities to the public chat embed, including microphone transcription, read-aloud responses, and voice conversation mode.
  * Added configurable voice, language, recording, response-length, and disclosure settings.
  * Added consent-based microphone access, visible status controls, typed-chat fallback, and automatic cleanup when the widget closes or the page is hidden.
  * Added safeguards for session-bound access, usage limits, and temporary audio handling.

* **Documentation**
  * Documented setup, privacy, accessibility, configuration, and operational requirements for public speech embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->