### PR TITLE
GH#2658: preserve Wikimedia metadata and dimensions

### DIFF
--- a/includes/Abilities/ImageSources/WikimediaImageSource.php
+++ b/includes/Abilities/ImageSources/WikimediaImageSource.php
@@ -48,10 +48,12 @@ class WikimediaImageSource implements ImageSourceInterface {
 			$url  = (string) ( $info['url'] ?? '' );
 			if ( '' === $url || empty( $info['width'] ) || empty( $info['height'] ) ) {
 				continue; }
-			$meta    = $info['extmetadata'] ?? array();
-			$license = (string) ( $meta['LicenseShortName']['value'] ?? 'CC BY-SA' );
-			$author  = wp_strip_all_tags( (string) ( $meta['Artist']['value'] ?? '' ) );
-			$hits[]  = array(
+			$meta        = $info['extmetadata'] ?? array();
+			$license     = (string) ( $meta['LicenseShortName']['value'] ?? '' );
+			$author      = wp_strip_all_tags( (string) ( $meta['Artist']['value'] ?? '' ) );
+			$license_url = (string) ( $meta['LicenseUrl']['value'] ?? '' );
+			$attribution = wp_strip_all_tags( (string) ( $meta['Attribution']['value'] ?? '' ) );
+			$hits[]      = array(
 				'id'          => (string) ( $page['title'] ?? '' ),
 				'preview'     => (string) ( $info['thumburl'] ?? $url ),
 				'medium'      => (string) ( $info['thumburl'] ?? $url ),
@@ -62,9 +64,9 @@ class WikimediaImageSource implements ImageSourceInterface {
 				'author'      => $author,
 				'author_url'  => '',
 				'license'     => $license,
-				'license_url' => 'https://creativecommons.org/licenses/',
+				'license_url' => $license_url,
 				'source'      => 'wikimedia',
-				'attribution' => trim( $author . ' / ' . $license ),
+				'attribution' => '' !== $attribution ? $attribution : trim( $author . ' / ' . $license ),
 			);
 		}
 		return array(
@@ -97,9 +99,10 @@ class WikimediaImageSource implements ImageSourceInterface {
 		if ( empty( $info['url'] ) ) {
 			return new WP_Error( 'wikimedia_error', 'No Wikimedia image URL available.' ); }
 		$meta        = $info['extmetadata'] ?? array();
-		$license     = (string) ( $meta['LicenseShortName']['value'] ?? 'CC BY-SA' );
+		$license     = (string) ( $meta['LicenseShortName']['value'] ?? '' );
 		$author      = wp_strip_all_tags( (string) ( $meta['Artist']['value'] ?? '' ) );
-		$license_url = (string) ( $meta['LicenseUrl']['value'] ?? 'https://creativecommons.org/licenses/' );
+		$license_url = (string) ( $meta['LicenseUrl']['value'] ?? '' );
+		$attribution = wp_strip_all_tags( (string) ( $meta['Attribution']['value'] ?? '' ) );
 		return array(
 			'url'         => (string) ( $info['thumburl'] ?? $info['url'] ),
 			'width'       => (int) ( $info['width'] ?? 0 ),
@@ -109,7 +112,7 @@ class WikimediaImageSource implements ImageSourceInterface {
 			'author_url'  => '',
 			'license'     => $license,
 			'license_url' => $license_url,
-			'attribution' => trim( $author . ' / ' . $license ),
+			'attribution' => '' !== $attribution ? $attribution : trim( $author . ' / ' . $license ),
 			'source'      => 'wikimedia',
 		);
 	}

--- a/includes/Abilities/ImageSources/WikimediaImageSource.php
+++ b/includes/Abilities/ImageSources/WikimediaImageSource.php
@@ -74,8 +74,8 @@ class WikimediaImageSource implements ImageSourceInterface {
 		);
 	}
 
-	public function get_image( string $image_id ): array|\WP_Error {
-		$args     = array(
+	public function get_image( string $image_id, int $width = 0, int $height = 0 ): array|\WP_Error {
+		$args = array(
 			'action'        => 'query',
 			'format'        => 'json',
 			'formatversion' => 2,
@@ -83,6 +83,12 @@ class WikimediaImageSource implements ImageSourceInterface {
 			'prop'          => 'imageinfo',
 			'iiprop'        => 'url|size|extmetadata',
 		);
+		if ( $width > 0 ) {
+			$args['iiurlwidth'] = $width;
+		}
+		if ( $height > 0 ) {
+			$args['iiurlheight'] = $height;
+		}
 		$response = SafeHttpClient::instance()->safe_remote_get( add_query_arg( $args, self::API ), array( 'timeout' => 30 ) );
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'wikimedia_error', 'Failed to retrieve Wikimedia image.' ); }
@@ -90,22 +96,26 @@ class WikimediaImageSource implements ImageSourceInterface {
 		$info = $page['imageinfo'][0] ?? array();
 		if ( empty( $info['url'] ) ) {
 			return new WP_Error( 'wikimedia_error', 'No Wikimedia image URL available.' ); }
+		$meta        = $info['extmetadata'] ?? array();
+		$license     = (string) ( $meta['LicenseShortName']['value'] ?? 'CC BY-SA' );
+		$author      = wp_strip_all_tags( (string) ( $meta['Artist']['value'] ?? '' ) );
+		$license_url = (string) ( $meta['LicenseUrl']['value'] ?? 'https://creativecommons.org/licenses/' );
 		return array(
-			'url'         => $info['url'],
+			'url'         => (string) ( $info['thumburl'] ?? $info['url'] ),
 			'width'       => (int) ( $info['width'] ?? 0 ),
 			'height'      => (int) ( $info['height'] ?? 0 ),
 			'title'       => $image_id,
-			'author'      => '',
+			'author'      => $author,
 			'author_url'  => '',
-			'license'     => 'CC BY-SA',
-			'license_url' => 'https://creativecommons.org/licenses/',
-			'attribution' => 'Wikimedia Commons',
+			'license'     => $license,
+			'license_url' => $license_url,
+			'attribution' => trim( $author . ' / ' . $license ),
 			'source'      => 'wikimedia',
 		);
 	}
 
 	public function download( string $image_id, int $width = 0, int $height = 0 ): string|\WP_Error {
-		$image = $this->get_image( $image_id );
+		$image = $this->get_image( $image_id, $width, $height );
 		if ( is_wp_error( $image ) ) {
 			return $image; }
 		return SafeHttpClient::instance()->safe_download_url( (string) $image['url'], 60 );


### PR DESCRIPTION
## Summary

Preserve Commons metadata and request derivative URLs for constrained downloads.

## Files Changed

includes/Abilities/ImageSources/WikimediaImageSource.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — PHP syntax check and PHPCS passed.

Resolves #2658


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 9m and 85,098 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wikimedia image retrieval now supports optional thumbnail width and height settings.
  - Image results use available thumbnail URLs when provided.
  - Author and licensing details are populated from Wikimedia metadata.
- **Enhancements**
  - Downloaded Wikimedia images respect the requested dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->