### PR TITLE
GH#2659: preserve voice conversation state

### DIFF
--- a/src/components/use-voice-conversation.js
+++ b/src/components/use-voice-conversation.js
@@ -147,13 +147,18 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 		voice: voiceId,
 	} );
 
-	const stopSpeaking = useCallback( () => {
-		if ( activePlayback?.owner === ownerRef.current ) {
-			activePlayback = null;
-		}
-		cancelSpeech();
-		setPhase( 'idle' );
-	}, [ cancelSpeech ] );
+	const stopSpeaking = useCallback(
+		( { resetPhase = true } = {} ) => {
+			if ( activePlayback?.owner === ownerRef.current ) {
+				activePlayback = null;
+			}
+			cancelSpeech();
+			if ( resetPhase ) {
+				setPhase( 'idle' );
+			}
+		},
+		[ cancelSpeech ]
+	);
 
 	const readAloud = useCallback(
 		async ( text, options = {} ) => {
@@ -162,16 +167,17 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 				return false;
 			}
 			const owner = ownerRef.current;
-			activePlayback = {
+			const playback = {
 				cancel: () => {
 					cancelSpeech();
 					setPhase( 'idle' );
 				},
 				owner,
 			};
+			activePlayback = playback;
 			setPhase( 'speaking' );
 			const completed = await speak( text, options );
-			if ( activePlayback?.owner === owner ) {
+			if ( activePlayback === playback ) {
 				activePlayback = null;
 				setPhase( completed ? 'idle' : 'error' );
 			}
@@ -298,7 +304,7 @@ export default function useVoiceConversation( { surface = 'main' } = {} ) {
 			! previousSessionId && currentSessionId && sending
 		);
 		cancelRecognition();
-		stopSpeaking();
+		stopSpeaking( { resetPhase: ! createdSessionForPendingTurn } );
 		if ( createdSessionForPendingTurn ) {
 			awaitingResponseRef.current = true;
 			return;

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -8,11 +8,30 @@ import apiFetch from '@wordpress/api-fetch';
 const currentUserId = globalThis.sdAiAgentData?.currentUserId || 0;
 const speechStorageKey = ( preference ) =>
 	`sdAiAgent:${ currentUserId }:speech:${ preference }`;
+const legacySpeechStorageKeys = {
+	legacyPitch: 'sdAiAgentTtsPitch',
+	readAloud: 'sdAiAgentTtsEnabled',
+	speed: 'sdAiAgentTtsRate',
+	voiceId: 'sdAiAgentTtsVoiceURI',
+};
 
 const readSpeechPreference = ( preference, fallback = '' ) => {
 	const key = speechStorageKey( preference );
 	const value = localStorage.getItem( key );
-	return value ?? fallback;
+	if ( value !== null ) {
+		return value;
+	}
+	const legacyKey = legacySpeechStorageKeys[ preference ];
+	if ( ! currentUserId || ! legacyKey ) {
+		return fallback;
+	}
+	const legacyValue = localStorage.getItem( legacyKey );
+	if ( legacyValue === null ) {
+		return fallback;
+	}
+	localStorage.setItem( key, legacyValue );
+	localStorage.removeItem( legacyKey );
+	return legacyValue;
 };
 
 const writeSpeechPreference = ( preference, value ) => {


### PR DESCRIPTION
## Summary

Preserve replacement playback ownership and pending voice turn state while migrating legacy speech preferences for authenticated users.

## Files Changed

src/components/use-voice-conversation.js, src/store/slices/uiSlice.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run lint:js; pnpm run test:js -- src/components/__tests__/use-voice-conversation.test.js

Resolves #2659


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 29m and 158,578 tokens on this as a headless worker.