### PR TITLE
fix: allow configured managed edge resolved locally

### DIFF
--- a/includes/Bootstrap/SuperdavAiProviderHandler.php
+++ b/includes/Bootstrap/SuperdavAiProviderHandler.php
@@ -100,8 +100,11 @@ final class SuperdavAiProviderHandler {
 		$base_host    = strtolower( (string) ( $base_parts['host'] ?? '' ) );
 		$request_host = strtolower( (string) ( $request_parts['host'] ?? '' ) );
 		$filter_host  = strtolower( trim( $host, '.' ) );
-		if ( ! in_array( $base_host, array( '127.0.0.1', 'localhost' ), true )
-			|| $request_host !== $base_host
+		// Production routes api.sdaiagent.com to the local managed edge (127.0.0.1).
+		// WordPress therefore classifies the public hostname as local and rejects it
+		// before the SDK can send the request. The configured exact host is safe to
+		// allow here; the path and scheme checks below still constrain the exception.
+		if ( $request_host !== $base_host
 			|| $filter_host !== $base_host
 		) {
 			return false;


### PR DESCRIPTION
Allow the exact configured managed API hostname through WordPress safe HTTP validation when production DNS resolves it to the local edge. This unblocks provider model discovery and chat requests while retaining exact scheme/host/path checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated local routing validation to support configured base hosts beyond `localhost` or `127.0.0.1`.
  - Requests can now use a production or custom hostname routed to the local managed edge when the request, filter, and configured base hosts match.
  - Existing scheme, port, and path validation remains enforced for security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->