### PR TITLE
fix: preserve idless Gemini tool cycles

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -61,7 +61,10 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	 */
 	public function execute_ability( FunctionCall $call ): FunctionResponse {
 		$function_name = $call->getName() ?? 'unknown';
-		$function_id   = $call->getId() ?? 'unknown';
+		// Older Gemini models omit function call IDs. Keep an empty internal ID
+		// so the response pairs with the idless call in conversation history;
+		// the Google provider omits empty IDs when serializing the next request.
+		$function_id = $call->getId() ?? '';
 
 		if ( ! $this->is_ability_call( $call ) ) {
 			return new FunctionResponse(

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -1239,8 +1239,6 @@ class ConversationTrimmer {
 				}
 				++$call_end;
 			}
-			$tool_call_ids = array_values( array_unique( $tool_call_ids ) );
-
 			// Collect the tool-response messages that follow the entire call cluster.
 			$response_ids   = [];
 			$response_start = $call_end;
@@ -1258,10 +1256,10 @@ class ConversationTrimmer {
 				}
 			}
 
-			// Check if ALL tool_call IDs have matching responses.
-			$missing = array_diff( $tool_call_ids, $response_ids );
-
-			if ( empty( $missing ) ) {
+			// Check if every tool call has its own matching response. Counts matter
+			// because older Gemini models may omit IDs from parallel calls, causing
+			// multiple calls and responses to share the empty-string compatibility ID.
+			if ( self::has_matching_tool_responses( $tool_call_ids, $response_ids ) ) {
 				// All tool calls have responses — keep the entire split cycle.
 				for ( $j = $call_start; $j < $call_end; $j++ ) {
 					$result[] = $history[ $j ];
@@ -1277,6 +1275,26 @@ class ConversationTrimmer {
 		}
 
 		return self::strip_orphan_tool_responses( $result );
+	}
+
+	/**
+	 * Determine whether each tool call ID has a distinct matching response ID.
+	 *
+	 * @param string[] $tool_call_ids Tool call IDs, including duplicate empty IDs.
+	 * @param string[] $response_ids  Tool response IDs, including duplicate empty IDs.
+	 */
+	private static function has_matching_tool_responses( array $tool_call_ids, array $response_ids ): bool {
+		$response_counts = array_count_values( $response_ids );
+
+		foreach ( $tool_call_ids as $tool_call_id ) {
+			if ( empty( $response_counts[ $tool_call_id ] ) ) {
+				return false;
+			}
+
+			--$response_counts[ $tool_call_id ];
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -15,7 +15,11 @@ use SdAiAgent\Abilities\BlockAbilities;
 use SdAiAgent\Abilities\KnowledgeAbilities;
 use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\AbilityFunctionResolver;
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\IdenticalFailureTracker;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WP_UnitTestCase;
 
@@ -126,6 +130,28 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'query' ), $payload['missing_required_fields'] );
 		$this->assertSame( array( 'query' => '<string — Search keywords. Required.>' ), $payload['example_arguments'] );
 		$this->assertStringContainsString( 'Do not retry with empty arguments', $payload['hint'] );
+	}
+
+	public function test_idless_function_call_response_remains_in_gemini_history(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_schema_thrower_ability();
+		$this->assertNotNull( $ability );
+
+		$function_name = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/schema-thrower' );
+		$call          = new FunctionCall( null, $function_name, array( 'query' => 'trigger callback validation exception' ) );
+		$resolver      = new AbilityFunctionResolver( $ability );
+		$response      = $resolver->execute_ability( $call );
+
+		$this->assertNull( $call->getId() );
+		$this->assertSame( '', $response->getId() );
+
+		$history = array(
+			new ModelMessage( array( new MessagePart( $call ) ) ),
+			new UserMessage( array( new MessagePart( $response ) ) ),
+		);
+
+		$this->assertCount( 2, ConversationTrimmer::validate_tool_pairs( $history ) );
 	}
 
 	public function test_public_knowledge_search_hydrates_empty_args_from_customer_query(): void {

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -21,6 +21,7 @@ use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WP_UnitTestCase;
 
 final class ThrowingValidationAbility extends \WP_Ability {
@@ -132,6 +133,9 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Do not retry with empty arguments', $payload['hint'] );
 	}
 
+	/**
+	 * Test that an idless Gemini call and response survive history validation.
+	 */
 	public function test_idless_function_call_response_remains_in_gemini_history(): void {
 		$this->skip_if_resolver_unavailable();
 
@@ -151,7 +155,36 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 			new UserMessage( array( new MessagePart( $response ) ) ),
 		);
 
-		$this->assertCount( 2, ConversationTrimmer::validate_tool_pairs( $history ) );
+		$validated = ConversationTrimmer::validate_tool_pairs( $history );
+		$this->assertCount( 2, $validated );
+		$this->assertSame( $history[0], $validated[0] );
+		$this->assertSame( $history[1], $validated[1] );
+	}
+
+	/**
+	 * Test parallel idless calls require one response per call.
+	 */
+	public function test_parallel_idless_calls_require_distinct_responses(): void {
+		$first_user_message = new UserMessage( array( new MessagePart( 'Do two things' ) ) );
+		$first_call         = new FunctionCall( null, 'tool-a', array() );
+		$second_call        = new FunctionCall( null, 'tool-b', array() );
+		$call_message       = new ModelMessage(
+			array(
+				new MessagePart( $first_call ),
+				new MessagePart( $second_call ),
+			)
+		);
+		$response_message = new UserMessage(
+			array( new MessagePart( new FunctionResponse( '', 'tool-a', '{"success":true}' ) ) )
+		);
+		$next_user_message = new UserMessage( array( new MessagePart( 'What happened?' ) ) );
+		$history           = array( $first_user_message, $call_message, $response_message, $next_user_message );
+
+		$validated = ConversationTrimmer::validate_tool_pairs( $history );
+
+		$this->assertCount( 2, $validated );
+		$this->assertSame( $first_user_message, $validated[0] );
+		$this->assertSame( $next_user_message, $validated[1] );
 	}
 
 	public function test_public_knowledge_search_hydrates_empty_args_from_customer_query(): void {


### PR DESCRIPTION
## Summary

- Preserve an empty internal ID when a provider returns an idless function call instead of replacing it with `unknown`.
- Keep the resulting function response paired with its call during conversation-history validation.
- Add focused coverage for the resolver-to-`ConversationTrimmer` path.

## Why

Gemini 2.5 can return function calls without IDs. The resolver previously assigned the response ID `unknown`, while the original call normalized to an empty ID. `ConversationTrimmer::validate_tool_pairs()` treated that completed cycle as mismatched and removed both messages before the next provider request, causing the model to repeat the same tool call until the loop limit.

The companion Google provider change in WordPress/ai-provider-for-google#45 preserves real Gemini 3 IDs and omits this empty compatibility sentinel from older-model request payloads.

## Files

- `includes/Core/AbilityFunctionResolver.php`: retain an empty internal ID for idless provider calls.
- `tests/SdAiAgent/Core/AbilityFunctionResolverTest.php`: prove the response stays paired through history validation.

## Verification

- Focused PHPUnit: 6 tests, 31 assertions
- PHPCS: both changed files passed
- PHP syntax checks passed
- `git diff --check`
- Live Gemini 2.5 Flash completed sequential `list-posts` and `get-post` calls in 3 iterations with no repeats.
- Live Gemini 3.8 Flash completed the same workflow in 3 iterations with matching unique IDs and no repeats.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-sol spent 2d and 3,507,531 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the pairing between function calls without IDs and their corresponding responses in conversation history.
  - Improved compatibility with providers that omit empty function-call IDs during request serialization.

- **Tests**
  - Added coverage confirming id-less function-call responses remain intact after conversation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->