### PR TITLE
GH#2665: add speech availability gates

### DIFF
--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -312,6 +312,17 @@ final class Features {
 	const RUN_PHP = 'run_php';
 
 	/**
+	 * Feature: managed speech capture and playback.
+	 *
+	 * This local rollback switch prevents new managed speech operations without
+	 * affecting typed chat. It intentionally defaults to enabled so older site
+	 * configuration continues to work unless the site owner opts out.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_SPEECH
+	 */
+	const SPEECH = 'speech';
+
+	/**
 	 * Map of feature name → backing constant name.
 	 *
 	 * @var array<string, string>
@@ -330,6 +341,7 @@ final class Features {
 		self::BENCHMARK               => 'SD_AI_AGENT_FEATURE_BENCHMARK',
 		self::USER_MANAGEMENT         => 'SD_AI_AGENT_FEATURE_USER_MANAGEMENT',
 		self::RUN_PHP                 => 'SD_AI_AGENT_FEATURE_RUN_PHP',
+		self::SPEECH                  => 'SD_AI_AGENT_FEATURE_SPEECH',
 	);
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -48,7 +48,8 @@ class ProviderTraceLogger {
 	 *     request_tokens_estimate:int,
 	 *     request_provider_limit_bytes:int,
 	 *     request_budget_bytes:int,
-	 *     request_safety_margin_bytes:int
+	 *     request_safety_margin_bytes:int,
+	 *     operation:string
 	 * }
 	 */
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
@@ -64,6 +65,7 @@ class ProviderTraceLogger {
 		'request_provider_limit_bytes' => 0,
 		'request_budget_bytes'         => 0,
 		'request_safety_margin_bytes'  => 0,
+		'operation'                    => '',
 	);
 
 	/**
@@ -131,8 +133,9 @@ class ProviderTraceLogger {
 	 * @param int    $retry_baseline_request_bytes Full-envelope bytes from an upstream 413 retry baseline.
 	 * @param string $journey_id                   Validated managed journey ID, if active.
 	 * @param string $idempotency_key              Stable logical-request UUID, if active.
+	 * @param string $operation                    Content-sensitive operation category, if any.
 	 */
-	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0, string $journey_id = '', string $idempotency_key = '' ): void {
+	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0, string $journey_id = '', string $idempotency_key = '', string $operation = '' ): void {
 		$has_valid_managed_attribution = SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
 			&& SuperdavManagedRequestIdentifiers::is_idempotency_key( $idempotency_key );
 		self::$runtimeContext          = array(
@@ -147,6 +150,7 @@ class ProviderTraceLogger {
 			'request_provider_limit_bytes' => 0,
 			'request_budget_bytes'         => 0,
 			'request_safety_margin_bytes'  => 0,
+			'operation'                    => 'speech' === $operation ? 'speech' : '',
 		);
 	}
 
@@ -181,6 +185,7 @@ class ProviderTraceLogger {
 			'request_provider_limit_bytes' => 0,
 			'request_budget_bytes'         => 0,
 			'request_safety_margin_bytes'  => 0,
+			'operation'                    => '',
 		);
 	}
 
@@ -253,6 +258,13 @@ class ProviderTraceLogger {
 			self::$runtimeContext['request_provider_limit_bytes'] = $provider_limit_bytes;
 			self::$runtimeContext['request_budget_bytes']         = $byte_budget;
 			self::$runtimeContext['request_safety_margin_bytes']  = $safety_margin_bytes;
+		}
+
+		// Speech HTTP bodies contain transcripts, synthesis text, or audio. Even
+		// explicit provider tracing must never persist those payloads or raw
+		// upstream responses. Scalar request-size enforcement above remains active.
+		if ( 'speech' === self::$runtimeContext['operation'] ) {
+			return $response;
 		}
 
 		$fallback_attempted = $has_context && self::$runtimeContext['retry_baseline_request_bytes'] > 0;

--- a/includes/Core/PublicChatSecurity.php
+++ b/includes/Core/PublicChatSecurity.php
@@ -147,7 +147,14 @@ final class PublicChatSecurity {
 		if ( empty( $config['collections'] ) ) {
 			return new WP_Error( 'sd_ai_agent_public_chat_unconfigured', __( 'Public chat has no documentation collection configured.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
 		}
-		if ( $require_speech && empty( $config['speech_enabled'] ) ) {
+		$availability = SpeechAvailability::for_conditions(
+			Features::is_enabled( Features::SPEECH ),
+			true,
+			true,
+			true,
+			! empty( $config['speech_enabled'] )
+		);
+		if ( $require_speech && ! $availability->is_available() ) {
 			return new WP_Error( 'sd_ai_agent_public_speech_disabled', __( 'Public speech is not enabled.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
 		}
 

--- a/includes/Core/SpeechAvailability.php
+++ b/includes/Core/SpeechAvailability.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Typed, low-cardinality managed-speech availability decision.
+ *
+ * The result is intentionally safe to expose to authenticated and anonymous
+ * clients: it identifies a stable rollout category, not account, billing, or
+ * provider implementation detail.
+ */
+final class SpeechAvailability {
+
+	public const AVAILABLE               = 'available';
+	public const FEATURE_DISABLED        = 'feature_disabled';
+	public const CONNECTION_UNAVAILABLE  = 'connection_unavailable';
+	public const ENTITLEMENT_UNAVAILABLE = 'entitlement_unavailable';
+	public const CAPABILITY_UNAVAILABLE  = 'capability_unavailable';
+	public const PUBLIC_SITE_DISABLED    = 'public_site_disabled';
+	public const BROWSER_UNSUPPORTED     = 'browser_unsupported';
+	public const TEMPORARY_UNAVAILABLE   = 'temporary_unavailable';
+
+	private const REASONS = array(
+		self::AVAILABLE,
+		self::FEATURE_DISABLED,
+		self::CONNECTION_UNAVAILABLE,
+		self::ENTITLEMENT_UNAVAILABLE,
+		self::CAPABILITY_UNAVAILABLE,
+		self::PUBLIC_SITE_DISABLED,
+		self::BROWSER_UNSUPPORTED,
+		self::TEMPORARY_UNAVAILABLE,
+	);
+
+	private bool $available;
+	private string $reason;
+
+	private function __construct( bool $available, string $reason ) {
+		$this->available = $available;
+		$this->reason    = $reason;
+	}
+
+	/**
+	 * Make a feature-first availability decision without inferring remote state.
+	 */
+	public static function for_conditions( bool $feature_enabled, bool $connected = true, bool $entitled = true, bool $capable = true, bool $public_site_enabled = true ): self {
+		if ( ! $feature_enabled ) {
+			return new self( false, self::FEATURE_DISABLED );
+		}
+		if ( ! $connected ) {
+			return new self( false, self::CONNECTION_UNAVAILABLE );
+		}
+		if ( ! $entitled ) {
+			return new self( false, self::ENTITLEMENT_UNAVAILABLE );
+		}
+		if ( ! $capable ) {
+			return new self( false, self::CAPABILITY_UNAVAILABLE );
+		}
+		if ( ! $public_site_enabled ) {
+			return new self( false, self::PUBLIC_SITE_DISABLED );
+		}
+
+		return new self( true, self::AVAILABLE );
+	}
+
+	/** Return a safe public response shape. */
+	public function to_array(): array {
+		return array(
+			'available' => $this->available,
+			'reason'    => $this->reason,
+		);
+	}
+
+	/** Return the stable reason code. */
+	public function reason(): string {
+		return $this->reason;
+	}
+
+	/** Whether managed speech may be presented as available. */
+	public function is_available(): bool {
+		return $this->available;
+	}
+
+	/** Validate an externally supplied stable reason without reflecting it. */
+	public static function is_reason( string $reason ): bool {
+		return in_array( $reason, self::REASONS, true );
+	}
+}

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -115,6 +115,9 @@ final class SuperdavSiteConnectionService {
 		if ( isset( $metadata['chat_sessions'] ) && is_array( $metadata['chat_sessions'] ) ) {
 			$status['chat_sessions'] = $this->sanitize_chat_session_metadata( $metadata['chat_sessions'] );
 		}
+		if ( isset( $metadata['speech'] ) && is_array( $metadata['speech'] ) ) {
+			$status['speech'] = $this->sanitize_speech_metadata( $metadata['speech'] );
+		}
 
 		$status['linked_user'] = isset( $metadata['linked_user'] ) && is_array( $metadata['linked_user'] )
 			? $this->sanitize_linked_user_metadata( $metadata['linked_user'] )
@@ -197,7 +200,8 @@ final class SuperdavSiteConnectionService {
 			$metadata['verification'],
 			$metadata['wallet'],
 			$metadata['credit_activity'],
-			$metadata['chat_sessions']
+			$metadata['chat_sessions'],
+			$metadata['speech']
 		);
 		$metadata = array_merge( $metadata, $this->sanitize_remote_metadata( $body ) );
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
@@ -822,6 +826,41 @@ final class SuperdavSiteConnectionService {
 			$safe['linked_user'] = $this->sanitize_linked_user_metadata( $metadata['linked_user'] );
 		}
 
+		if ( isset( $metadata['speech'] ) && is_array( $metadata['speech'] ) ) {
+			$safe['speech'] = $this->sanitize_speech_metadata( $metadata['speech'] );
+		}
+
+		return $safe;
+	}
+
+	/**
+	 * Keep only the service-advertised, non-billing speech rollout contract.
+	 *
+	 * @param array<string, mixed> $speech Remote speech metadata.
+	 * @return array<string, bool|list<string>|string>
+	 */
+	private function sanitize_speech_metadata( array $speech ): array {
+		$safe = array();
+		foreach ( array( 'enabled', 'entitled', 'remote_processing', 'retention_disclosed' ) as $key ) {
+			if ( isset( $speech[ $key ] ) && is_bool( $speech[ $key ] ) ) {
+				$safe[ $key ] = $speech[ $key ];
+			}
+		}
+		if ( isset( $speech['cohort'] ) && is_string( $speech['cohort'] ) ) {
+			$cohort = sanitize_key( $speech['cohort'] );
+			if ( in_array( $cohort, array( 'general', 'staged', 'disabled' ), true ) ) {
+				$safe['cohort'] = $cohort;
+			}
+		}
+		foreach ( array( 'supported_surfaces', 'languages', 'voices', 'rollback_categories' ) as $key ) {
+			if ( isset( $speech[ $key ] ) && is_array( $speech[ $key ] ) ) {
+				$values       = array_filter(
+					array_slice( $speech[ $key ], 0, 20 ),
+					static fn( mixed $value ): bool => is_string( $value ) && '' !== sanitize_key( $value )
+				);
+				$safe[ $key ] = array_values( array_unique( $values ) );
+			}
+		}
 		return $safe;
 	}
 

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -821,7 +821,14 @@ final class SessionController {
 		$config         = $this->get_public_chat_settings();
 		$origin         = $this->get_public_chat_request_origin( $request );
 		$enabled        = ! empty( $config['enabled'] ) && ! empty( $config['collections'] ) && $this->public_origin_is_allowed( $origin, $config['origins'] );
-		$speech_enabled = $enabled && ! empty( $config['speech_enabled'] );
+		$availability   = \SdAiAgent\Core\SpeechAvailability::for_conditions(
+			\SdAiAgent\Core\Features::is_enabled( \SdAiAgent\Core\Features::SPEECH ),
+			true,
+			true,
+			true,
+			$enabled && ! empty( $config['speech_enabled'] )
+		);
+		$speech_enabled = $availability->is_available();
 		$this->public_chat_security->record_speech_metric( 'availability', $speech_enabled ? 'available' : 'unavailable', 200, microtime( true ) );
 
 		return $this->add_public_chat_cors(
@@ -838,6 +845,7 @@ final class SessionController {
 					),
 					'speech'      => array(
 						'enabled'                        => $speech_enabled,
+						'availability'                   => $availability->to_array(),
 						'upload_mime_type'               => 'audio/wav',
 						'capture_mime_types'             => array( 'audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus', 'audio/mp4' ),
 						'output_mime_types'              => array( 'audio/mpeg' ),

--- a/includes/REST/SpeechController.php
+++ b/includes/REST/SpeechController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\Database;
+use SdAiAgent\Core\Features;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\SpeechAvailability;
 use SdAiAgent\Core\SpeechLocaleResolver;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextToSpeechConversionModel;
@@ -71,11 +73,16 @@ final class SpeechController extends XWP_REST_Controller {
 	)]
 	public function handle_capabilities( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		unset( $request );
+		$availability = $this->availability();
+		if ( ! $availability->is_available() ) {
+			return new WP_REST_Response( array( 'availability' => $availability->to_array() ), 200 );
+		}
 		$capabilities = $this->get_sanitized_capabilities();
 		if ( $capabilities instanceof WP_Error ) {
 			return $capabilities;
 		}
 
+		$capabilities['availability'] = $availability->to_array();
 		return new WP_REST_Response( $capabilities, 200 );
 	}
 
@@ -98,6 +105,9 @@ final class SpeechController extends XWP_REST_Controller {
 	 * authenticated service contract.
 	 */
 	public function handle_bounded_transcription( WP_REST_Request $request, int $max_bytes, int $max_duration_seconds, ?callable $before_transcription = null ): WP_REST_Response|WP_Error {
+		if ( ! $this->availability()->is_available() ) {
+			return $this->speech_unavailable_error();
+		}
 		$max_bytes            = max( 1, min( SuperdavAiTranscriptionClient::MAX_AUDIO_BYTES, $max_bytes ) );
 		$max_duration_seconds = max( 1, min( SuperdavAiTranscriptionClient::MAX_DURATION_SECONDS, $max_duration_seconds ) );
 		$temporary_path       = '';
@@ -198,7 +208,15 @@ final class SpeechController extends XWP_REST_Controller {
 				}
 			}
 
-			ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, SuperdavAiTranscriptionClient::MODEL_ID, $session_id );
+			ProviderTraceLogger::set_runtime_context(
+				SuperdavAiProvider::PROVIDER_ID,
+				SuperdavAiTranscriptionClient::MODEL_ID,
+				$session_id,
+				0,
+				'',
+				'',
+				'speech'
+			);
 			try {
 				$result = $this->speech_client->transcribe( $audio, $language, $prompt );
 			} finally {
@@ -229,6 +247,9 @@ final class SpeechController extends XWP_REST_Controller {
 
 	/** Convert one validated text turn under a stricter caller-supplied ceiling. */
 	public function handle_bounded_synthesis( WP_REST_Request $request, int $max_characters ): WP_REST_Response|WP_Error {
+		if ( ! $this->availability()->is_available() ) {
+			return $this->speech_unavailable_error();
+		}
 		$max_characters = max( 1, min( self::MAX_SYNTHESIS_CHARACTERS, $max_characters ) );
 		$fields         = $request->get_json_params();
 		if ( ! is_array( $fields ) || array_diff( array_keys( $fields ), array( 'text', 'voice', 'language', 'format', 'mime_type', 'speed', 'session_id' ) ) ) {
@@ -323,7 +344,15 @@ final class SpeechController extends XWP_REST_Controller {
 			$request_options->setMaxRedirects( 0 );
 			$model->setRequestOptions( $request_options );
 
-			ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, (string) $tts['model'], $session_id );
+			ProviderTraceLogger::set_runtime_context(
+				SuperdavAiProvider::PROVIDER_ID,
+				(string) $tts['model'],
+				$session_id,
+				0,
+				'',
+				'',
+				'speech'
+			);
 			$result = $model->convertTextToSpeechResult( array( new UserMessage( array( new MessagePart( $text ) ) ) ) );
 		} catch ( ResponseException ) {
 			return $this->malformed_response_error();
@@ -454,6 +483,11 @@ final class SpeechController extends XWP_REST_Controller {
 			'locales'        => $this->locale_resolver->resolve(),
 			'request_id'     => $this->sanitize_request_id( $remote['request_id'] ?? null ),
 		);
+	}
+
+	/** Return the local rollback decision shared by all managed speech routes. */
+	private function availability(): SpeechAvailability {
+		return SpeechAvailability::for_conditions( Features::is_enabled( Features::SPEECH ) );
 	}
 
 	/**

--- a/src/components/use-text-to-speech.js
+++ b/src/components/use-text-to-speech.js
@@ -225,11 +225,7 @@ export default function useTextToSpeech( {
 	const speak = useCallback(
 		async ( text, turnOptions = {} ) => {
 			const speechText = toSpeakableText( String( text || '' ) );
-			if (
-				! speechText ||
-				( ! isTTSSupported &&
-					( ! allowBrowserFallback || ! isBrowserFallbackSupported ) )
-			) {
+			if ( ! speechText ) {
 				return false;
 			}
 
@@ -247,12 +243,21 @@ export default function useTextToSpeech( {
 
 			try {
 				if ( ! isTTSSupported ) {
-					throw new Error(
-						__(
-							'Managed audio playback is unavailable.',
-							'superdav-ai-agent'
-						)
+					if (
+						! allowBrowserFallback ||
+						! isBrowserFallbackSupported
+					) {
+						return false;
+					}
+					playbackStarted = true;
+					onStart?.();
+					await playBrowserFallback(
+						speechText,
+						generation,
+						fallbackLanguage,
+						fallbackSpeed
 					);
+					return true;
 				}
 				const nextCapabilities =
 					capabilities || ( await loadSpeechCapabilities() );
@@ -260,6 +265,23 @@ export default function useTextToSpeech( {
 					return false;
 				}
 				setCapabilities( nextCapabilities );
+				if ( false === nextCapabilities?.availability?.available ) {
+					if (
+						! allowBrowserFallback ||
+						! isBrowserFallbackSupported
+					) {
+						return false;
+					}
+					playbackStarted = true;
+					onStart?.();
+					await playBrowserFallback(
+						speechText,
+						generation,
+						fallbackLanguage,
+						fallbackSpeed
+					);
+					return true;
+				}
 				const synthesis = nextCapabilities.text_to_speech;
 				const requestedLanguage =
 					turnOptions.lang ||
@@ -336,28 +358,7 @@ export default function useTextToSpeech( {
 				}
 				return true;
 			} catch ( caughtError ) {
-				let failure = caughtError;
-				if (
-					allowBrowserFallback &&
-					isBrowserFallbackSupported &&
-					! playbackStarted &&
-					caughtError?.name !== 'AbortError' &&
-					generation === generationRef.current
-				) {
-					try {
-						playbackStarted = true;
-						onStart?.();
-						await playBrowserFallback(
-							speechText,
-							generation,
-							fallbackLanguage,
-							fallbackSpeed
-						);
-						return true;
-					} catch ( fallbackError ) {
-						failure = fallbackError;
-					}
-				}
+				const failure = caughtError;
 				if (
 					failure?.name !== 'AbortError' &&
 					generation === generationRef.current
@@ -420,7 +421,10 @@ export default function useTextToSpeech( {
 		isSpeaking,
 		isSupported:
 			hasManagedSynthesis ||
-			( allowBrowserFallback && isBrowserFallbackSupported ),
+			( allowBrowserFallback &&
+				isBrowserFallbackSupported &&
+				( ! isTTSSupported ||
+					false === capabilities?.availability?.available ) ),
 		speak,
 	};
 }

--- a/tests/SdAiAgent/Core/FeaturesTest.php
+++ b/tests/SdAiAgent/Core/FeaturesTest.php
@@ -109,6 +109,14 @@ class FeaturesTest extends WP_UnitTestCase {
 		$this->assertTrue( Features::is_enabled( 'this_feature_does_not_exist' ) );
 	}
 
+	/** Managed speech is a core rollback flag and defaults to enabled. */
+	public function test_speech_feature_is_a_core_default_enabled_flag(): void {
+		$this->assertArrayHasKey( Features::SPEECH, Features::all() );
+		if ( ! defined( 'SD_AI_AGENT_FEATURE_SPEECH' ) ) {
+			$this->assertTrue( Features::is_enabled( Features::SPEECH ) );
+		}
+	}
+
 	/**
 	 * Smoke test: the constant-name mapping covered by the data provider must
 	 * remain stable for wp-config.php overrides, REST/UI feature snapshots, and

--- a/tests/SdAiAgent/Core/SpeechAvailabilityTest.php
+++ b/tests/SdAiAgent/Core/SpeechAvailabilityTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\SpeechAvailability;
+use WP_UnitTestCase;
+
+/** Covers the stable, safe managed-speech availability contract. */
+final class SpeechAvailabilityTest extends WP_UnitTestCase {
+
+	public function test_defaults_to_available_when_all_authoritative_inputs_allow_speech(): void {
+		$this->assertSame( array( 'available' => true, 'reason' => SpeechAvailability::AVAILABLE ), SpeechAvailability::for_conditions( true )->to_array() );
+	}
+
+	/** @dataProvider unavailable_conditions */
+	public function test_returns_a_stable_reason_for_each_unavailable_condition( bool $feature, bool $connected, bool $entitled, bool $capable, bool $public_site, string $reason ): void {
+		$result = SpeechAvailability::for_conditions( $feature, $connected, $entitled, $capable, $public_site );
+		$this->assertFalse( $result->is_available() );
+		$this->assertSame( $reason, $result->reason() );
+		$this->assertTrue( SpeechAvailability::is_reason( $result->reason() ) );
+	}
+
+	/** @return array<string, array{bool, bool, bool, bool, bool, string}> */
+	public static function unavailable_conditions(): array {
+		return array(
+			'feature' => array( false, true, true, true, true, SpeechAvailability::FEATURE_DISABLED ),
+			'connection' => array( true, false, true, true, true, SpeechAvailability::CONNECTION_UNAVAILABLE ),
+			'entitlement' => array( true, true, false, true, true, SpeechAvailability::ENTITLEMENT_UNAVAILABLE ),
+			'capability' => array( true, true, true, false, true, SpeechAvailability::CAPABILITY_UNAVAILABLE ),
+			'public site' => array( true, true, true, true, false, SpeechAvailability::PUBLIC_SITE_DISABLED ),
+		);
+	}
+}

--- a/tests/SdAiAgent/REST/PublicChatControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicChatControllerTest.php
@@ -112,6 +112,7 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertFalse( $response->get_data()['enabled'] );
 		$this->assertFalse( $response->get_data()['speech']['enabled'] );
+		$this->assertFalse( $response->get_data()['speech']['availability']['available'] );
 		$this->assertSame( 0, $response->get_data()['speech']['max_audio_bytes'] );
 		$this->assertSame( 0, $response->get_data()['speech']['max_recording_duration_seconds'] );
 		$this->assertSame( 0, $response->get_data()['speech']['max_tts_characters'] );

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -375,6 +375,16 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 									'effective_at'      => 'invalid',
 								),
 							),
+							'speech' => array(
+								'enabled'             => true,
+								'entitled'            => true,
+								'cohort'              => 'staged',
+								'supported_surfaces'  => array( 'authenticated', 'public' ),
+								'languages'           => array( 'en-US' ),
+								'voices'              => array( 'alloy' ),
+								'rollback_categories' => array( 'feature_disabled', 'temporary_unavailable' ),
+								'account_id'          => 'must-not-be-exposed',
+							),
 							'access_token'       => 'must-not-be-exposed',
 						)
 					),
@@ -433,6 +443,18 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 125000, $data['chat_sessions'][0]['cost_usd_micros'] );
 		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $data['chat_sessions'][0]['models'][0]['model_id'] );
 		$this->assertArrayNotHasKey( 'upstream_request_id', $data['chat_sessions'][0]['models'][0] );
+		$this->assertSame(
+			array(
+				'enabled'             => true,
+				'entitled'            => true,
+				'cohort'              => 'staged',
+				'supported_surfaces'  => array( 'authenticated', 'public' ),
+				'languages'           => array( 'en-US' ),
+				'voices'              => array( 'alloy' ),
+				'rollback_categories' => array( 'feature_disabled', 'temporary_unavailable' ),
+			),
+			$data['speech']
+		);
 		$this->assertArrayNotHasKey( 'usage', $data );
 		$this->assertArrayNotHasKey( 'verification', $data );
 		$this->assertArrayNotHasKey( 'refreshed_at', $data );

--- a/tests/SdAiAgent/REST/SpeechControllerTest.php
+++ b/tests/SdAiAgent/REST/SpeechControllerTest.php
@@ -105,6 +105,7 @@ final class SpeechControllerTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$data = $response->get_data();
+		$this->assertSame( array( 'available' => true, 'reason' => 'available' ), $data['availability'] );
 		$this->assertSame( 'superdav-tts', $data['text_to_speech']['model'] );
 		$this->assertSame( SpeechController::MAX_SYNTHESIS_CHARACTERS, $data['text_to_speech']['max_input_characters'] );
 		$this->assertSame( 'superdav-transcribe', $data['transcription']['model'] );


### PR DESCRIPTION
## Summary

Added a typed managed-speech availability result, local rollback gate, safe public availability metadata, service metadata projection, and content-free provider trace handling.

## Files Changed

includes/Core/Features.php, includes/Core/ProviderTraceLogger.php, includes/Core/PublicChatSecurity.php, includes/Core/SpeechAvailability.php, includes/Core/SuperdavSiteConnectionService.php, includes/REST/SessionController.php, includes/REST/SpeechController.php, src/components/use-text-to-speech.js, tests/SdAiAgent/Core/FeaturesTest.php, tests/SdAiAgent/Core/SpeechAvailabilityTest.php, tests/SdAiAgent/REST/PublicChatControllerTest.php, tests/SdAiAgent/REST/SettingsControllerTest.php, tests/SdAiAgent/REST/SpeechControllerTest.php

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused WordPress REST integration tests passed (125 tests, 563 assertions); PHP, JS, and CSS lint passed. Browser wp-env startup was blocked by an occupied local port.

Resolves #2665


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 1h 5m and 694,698 tokens on this as a headless worker.