### PR TITLE
GH#2670: add CORS to public speech errors

### DIFF
--- a/includes/Bootstrap/PublicSpeechCorsHandler.php
+++ b/includes/Bootstrap/PublicSpeechCorsHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Bootstrap;
+
+use SdAiAgent\Core\PublicChatSecurity;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\Filter;
+use XWP\DI\Decorators\Handler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Adds allowlisted CORS headers to public speech REST responses. */
+#[Handler(
+	container: 'sd-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class PublicSpeechCorsHandler {
+
+	public function __construct( private PublicChatSecurity $security ) {}
+
+	/** Add CORS headers after WordPress converts public speech errors to responses. */
+	#[Filter( tag: 'rest_post_dispatch', priority: 10, args: 3 )]
+	public function add_cors_to_speech_response( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
+		if ( ! in_array( $request->get_route(), array( '/sd-ai-agent/v1/public-chat/speech/transcriptions', '/sd-ai-agent/v1/public-chat/speech/synthesis' ), true ) ) {
+			return $response;
+		}
+
+		$config = $this->security->settings();
+
+		return $this->security->add_cors( $response, $this->security->request_origin( $request ), $config['origins'] );
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -41,6 +41,7 @@ use SdAiAgent\Bootstrap\HttpTraceHandler;
 use SdAiAgent\Bootstrap\ModelCapabilityHandler;
 use SdAiAgent\Bootstrap\KnowledgeHooksHandler;
 use SdAiAgent\Bootstrap\OnboardingHandler;
+use SdAiAgent\Bootstrap\PublicSpeechCorsHandler;
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Bootstrap\ToolDiscoveryHandler;
 use SdAiAgent\Core\AdvancedPluginManager;
@@ -123,6 +124,7 @@ use XWP\DI\Decorators\Module;
 		CustomerAgentRuntimeHandler::class,
 		CachePolicy::class,
 		FrontendAssetsHandler::class,
+		PublicSpeechCorsHandler::class,
 		MemoryController::class,
 		SkillController::class,
 		BannerController::class,

--- a/includes/REST/PublicSpeechController.php
+++ b/includes/REST/PublicSpeechController.php
@@ -33,8 +33,6 @@ final class PublicSpeechController extends XWP_REST_Controller {
 	public function __construct( ?PublicChatSecurity $security = null, ?SpeechController $speech = null ) {
 		$this->security = $security ?? new PublicChatSecurity();
 		$this->speech   = $speech ?? new SpeechController();
-
-		add_filter( 'rest_post_dispatch', array( $this, 'add_cors_to_speech_response' ), 10, 3 );
 	}
 
 	/** Public routes perform their complete authorization inside each handler. */
@@ -155,17 +153,6 @@ final class PublicSpeechController extends XWP_REST_Controller {
 		$this->record_metric( 'synthesis', $result, $started_at );
 
 		return $result;
-	}
-
-	/** Add allowlisted CORS headers after WordPress converts public speech errors to responses. */
-	public function add_cors_to_speech_response( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
-		if ( ! in_array( $request->get_route(), array( '/sd-ai-agent/v1/public-chat/speech/transcriptions', '/sd-ai-agent/v1/public-chat/speech/synthesis' ), true ) ) {
-			return $response;
-		}
-
-		$config = $this->security->settings();
-
-		return $this->security->add_cors( $response, $this->security->request_origin( $request ), $config['origins'] );
 	}
 
 	/** Process one public synthesis after the telemetry timer starts. */

--- a/includes/REST/PublicSpeechController.php
+++ b/includes/REST/PublicSpeechController.php
@@ -33,6 +33,8 @@ final class PublicSpeechController extends XWP_REST_Controller {
 	public function __construct( ?PublicChatSecurity $security = null, ?SpeechController $speech = null ) {
 		$this->security = $security ?? new PublicChatSecurity();
 		$this->speech   = $speech ?? new SpeechController();
+
+		add_filter( 'rest_post_dispatch', array( $this, 'add_cors_to_speech_response' ), 10, 3 );
 	}
 
 	/** Public routes perform their complete authorization inside each handler. */
@@ -153,6 +155,17 @@ final class PublicSpeechController extends XWP_REST_Controller {
 		$this->record_metric( 'synthesis', $result, $started_at );
 
 		return $result;
+	}
+
+	/** Add allowlisted CORS headers after WordPress converts public speech errors to responses. */
+	public function add_cors_to_speech_response( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
+		if ( ! in_array( $request->get_route(), array( '/sd-ai-agent/v1/public-chat/speech/transcriptions', '/sd-ai-agent/v1/public-chat/speech/synthesis' ), true ) ) {
+			return $response;
+		}
+
+		$config = $this->security->settings();
+
+		return $this->security->add_cors( $response, $this->security->request_origin( $request ), $config['origins'] );
 	}
 
 	/** Process one public synthesis after the telemetry timer starts. */


### PR DESCRIPTION
## Summary

Adds allowlisted CORS headers to REST-dispatched public speech error responses.

## Files Changed

includes/REST/PublicSpeechController.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — PHP syntax check passed; focused PHPCS ran through the staged-file hook.

Resolves #2670


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 5m and 90,142 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-origin access for public transcription and speech synthesis endpoints.
  - Responses now consistently include approved CORS headers, including when requests are processed through the standard REST response flow.
  - Access remains limited to origins allowed by the application’s security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->