### PR TITLE
GH#2669: test: cover configured managed edge host

### DIFF
--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -160,6 +160,27 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertTrue(
 			$handler->allow_configured_loopback_host( true, 'unrelated.example', 'https://unrelated.example/models' )
 		);
+
+		add_filter(
+			'sd_ai_agent_cloud_base_url',
+			static fn(): string => 'https://api.sdaiagent.com/v1'
+		);
+
+		$this->assertTrue(
+			$handler->allow_configured_loopback_host( false, 'api.sdaiagent.com', 'https://api.sdaiagent.com/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, 'unrelated.example', 'https://api.sdaiagent.com/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, 'api.sdaiagent.com', 'http://api.sdaiagent.com/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, 'api.sdaiagent.com', 'https://api.sdaiagent.com:443/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, 'api.sdaiagent.com', 'https://api.sdaiagent.com/admin' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Added exact-match regression coverage for configured public managed-edge hosts.

## Files Changed

tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:php -- --filter=SuperdavAiProviderTest; pnpm run lint:php

Resolves #2669


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 28m and 133,356 tokens on this as a headless worker.