### PR TITLE
GH#2674: test: preserve WordPress data exports in simple mode test

### DIFF
--- a/src/components/chat-redesign/__tests__/customer-simple-mode.test.js
+++ b/src/components/chat-redesign/__tests__/customer-simple-mode.test.js
@@ -5,18 +5,22 @@
 import { createElement } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
-import { useDispatch, useSelect } from '@wordpress/data';
-
-import ChatRedesign from '../index';
-import InputArea from '../InputArea';
-import WidgetHeader from '../../chat-widget/widget-header';
 
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
+const useDispatch = jest.fn();
+const useSelect = jest.fn();
+const wordpressData = jest.requireActual( '@wordpress/data' );
+
+jest.doMock( '@wordpress/data', () => ( {
+	...wordpressData,
+	useDispatch,
+	useSelect,
 } ) );
+
+const ChatRedesign = require( '../index' ).default;
+const InputArea = require( '../InputArea' ).default;
+const WidgetHeader = require( '../../chat-widget/widget-header' ).default;
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str ) => str,
@@ -35,19 +39,60 @@ jest.mock( '@wordpress/icons', () => ( {
 	sidebar: 'sidebar',
 } ) );
 
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		Button: ( { children, label, disabled, onClick, className } ) =>
+			React.createElement(
+				'button',
+				{
+					type: 'button',
+					className,
+					'aria-label': label,
+					disabled,
+					onClick,
+				},
+				children
+			),
+		CheckboxControl: ( { label, checked, disabled, onChange } ) =>
+			React.createElement( 'input', {
+				type: 'checkbox',
+				'aria-label': label,
+				checked,
+				disabled,
+				onChange: ( event ) => onChange( event.target.checked ),
+			} ),
+	};
+} );
+
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '../../../store', () => 'sd-ai-agent' );
 jest.mock( '../../../utils/branding', () => ( {
 	getBranding: () => ( { agentName: 'Docs Assistant' } ),
 } ) );
 jest.mock( '../../use-speech-recognition', () => () => ( {
+	cancelListening: jest.fn(),
+	detectedLanguage: '',
+	error: null,
 	isListening: false,
 	isSupported: false,
+	isTranscribing: false,
+	startListening: jest.fn(),
+	status: 'idle',
+	stopListening: jest.fn(),
 	toggleListening: jest.fn(),
 } ) );
-jest.mock( '../../use-text-to-speech', () => ( {
-	isTTSSupported: false,
-} ) );
+jest.mock( '../../use-text-to-speech', () => {
+	const useTextToSpeech = () => ( {
+		cancel: jest.fn(),
+		isSpeaking: false,
+		isSupported: false,
+		speak: jest.fn(),
+	} );
+	useTextToSpeech.isTTSSupported = false;
+
+	return useTextToSpeech;
+} );
 jest.mock(
 	'../../slash-command-menu',
 	() => () =>


### PR DESCRIPTION
## Summary

Preserve real @wordpress/data exports while keeping simple-mode store hooks controllable, and supply focused UI mocks required by current WordPress packages.

## Files Changed

src/components/chat-redesign/__tests__/customer-simple-mode.test.js

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — pnpm run test:js -- --runInBand src/components/chat-redesign/__tests__/customer-simple-mode.test.js

Resolves #2674


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 48m and 215,333 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup and mocks for chat functionality.
  * Expanded speech recognition and text-to-speech test coverage support.
  * Preserved existing test behavior while improving test environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->