### PR TITLE
GH#2673: test: cover trash selector fixture

### DIFF
--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -340,7 +340,10 @@ describe( 'actions', () => {
 			fetchSessions: jest.fn(),
 			clearCurrentSession: jest.fn(),
 		};
-		const select = { getCurrentSessionId: jest.fn( () => null ) };
+		const select = {
+			getCurrentSessionId: jest.fn( () => 4 ),
+			getSessions: jest.fn( () => [ { id: 4 } ] ),
+		};
 
 		await actions.bulkSessionAction(
 			[ 4, 5 ],
@@ -368,12 +371,18 @@ describe( 'actions', () => {
 			data: { ids: [ 4, 5 ], action: 'delete' },
 		} );
 
+		dispatch.clearCurrentSession.mockClear();
 		await actions.emptySessionTrash()( { dispatch, select } );
 		expect( apiFetch ).toHaveBeenLastCalledWith( {
 			path: '/sd-ai-agent/v1/sessions/trash',
 			method: 'DELETE',
 		} );
-		expect( dispatch.fetchSessions ).toHaveBeenCalledTimes( 3 );
+		expect( dispatch.clearCurrentSession ).toHaveBeenCalledTimes( 1 );
+
+		select.getCurrentSessionId.mockReturnValue( 9 );
+		await actions.emptySessionTrash()( { dispatch, select } );
+		expect( dispatch.clearCurrentSession ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.fetchSessions ).toHaveBeenCalledTimes( 4 );
 	} );
 
 	test( 'sendMessage returns a thunk function', () => {


### PR DESCRIPTION
## Summary

Synchronised the scoped test fixture with the existing selector dependency and asserted both fixture arrangements.

## Files Changed

src/store/__tests__/index.test.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: pnpm run test:js -- --runInBand src/store/__tests__/index.test.js executed in Node/Jest with 143 passed; pnpm run lint:js passed. Full pnpm run test:js remains blocked by the unrelated customer-simple-mode test's combineReducers mock failure.

Resolves #2673


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 51m and 202,458 tokens on this as a headless worker.