### PR TITLE
GH#2680: Route PluginGenerator prompts through parent provider

### DIFF
--- a/advanced-plugin/includes/Abilities/GeneratePluginAbility.php
+++ b/advanced-plugin/includes/Abilities/GeneratePluginAbility.php
@@ -28,6 +28,38 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class GeneratePluginAbility extends AbstractAbility {
 
+	/**
+	 * Provider/model selected by the parent AgentLoop for this one ability call.
+	 *
+	 * @var array{provider_id:string,model_id:string}
+	 */
+	private array $provider_model_context = array(
+		'provider_id' => '',
+		'model_id'    => '',
+	);
+
+	/**
+	 * Bind the parent run's provider/model for one resolver dispatch.
+	 *
+	 * The resolver clears this immediately after execution. Keeping the context
+	 * on the registered ability instance avoids cross-request globals while
+	 * allowing nested prompt calls to inherit the successful parent route.
+	 */
+	public function set_provider_model_context( string $provider_id, string $model_id ): void {
+		$this->provider_model_context = array(
+			'provider_id' => substr( trim( $provider_id ), 0, 191 ),
+			'model_id'    => substr( trim( $model_id ), 0, 191 ),
+		);
+	}
+
+	/** Clear parent provider/model context after one resolver dispatch. */
+	public function clear_provider_model_context(): void {
+		$this->provider_model_context = array(
+			'provider_id' => '',
+			'model_id'    => '',
+		);
+	}
+
 	protected function label(): string {
 		return __( 'Generate Plugin', 'superdav-ai-agent' );
 	}
@@ -84,7 +116,7 @@ class GeneratePluginAbility extends AbstractAbility {
 		}
 
 		// Step 1: Generate structured plan (returns an array, not text).
-		$plan = PluginGenerator::generate_plan( $description );
+		$plan = PluginGenerator::generate_plan( $description, $this->provider_model_context );
 		if ( is_wp_error( $plan ) ) {
 			return $plan;
 		}
@@ -95,7 +127,7 @@ class GeneratePluginAbility extends AbstractAbility {
 		}
 
 		// Step 2: Generate code file-by-file respecting dependency order.
-		$code_result = PluginGenerator::generate_code( $plan );
+		$code_result = PluginGenerator::generate_code( $plan, $this->provider_model_context );
 		if ( is_wp_error( $code_result ) ) {
 			return $code_result;
 		}

--- a/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
+++ b/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SdAiAgent\PluginBuilder;
 
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\Settings;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -41,6 +42,8 @@ class PluginGenerator {
 	 *   @type array  $hooks          Hooks from HookScanner for extension plugins.
 	 *   @type array  $existing_files Existing plugin file paths for extensions.
 	 *   @type string $error_context  Error message from a previous failed attempt.
+	 *   @type string $provider_id    Parent run provider selected by AgentLoop.
+	 *   @type string $model_id       Parent run model selected by AgentLoop.
 	 * }
 	 * @return array<string,mixed>|\WP_Error Plan array or WP_Error on failure.
 	 */
@@ -51,8 +54,6 @@ class PluginGenerator {
 				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
 			);
 		}
-
-		ProviderCredentialLoader::load();
 
 		if ( empty( trim( $description ) ) ) {
 			return new WP_Error(
@@ -105,7 +106,12 @@ INSTRUCTION;
 			$prompt .= "\n\nPrevious attempt failed with this error (adjust the plan accordingly):\n" . (string) $context['error_context'];
 		}
 
-		$raw = wp_ai_client_prompt( $prompt )
+		$builder = self::create_prompt_builder( $prompt, $context );
+		if ( is_wp_error( $builder ) ) {
+			return $builder;
+		}
+
+		$raw = $builder
 			->using_system_instruction( $system_instruction )
 			->generate_text();
 
@@ -136,10 +142,11 @@ INSTRUCTION;
 	 * Files are generated in dependency order. Each previously generated file
 	 * is passed as context to subsequent file generation calls.
 	 *
-	 * @param array<string,mixed> $plan Plan array from generate_plan().
+	 * @param array<string,mixed> $plan    Plan array from generate_plan().
+	 * @param array<string,mixed> $context Parent provider/model routing context.
 	 * @return array{files: array<string,string>, plan: array<string,mixed>}|\WP_Error
 	 */
-	public static function generate_code( array $plan ): array|\WP_Error {
+	public static function generate_code( array $plan, array $context = [] ): array|\WP_Error {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'ai_client_unavailable',
@@ -182,13 +189,13 @@ INSTRUCTION;
 			}
 			$file_spec['path'] = $normalised;
 
-			$code = self::generate_file( $plan, $file_spec, $generated_files );
+			$code = self::generate_file( $plan, $file_spec, $generated_files, $context );
 
 			if ( is_wp_error( $code ) ) {
 				return $code;
 			}
 
-			$code = self::prepare_generated_php( (string) $code, $plan, $file_spec, $generated_files );
+			$code = self::prepare_generated_php( (string) $code, $plan, $file_spec, $generated_files, $context );
 			if ( is_wp_error( $code ) ) {
 				return $code;
 			}
@@ -221,17 +228,16 @@ INSTRUCTION;
 	 * @param array<string,mixed>  $plan        Plan array from generate_plan().
 	 * @param array<string,mixed>  $file_spec   File spec: path, purpose, dependencies.
 	 * @param array<string,string> $prior_files Already-generated files keyed by relative path.
+	 * @param array<string,mixed>  $context     Parent provider/model routing context.
 	 * @return string|\WP_Error Generated PHP source code or WP_Error.
 	 */
-	public static function generate_file( array $plan, array $file_spec, array $prior_files = [] ): string|\WP_Error {
+	public static function generate_file( array $plan, array $file_spec, array $prior_files = [], array $context = [] ): string|\WP_Error {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'ai_client_unavailable',
 				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
 			);
 		}
-
-		ProviderCredentialLoader::load();
 
 		$slug    = isset( $plan['slug'] ) ? (string) $plan['slug'] : 'generated-plugin';
 		$name    = isset( $plan['name'] ) ? (string) $plan['name'] : $slug;
@@ -288,7 +294,12 @@ INSTRUCTION;
 
 		$prompt .= "\nGenerate the complete PHP source code for {$path}. Output only PHP code, no markdown.";
 
-		$raw = wp_ai_client_prompt( $prompt )
+		$builder = self::create_prompt_builder( $prompt, $context );
+		if ( is_wp_error( $builder ) ) {
+			return $builder;
+		}
+
+		$raw = $builder
 			->using_system_instruction( $system_instruction )
 			->generate_text();
 
@@ -302,19 +313,18 @@ INSTRUCTION;
 	/**
 	 * Post-generation review pass for security, WP standards, and potential fatals.
 	 *
-	 * @param array<string,string> $files Map of relative path → source code.
-	 * @param array<string,mixed>  $plan  Plan array from generate_plan().
+	 * @param array<string,string> $files   Map of relative path → source code.
+	 * @param array<string,mixed>  $plan    Plan array from generate_plan().
+	 * @param array<string,mixed>  $context Parent provider/model routing context.
 	 * @return array{approved: bool, issues: array<int,array<string,mixed>>, suggested_fixes: array<int,array<string,mixed>>}|\WP_Error
 	 */
-	public static function review_code( array $files, array $plan ): array|\WP_Error {
+	public static function review_code( array $files, array $plan, array $context = [] ): array|\WP_Error {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'ai_client_unavailable',
 				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
 			);
 		}
-
-		ProviderCredentialLoader::load();
 
 		if ( empty( $files ) ) {
 			return new WP_Error(
@@ -362,7 +372,12 @@ INSTRUCTION;
 		$prompt .= "Plugin: {$plugin_name}\n";
 		$prompt .= $files_text;
 
-		$raw = wp_ai_client_prompt( $prompt )
+		$builder = self::create_prompt_builder( $prompt, $context );
+		if ( is_wp_error( $builder ) ) {
+			return $builder;
+		}
+
+		$raw = $builder
 			->using_system_instruction( $system_instruction )
 			->generate_text();
 
@@ -526,7 +541,103 @@ INSTRUCTION;
 		return $slug . '/' . $normalised;
 	}
 
+	/**
+	 * Resolve the provider/model pair for a nested plugin-generation request.
+	 *
+	 * Parent context wins because it represents the provider that successfully
+	 * produced the ability call. Direct callers fall back to Settings' validated
+	 * authenticated pair instead of allowing the SDK to choose an arbitrary
+	 * connector.
+	 *
+	 * @param array<string,mixed> $context Parent execution context.
+	 * @return array{provider_id:string,model_id:string}|WP_Error
+	 */
+	public static function resolve_generation_route( array $context = [] ): array|WP_Error {
+		$provider_id = trim( (string) ( $context['provider_id'] ?? '' ) );
+		$model_id    = trim( (string) ( $context['model_id'] ?? '' ) );
+
+		if ( '' !== $provider_id ) {
+			if ( '' !== $model_id && ! Settings::is_model_advertised( $provider_id, $model_id ) ) {
+				return new WP_Error(
+					'sd_ai_agent_plugin_generation_model_unavailable',
+					__( 'The AI model selected for this run is unavailable for plugin generation. Configure a compatible text model and retry.', 'superdav-ai-agent' )
+				);
+			}
+
+			return array(
+				'provider_id' => $provider_id,
+				'model_id'    => $model_id,
+			);
+		}
+
+		$settings    = Settings::instance();
+		$provider_id = trim( $settings->get_default_provider() );
+		$model_id    = trim( $settings->get_default_model() );
+
+		if ( '' === $provider_id ) {
+			return new WP_Error(
+				'sd_ai_agent_plugin_generation_provider_unavailable',
+				__( 'No authenticated AI provider is configured for plugin generation. Configure a text-capable provider and retry.', 'superdav-ai-agent' )
+			);
+		}
+
+		return array(
+			'provider_id' => $provider_id,
+			'model_id'    => $model_id,
+		);
+	}
+
 	// ─── Private helpers ──────────────────────────────────────────────────────
+
+	/**
+	 * Create one provider-bound prompt builder for every nested generation stage.
+	 *
+	 * @param string              $prompt  Prompt text.
+	 * @param array<string,mixed> $context Parent provider/model routing context.
+	 * @return \WP_AI_Client_Prompt_Builder|WP_Error
+	 */
+	private static function create_prompt_builder( string $prompt, array $context = [] ) {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error(
+				'ai_client_unavailable',
+				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
+			);
+		}
+
+		ProviderCredentialLoader::load();
+		$route = self::resolve_generation_route( $context );
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$provider_id = $route['provider_id'];
+		$model_id    = $route['model_id'];
+
+		try {
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			if ( ! $registry->hasProvider( $provider_id ) || null === $registry->getProviderRequestAuthentication( $provider_id ) ) {
+				return new WP_Error(
+					'sd_ai_agent_plugin_generation_provider_unavailable',
+					__( 'The AI provider selected for plugin generation is unavailable. Configure an authenticated text-capable provider and retry.', 'superdav-ai-agent' )
+				);
+			}
+
+			$builder = wp_ai_client_prompt( $prompt );
+			if ( '' !== $model_id ) {
+				$model = $registry->getProviderModel( $provider_id, $model_id );
+				$builder->using_model( $model );
+			} else {
+				$builder->using_provider( $provider_id );
+			}
+
+			return $builder;
+		} catch ( \Throwable $e ) {
+			return new WP_Error(
+				'sd_ai_agent_plugin_generation_provider_unavailable',
+				__( 'The AI provider selected for plugin generation is unavailable. Configure an authenticated text-capable provider and retry.', 'superdav-ai-agent' )
+			);
+		}
+	}
 
 	/**
 	 * Strip wrappers, lint generated PHP, and attempt one bounded repair.
@@ -535,9 +646,10 @@ INSTRUCTION;
 	 * @param array<string,mixed>  $plan        Plan array.
 	 * @param array<string,mixed>  $file_spec   File spec.
 	 * @param array<string,string> $prior_files Prior generated files.
+	 * @param array<string,mixed>  $context     Parent provider/model routing context.
 	 * @return string|\WP_Error Prepared PHP source or validation error with source data.
 	 */
-	private static function prepare_generated_php( string $code, array $plan, array $file_spec, array $prior_files ): string|\WP_Error {
+	private static function prepare_generated_php( string $code, array $plan, array $file_spec, array $prior_files, array $context = [] ): string|\WP_Error {
 		$path = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : '';
 		$code = self::extract_php_source( $code );
 		$lint = self::lint_php_source( $code );
@@ -545,7 +657,7 @@ INSTRUCTION;
 			return $code;
 		}
 
-		$repaired = self::repair_file( $plan, $file_spec, $code, $lint, $prior_files, true );
+		$repaired = self::repair_file( $plan, $file_spec, $code, $lint, $prior_files, true, $context );
 		if ( is_wp_error( $repaired ) ) {
 			return $repaired;
 		}
@@ -556,7 +668,7 @@ INSTRUCTION;
 			return $repaired;
 		}
 
-		$regenerated = self::repair_file( $plan, $file_spec, $repaired, $lint, $prior_files, false );
+		$regenerated = self::repair_file( $plan, $file_spec, $repaired, $lint, $prior_files, false, $context );
 		if ( is_wp_error( $regenerated ) ) {
 			return $regenerated;
 		}
@@ -587,15 +699,16 @@ INSTRUCTION;
 	/**
 	 * Request one syntax repair from the AI client.
 	 *
-	 * @param array<string,mixed>  $plan        Plan array.
-	 * @param array<string,mixed>  $file_spec   File spec.
-	 * @param string               $code        Invalid source.
-	 * @param array<string,mixed>  $lint        Lint result.
-	 * @param array<string,string> $prior_files Prior generated files.
+	 * @param array<string,mixed>  $plan           Plan array.
+	 * @param array<string,mixed>  $file_spec      File spec.
+	 * @param string               $code           Invalid source.
+	 * @param array<string,mixed>  $lint           Lint result.
+	 * @param array<string,string> $prior_files    Prior generated files.
 	 * @param bool                 $include_source Whether to include invalid source in the repair prompt.
+	 * @param array<string,mixed>  $context        Parent provider/model routing context.
 	 * @return string|\WP_Error
 	 */
-	private static function repair_file( array $plan, array $file_spec, string $code, array $lint, array $prior_files, bool $include_source ): string|\WP_Error {
+	private static function repair_file( array $plan, array $file_spec, string $code, array $lint, array $prior_files, bool $include_source, array $context = [] ): string|\WP_Error {
 		$path = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : 'plugin.php';
 
 		$system_instruction = <<<'INSTRUCTION'
@@ -617,7 +730,12 @@ INSTRUCTION;
 			$prompt .= "\nInvalid source:\n" . $code;
 		}
 
-		$raw = wp_ai_client_prompt( $prompt )
+		$builder = self::create_prompt_builder( $prompt, $context );
+		if ( is_wp_error( $builder ) ) {
+			return $builder;
+		}
+
+		$raw = $builder
 			->using_system_instruction( $system_instruction )
 			->generate_text();
 

--- a/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
+++ b/advanced-plugin/includes/PluginBuilder/PluginGenerator.php
@@ -624,7 +624,14 @@ INSTRUCTION;
 
 			$builder = wp_ai_client_prompt( $prompt );
 			if ( '' !== $model_id ) {
-				$model = $registry->getProviderModel( $provider_id, $model_id );
+				try {
+					$model = $registry->getProviderModel( $provider_id, $model_id );
+				} catch ( \InvalidArgumentException ) {
+					return new WP_Error(
+						'sd_ai_agent_plugin_generation_model_unavailable',
+						__( 'The AI model selected for this run is unavailable for plugin generation. Configure a compatible text model and retry.', 'superdav-ai-agent' )
+					);
+				}
 				$builder->using_model( $model );
 			} else {
 				$builder->using_provider( $provider_id );

--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -38,6 +38,13 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	private array $allowed = array();
 
 	/**
+	 * Provider/model routing inherited from the parent AgentLoop for one batch.
+	 *
+	 * @var array{provider_id:string,model_id:string}|null
+	 */
+	private ?array $provider_model_context = null;
+
+	/**
 	 * @param \WP_Ability|string ...$abilities Allowed abilities (objects or names).
 	 */
 	public function __construct( ...$abilities ) {
@@ -50,6 +57,24 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 				$this->allowed[ $ability ] = true;
 			}
 		}
+	}
+
+	/**
+	 * Bind the selected parent provider/model for the current ability batch.
+	 *
+	 * @param string $provider_id Provider selected by AgentLoop.
+	 * @param string $model_id    Model selected by AgentLoop.
+	 */
+	public function set_provider_model_context( string $provider_id, string $model_id ): void {
+		$this->provider_model_context = array(
+			'provider_id' => substr( trim( $provider_id ), 0, 191 ),
+			'model_id'    => substr( trim( $model_id ), 0, 191 ),
+		);
+	}
+
+	/** Clear parent provider/model context after the current ability batch. */
+	public function clear_provider_model_context(): void {
+		$this->provider_model_context = null;
 	}
 
 	/**
@@ -184,6 +209,7 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 		// or validate_output(). Our AbstractAbility::do_execute() override
 		// handles errors inside the callback itself.
 		try {
+			$this->set_ability_provider_model_context( $ability );
 			// @phpstan-ignore-next-line — execute() exists at runtime in WP 7.0.
 			$result = $ability->execute( $args );
 		} catch ( \Throwable $e ) {
@@ -238,6 +264,8 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 				$function_name,
 				$response_data
 			);
+		} finally {
+			$this->clear_ability_provider_model_context( $ability );
 		}
 
 		if ( is_wp_error( $result ) ) {
@@ -312,6 +340,36 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 		ModelHealthTracker::record_success();
 
 		return new FunctionResponse( $function_id, $function_name, $result );
+	}
+
+	/**
+	 * Pass the bounded parent route to abilities that opt into nested AI routing.
+	 *
+	 * @param \WP_Ability $ability Ability about to execute.
+	 */
+	private function set_ability_provider_model_context( \WP_Ability $ability ): void {
+		$setter = array( $ability, 'set_provider_model_context' );
+		if ( ! is_callable( $setter ) ) {
+			return;
+		}
+
+		$context = $this->provider_model_context ?? array(
+			'provider_id' => '',
+			'model_id'    => '',
+		);
+		$setter( $context['provider_id'], $context['model_id'] );
+	}
+
+	/**
+	 * Remove the parent route from an opted-in ability after every execution.
+	 *
+	 * @param \WP_Ability $ability Ability that has finished executing.
+	 */
+	private function clear_ability_provider_model_context( \WP_Ability $ability ): void {
+		$clearer = array( $ability, 'clear_provider_model_context' );
+		if ( is_callable( $clearer ) ) {
+			$clearer();
+		}
 	}
 
 	/**

--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -348,8 +348,9 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	 * @param \WP_Ability $ability Ability about to execute.
 	 */
 	private function set_ability_provider_model_context( \WP_Ability $ability ): void {
-		$setter = array( $ability, 'set_provider_model_context' );
-		if ( ! is_callable( $setter ) ) {
+		$setter  = array( $ability, 'set_provider_model_context' );
+		$clearer = array( $ability, 'clear_provider_model_context' );
+		if ( ! is_callable( $setter ) || ! is_callable( $clearer ) ) {
 			return;
 		}
 
@@ -366,10 +367,13 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	 * @param \WP_Ability $ability Ability that has finished executing.
 	 */
 	private function clear_ability_provider_model_context( \WP_Ability $ability ): void {
+		$setter  = array( $ability, 'set_provider_model_context' );
 		$clearer = array( $ability, 'clear_provider_model_context' );
-		if ( is_callable( $clearer ) ) {
-			$clearer();
+		if ( ! is_callable( $setter ) || ! is_callable( $clearer ) ) {
+			return;
 		}
+
+		$clearer();
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -224,8 +224,7 @@ PROMPT;
 	/** @var array<int|string, mixed> Page context from the widget. */
 	private $page_context = array();
 
-	/** @var WP_AI_Client_Ability_Function_Resolver|null */
-	private $ability_resolver = null;
+	private ?AbilityFunctionResolver $ability_resolver = null;
 
 	/** @var Settings Injected settings dependency. */
 	private $settings_service;

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4447,9 +4447,9 @@ PROMPT;
 	/**
 	 * Get or create the ability function resolver instance.
 	 *
-	 * @return WP_AI_Client_Ability_Function_Resolver
+	 * @return AbilityFunctionResolver
 	 */
-	private function get_ability_resolver(): WP_AI_Client_Ability_Function_Resolver {
+	private function get_ability_resolver(): AbilityFunctionResolver {
 		if ( null === $this->ability_resolver ) {
 			$abilities              = $this->resolve_abilities();
 			$this->ability_resolver = new AbilityFunctionResolver( ...$abilities );
@@ -4467,7 +4467,16 @@ PROMPT;
 	 * @return Message Tool-response message.
 	 */
 	protected function execute_abilities( Message $message ): Message {
-		return $this->get_ability_resolver()->execute_abilities( $message );
+		$resolver    = $this->get_ability_resolver();
+		$provider_id = $this->resolve_provider_id();
+		$model_id    = $this->resolve_effective_model_id( $provider_id );
+
+		$resolver->set_provider_model_context( $provider_id, $model_id );
+		try {
+			return $resolver->execute_abilities( $message );
+		} finally {
+			$resolver->clear_provider_model_context();
+		}
 	}
 
 	// ── Tool call logging ─────────────────────────────────────────────────

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -33,7 +33,6 @@ use SdAiAgent\Repositories\SkillUsageRepository;
 use SdAiAgent\Tools\ModelHealthTracker;
 use SdAiAgent\Tools\ToolDiscovery;
 use SdAiAgent\Core\RolePermissions;
-use WP_AI_Client_Ability_Function_Resolver;
 use WP_Error;
 use SdAiAgent\Core\CredentialResolver;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;

--- a/tests/SdAiAgent/Abilities/PluginBuilderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PluginBuilderAbilitiesTest.php
@@ -60,6 +60,33 @@ class PluginBuilderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'object', $schema['properties']['plan']['type'] );
 	}
 
+	/**
+	 * Provider/model context is scoped to one resolver dispatch and can be cleared.
+	 */
+	public function test_generate_plugin_provider_model_context_is_clearable(): void {
+		$ability  = new GeneratePluginAbility( 'sd-ai-agent/generate-plugin' );
+		$property = new \ReflectionProperty( GeneratePluginAbility::class, 'provider_model_context' );
+		$property->setAccessible( true );
+
+		$ability->set_provider_model_context( 'sd-ai-agent-cloud', 'superdav-chat-strong' );
+		$this->assertSame(
+			array(
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-strong',
+			),
+			$property->getValue( $ability )
+		);
+
+		$ability->clear_provider_model_context();
+		$this->assertSame(
+			array(
+				'provider_id' => '',
+				'model_id'    => '',
+			),
+			$property->getValue( $ability )
+		);
+	}
+
 	// ── SandboxTestPluginAbility ───────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -36,6 +36,45 @@ final class ThrowingValidationAbility extends \WP_Ability {
 	}
 }
 
+final class ProviderContextAbility extends \WP_Ability {
+
+	/** @var array{provider_id:string,model_id:string} */
+	public array $provider_model_context = array(
+		'provider_id' => '',
+		'model_id'    => '',
+	);
+
+	/** @var list<array{provider_id:string,model_id:string}> */
+	public array $executed_contexts = array();
+
+	public int $clear_count = 0;
+
+	public function set_provider_model_context( string $provider_id, string $model_id ): void {
+		$this->provider_model_context = array(
+			'provider_id' => $provider_id,
+			'model_id'    => $model_id,
+		);
+	}
+
+	public function clear_provider_model_context(): void {
+		$this->provider_model_context = array(
+			'provider_id' => '',
+			'model_id'    => '',
+		);
+		++$this->clear_count;
+	}
+
+	/**
+	 * @param mixed $input Input passed by the resolver.
+	 * @return array{success:bool}
+	 */
+	public function execute( $input = null ): array {
+		unset( $input );
+		$this->executed_contexts[] = $this->provider_model_context;
+		return array( 'success' => true );
+	}
+}
+
 class AbilityFunctionResolverTest extends WP_UnitTestCase {
 
 	/**
@@ -54,6 +93,7 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		IdenticalFailureTracker::reset();
 		if ( function_exists( 'wp_unregister_ability' ) ) {
 			wp_unregister_ability( 'test-plugin/schema-thrower' );
+			wp_unregister_ability( 'test-plugin/provider-context' );
 		}
 		if ( function_exists( 'wp_unregister_ability_category' ) ) {
 			foreach ( $this->registered_test_categories as $category_slug ) {
@@ -131,6 +171,39 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'query' ), $payload['missing_required_fields'] );
 		$this->assertSame( array( 'query' => '<string — Search keywords. Required.>' ), $payload['example_arguments'] );
 		$this->assertStringContainsString( 'Do not retry with empty arguments', $payload['hint'] );
+	}
+
+	public function test_provider_model_context_is_forwarded_and_cleared_for_each_dispatch(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_provider_context_ability();
+		$this->assertInstanceOf( ProviderContextAbility::class, $ability );
+
+		$resolver = new AbilityFunctionResolver( $ability );
+		$resolver->set_provider_model_context( 'sd-ai-agent-cloud', 'superdav-chat-strong' );
+		$resolver->execute_ability(
+			new FunctionCall(
+				'call_provider_context',
+				\WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/provider-context' ),
+				array()
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-strong',
+			),
+			$ability->executed_contexts[0]
+		);
+		$this->assertSame(
+			array(
+				'provider_id' => '',
+				'model_id'    => '',
+			),
+			$ability->provider_model_context
+		);
+		$this->assertSame( 1, $ability->clear_count );
 	}
 
 	/**
@@ -291,6 +364,38 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 					),
 					'execute_callback'    => static function ( array $input ): array {
 						unset( $input );
+						return array( 'unused' => true );
+					},
+					'permission_callback' => static function (): bool {
+						return true;
+					},
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	private function register_provider_context_ability(): ?\WP_Ability {
+		$this->ensure_test_category( 'test-plugin' );
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			return wp_register_ability(
+				'test-plugin/provider-context',
+				array(
+					'ability_class'       => ProviderContextAbility::class,
+					'label'               => 'Provider Context',
+					'description'         => 'Records provider routing context for resolver tests.',
+					'category'            => 'test-plugin',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'execute_callback'    => static function (): array {
 						return array( 'unused' => true );
 					},
 					'permission_callback' => static function (): bool {

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -75,6 +75,46 @@ final class ProviderContextAbility extends \WP_Ability {
 	}
 }
 
+final class SetterOnlyProviderContextAbility extends \WP_Ability {
+
+	/** @var array{provider_id:string,model_id:string} */
+	public array $provider_model_context = array(
+		'provider_id' => '',
+		'model_id'    => '',
+	);
+
+	/** @var list<array{provider_id:string,model_id:string}> */
+	public array $executed_contexts = array();
+
+	public int $set_count = 0;
+
+	/**
+	 * Record provider/model context without exposing the required cleanup hook.
+	 *
+	 * @param string $provider_id Provider identifier.
+	 * @param string $model_id    Model identifier.
+	 */
+	public function set_provider_model_context( string $provider_id, string $model_id ): void {
+		$this->provider_model_context = array(
+			'provider_id' => $provider_id,
+			'model_id'    => $model_id,
+		);
+		++$this->set_count;
+	}
+
+	/**
+	 * Record context observed during execution.
+	 *
+	 * @param mixed $input Input passed by the resolver.
+	 * @return array{success:bool}
+	 */
+	public function execute( $input = null ): array {
+		unset( $input );
+		$this->executed_contexts[] = $this->provider_model_context;
+		return array( 'success' => true );
+	}
+}
+
 class AbilityFunctionResolverTest extends WP_UnitTestCase {
 
 	/**
@@ -94,6 +134,7 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		if ( function_exists( 'wp_unregister_ability' ) ) {
 			wp_unregister_ability( 'test-plugin/schema-thrower' );
 			wp_unregister_ability( 'test-plugin/provider-context' );
+			wp_unregister_ability( 'test-plugin/setter-only-provider-context' );
 		}
 		if ( function_exists( 'wp_unregister_ability_category' ) ) {
 			foreach ( $this->registered_test_categories as $category_slug ) {
@@ -204,6 +245,39 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 			$ability->provider_model_context
 		);
 		$this->assertSame( 1, $ability->clear_count );
+	}
+
+	/**
+	 * Setter-only abilities do not receive context they cannot clear between calls.
+	 */
+	public function test_provider_model_context_requires_atomic_setter_and_clearer_hooks(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_setter_only_provider_context_ability();
+		$this->assertInstanceOf( SetterOnlyProviderContextAbility::class, $ability );
+
+		$resolver      = new AbilityFunctionResolver( $ability );
+		$function_name = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/setter-only-provider-context' );
+
+		$resolver->set_provider_model_context( 'sd-ai-agent-cloud', 'first-model' );
+		$resolver->execute_ability( new FunctionCall( 'call_setter_only_context_1', $function_name, array() ) );
+		$resolver->set_provider_model_context( 'another-provider', 'second-model' );
+		$resolver->execute_ability( new FunctionCall( 'call_setter_only_context_2', $function_name, array() ) );
+
+		$this->assertSame( 0, $ability->set_count );
+		$this->assertSame(
+			array(
+				array(
+					'provider_id' => '',
+					'model_id'    => '',
+				),
+				array(
+					'provider_id' => '',
+					'model_id'    => '',
+				),
+			),
+			$ability->executed_contexts
+		);
 	}
 
 	/**
@@ -390,6 +464,38 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 					'ability_class'       => ProviderContextAbility::class,
 					'label'               => 'Provider Context',
 					'description'         => 'Records provider routing context for resolver tests.',
+					'category'            => 'test-plugin',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(),
+					),
+					'execute_callback'    => static function (): array {
+						return array( 'unused' => true );
+					},
+					'permission_callback' => static function (): bool {
+						return true;
+					},
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	private function register_setter_only_provider_context_ability(): ?\WP_Ability {
+		$this->ensure_test_category( 'test-plugin' );
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			return wp_register_ability(
+				'test-plugin/setter-only-provider-context',
+				array(
+					'ability_class'       => SetterOnlyProviderContextAbility::class,
+					'label'               => 'Setter-only Provider Context',
+					'description'         => 'Records whether the resolver forwards context without a cleanup hook.',
 					'category'            => 'test-plugin',
 					'input_schema'        => array(
 						'type'       => 'object',

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -33,6 +33,7 @@ namespace SdAiAgent\Tests\Core;
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Abilities\KnowledgeAbilities;
 use SdAiAgent\Core\ActiveJobFailureDiagnostic;
+use SdAiAgent\Core\AbilityFunctionResolver;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\ConversationSerializer;
@@ -161,6 +162,30 @@ final class ScriptedAbilityAgentLoop extends ScriptedAgentLoop {
 	}
 }
 
+/** Resolver spy for parent provider/model propagation. */
+final class ProviderContextRecordingResolver extends AbilityFunctionResolver {
+
+	/** @var list<array{provider_id:string,model_id:string}> */
+	public array $contexts = array();
+
+	public int $clear_count = 0;
+
+	public function set_provider_model_context( string $provider_id, string $model_id ): void {
+		$this->contexts[] = array(
+			'provider_id' => $provider_id,
+			'model_id'    => $model_id,
+		);
+	}
+
+	public function clear_provider_model_context(): void {
+		++$this->clear_count;
+	}
+
+	public function execute_abilities( Message $message ): Message {
+		return $message;
+	}
+}
+
 /**
  * Integration tests for AgentLoop.
  *
@@ -204,6 +229,44 @@ class AgentLoopTest extends WP_UnitTestCase {
 		remove_all_filters( 'pre_http_request' );
 		ToolDiscovery::clear_anonymous_allowed_abilities();
 		KnowledgeAbilities::clear_public_collection_allowlist();
+	}
+
+	public function test_execute_abilities_scopes_effective_provider_model_on_resolver(): void {
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WordPress AI Client ability resolver is unavailable.' );
+		}
+
+		$loop = new AgentLoop(
+			'Generate a plugin.',
+			array(),
+			array(),
+			array(
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-strong',
+			)
+		);
+		$resolver = new ProviderContextRecordingResolver();
+
+		$resolver_property = new \ReflectionProperty( AgentLoop::class, 'ability_resolver' );
+		$resolver_property->setAccessible( true );
+		$resolver_property->setValue( $loop, $resolver );
+
+		$message = new UserMessage( array( new MessagePart( 'Run the nested request.' ) ) );
+		$method  = new \ReflectionMethod( AgentLoop::class, 'execute_abilities' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertSame( $message, $result );
+		$this->assertSame(
+			array(
+				array(
+					'provider_id' => 'sd-ai-agent-cloud',
+					'model_id'    => 'superdav-chat-strong',
+				),
+			),
+			$resolver->contexts
+		);
+		$this->assertSame( 1, $resolver->clear_count );
 	}
 
 	/**

--- a/tests/SdAiAgent/PluginBuilder/PluginGeneratorTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginGeneratorTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\PluginBuilder;
 
+use SdAiAgent\Core\Settings;
 use SdAiAgent\PluginBuilder\PluginGenerator;
 use WP_UnitTestCase;
 
@@ -275,6 +276,101 @@ RAW;
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'ai_client_unavailable', $result->get_error_code() );
+	}
+
+	// ─── nested generation route ─────────────────────────────────────────────
+
+	/**
+	 * Nested plugin prompts retain the parent AgentLoop provider/model pair.
+	 */
+	public function test_resolve_generation_route_preserves_parent_provider_model(): void {
+		$models_filter = static function (): array {
+			return array(
+				'sd-ai-agent-cloud' => array( 'superdav-chat-strong' ),
+			);
+		};
+		add_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+
+		try {
+			$result = PluginGenerator::resolve_generation_route(
+				array(
+					'provider_id' => 'sd-ai-agent-cloud',
+					'model_id'    => 'superdav-chat-strong',
+				)
+			);
+
+			$this->assertIsArray( $result );
+			$this->assertSame( 'sd-ai-agent-cloud', $result['provider_id'] );
+			$this->assertSame( 'superdav-chat-strong', $result['model_id'] );
+		} finally {
+			remove_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+		}
+	}
+
+	/**
+	 * An unavailable parent model is rejected instead of silently changing route.
+	 */
+	public function test_resolve_generation_route_rejects_unavailable_parent_model(): void {
+		$models_filter = static function (): array {
+			return array(
+				'sd-ai-agent-cloud' => array( 'superdav-chat-strong' ),
+			);
+		};
+		add_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+
+		try {
+			if ( Settings::is_model_advertised( 'sd-ai-agent-cloud', 'unavailable-model' ) ) {
+				$this->markTestSkipped( 'The SDK registry is unavailable, so model compatibility cannot be validated.' );
+			}
+
+			$result = PluginGenerator::resolve_generation_route(
+				array(
+					'provider_id' => 'sd-ai-agent-cloud',
+					'model_id'    => 'unavailable-model',
+				)
+			);
+
+			$this->assertWPError( $result );
+			$this->assertSame( 'sd_ai_agent_plugin_generation_model_unavailable', $result->get_error_code() );
+		} finally {
+			remove_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+		}
+	}
+
+	/**
+	 * Direct callers fall back to the validated configured provider/model pair.
+	 */
+	public function test_resolve_generation_route_uses_configured_default_without_parent_context(): void {
+		$original_settings = get_option( Settings::OPTION_NAME, null );
+		$models_filter     = static function (): array {
+			return array(
+				'sd-ai-agent-cloud' => array( 'superdav-chat-strong' ),
+			);
+		};
+		add_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'default_provider' => 'sd-ai-agent-cloud',
+				'default_model'    => 'superdav-chat-strong',
+			),
+			false
+		);
+
+		try {
+			$result = PluginGenerator::resolve_generation_route();
+
+			$this->assertIsArray( $result );
+			$this->assertSame( 'sd-ai-agent-cloud', $result['provider_id'] );
+			$this->assertSame( 'superdav-chat-strong', $result['model_id'] );
+		} finally {
+			remove_filter( 'sd_ai_agent_registered_models_for_validation', $models_filter );
+			if ( null === $original_settings ) {
+				delete_option( Settings::OPTION_NAME );
+			} else {
+				update_option( Settings::OPTION_NAME, $original_settings, false );
+			}
+		}
 	}
 
 	// ─── review_code — SDK-unavailable path ──────────────────────────────────


### PR DESCRIPTION
## Summary

- Route nested PluginGenerator prompt builders through the effective AgentLoop provider and model.
- Bind and clear the provider/model context around each ability dispatch to prevent cross-request leakage.
- Use the authenticated Settings fallback only when no parent route is available.
- Return model-specific recovery errors when a selected model cannot be resolved.
- Require atomic provider-context set/clear hooks and cover setter-only ability reuse.

Resolves #2680

## Worker self-verification

- PHPUnit: Tests: 4394, Assertions: 20434, Errors: 0, Failures: 0, Skipped: 139
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:worker -->

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 14m and 858,414 tokens on this with the user in an interactive session.