### PR TITLE
GH#2679: bound screenshot URL iframe loading

### DIFF
--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -2,6 +2,14 @@
  * Unit tests for screenshot URL validation.
  */
 
+jest.mock( 'html2canvas', () =>
+	jest.fn( async () => ( {
+		width: 700,
+		height: 438,
+		toDataURL: () => 'data:image/jpeg;base64,c2NyZWVuc2hvdA==',
+	} ) )
+);
+
 /**
  * Load an isolated screenshot module instance.
  *
@@ -130,5 +138,76 @@ describe( 'full-page screenshot safety', () => {
 				expect( descriptor.input_schema.required ).toEqual( [ 'url' ] );
 			}
 		}
+	} );
+} );
+
+describe( 'screenshot-url iframe navigation', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		document.body.innerHTML = '';
+		window.sdAiAgentData = {
+			screenshotOrigins: [ window.location.origin ],
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+		delete window.sdAiAgentData;
+		delete window.__sdAiAgentClientAbilityRegistry;
+		document.body.innerHTML = '';
+	} );
+
+	test( 'captures a same-origin iframe that loads after the initial window', async () => {
+		const { executeScreenshotUrl } = loadScreenshotModule();
+		const resultPromise = executeScreenshotUrl( { url: '/wp-admin/' } );
+		const iframe = document.querySelector( 'iframe' );
+
+		expect( iframe ).not.toBeNull();
+		Object.defineProperty( iframe, 'contentDocument', {
+			configurable: true,
+			value: document.implementation.createHTMLDocument(),
+		} );
+		await jest.advanceTimersByTimeAsync( 16000 );
+		iframe.dispatchEvent( new Event( 'load' ) );
+		await jest.advanceTimersByTimeAsync( 1500 );
+
+		await expect( resultPromise ).resolves.toMatchObject( {
+			success: true,
+			url: `${ window.location.origin }/wp-admin/`,
+			error: '',
+		} );
+		expect( document.querySelector( 'iframe' ) ).toBeNull();
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'returns a bounded navigation error and cleans up a never-loading iframe', async () => {
+		const { executeScreenshotUrl } = loadScreenshotModule();
+		const resultPromise = executeScreenshotUrl( { url: '/wp-admin/' } );
+
+		expect( document.querySelector( 'iframe' ) ).not.toBeNull();
+		await jest.advanceTimersByTimeAsync( 60000 );
+
+		await expect( resultPromise ).resolves.toMatchObject( {
+			success: false,
+			error: 'Screenshot failed: Iframe navigation timed out after 60 seconds.',
+		} );
+		expect( document.querySelector( 'iframe' ) ).toBeNull();
+		expect( jest.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'returns a distinct navigation failure and cleans up the iframe', async () => {
+		const { executeScreenshotUrl } = loadScreenshotModule();
+		const resultPromise = executeScreenshotUrl( { url: '/wp-admin/' } );
+		const iframe = document.querySelector( 'iframe' );
+
+		iframe.dispatchEvent( new Event( 'error' ) );
+
+		await expect( resultPromise ).resolves.toMatchObject( {
+			success: false,
+			error: 'Screenshot failed: Iframe failed to load.',
+		} );
+		expect( document.querySelector( 'iframe' ) ).toBeNull();
+		expect( jest.getTimerCount() ).toBe( 0 );
 	} );
 } );

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -34,8 +34,14 @@ const MAX_IMAGE_WIDTH = 768;
 /** JPEG quality (0-1). Keeps parallel vision evidence within provider envelopes. */
 const JPEG_QUALITY = 0.72;
 
-/** How long to wait (ms) for an iframe page to fully load before capture. */
-const IFRAME_LOAD_TIMEOUT = 15000;
+/** Start probing an iframe document after this initial navigation window. */
+const IFRAME_LOAD_SOFT_TIMEOUT = 15000;
+
+/** Never wait longer than this for an iframe navigation to become ready. */
+const IFRAME_LOAD_MAX_TIMEOUT = 60000;
+
+/** How often to probe a same-origin document after the initial window. */
+const IFRAME_READY_PROBE_INTERVAL = 1000;
 
 /** Extra settle time (ms) after iframe load event for async renders. */
 const IFRAME_SETTLE_DELAY = 1500;
@@ -240,6 +246,80 @@ async function scrollToRevealLazyContent( win, doc, maxHeight ) {
 	await new Promise( ( r ) => setTimeout( r, 300 ) );
 }
 
+/**
+ * Wait for an iframe navigation while allowing a same-origin document that is
+ * still finishing heavy dashboard work to reach a bounded readiness state.
+ *
+ * @param {HTMLIFrameElement} iframe      Iframe being navigated.
+ * @param {string}            expectedUrl Same-origin destination URL.
+ * @return {Promise<void>} Resolves when the iframe is ready to capture.
+ */
+function waitForIframeNavigation( iframe, expectedUrl ) {
+	return new Promise( ( resolveLoad, rejectLoad ) => {
+		let probeTimeout;
+		let settled = false;
+
+		const onLoad = () => settle( resolveLoad );
+		const onError = () =>
+			settle( rejectLoad, new Error( 'Iframe failed to load.' ) );
+		const cleanup = () => {
+			clearTimeout( softTimeout );
+			clearTimeout( hardTimeout );
+			clearTimeout( probeTimeout );
+			iframe.removeEventListener( 'load', onLoad );
+			iframe.removeEventListener( 'error', onError );
+		};
+		const settle = ( callback, value ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			callback( value );
+		};
+		const documentIsReady = () => {
+			try {
+				const iframeDoc =
+					iframe.contentDocument || iframe.contentWindow?.document;
+				return (
+					iframe.contentWindow?.location.href === expectedUrl &&
+					iframeDoc?.readyState === 'complete' &&
+					!! iframeDoc.body
+				);
+			} catch ( _err ) {
+				return false;
+			}
+		};
+		const probeForReadyDocument = () => {
+			if ( documentIsReady() ) {
+				settle( resolveLoad );
+				return;
+			}
+			probeTimeout = setTimeout(
+				probeForReadyDocument,
+				IFRAME_READY_PROBE_INTERVAL
+			);
+		};
+
+		iframe.addEventListener( 'load', onLoad );
+		iframe.addEventListener( 'error', onError );
+		const softTimeout = setTimeout(
+			probeForReadyDocument,
+			IFRAME_LOAD_SOFT_TIMEOUT
+		);
+		const hardTimeout = setTimeout( () => {
+			settle(
+				rejectLoad,
+				new Error(
+					`Iframe navigation timed out after ${
+						IFRAME_LOAD_MAX_TIMEOUT / 1000
+					} seconds.`
+				)
+			);
+		}, IFRAME_LOAD_MAX_TIMEOUT );
+	} );
+}
+
 /* ── Ability 1: capture-screenshot ─────────────────────────────────────── */
 
 /**
@@ -361,7 +441,7 @@ async function executeCaptureScreenshot( args ) {
  * @param {boolean} [args.fullPage] Capture the full scrollable height.
  * @return {Promise<Object>} Screenshot result.
  */
-async function executeScreenshotUrl( args ) {
+export async function executeScreenshotUrl( args ) {
 	const rawUrl = args?.url || '';
 	const viewportWidth = args?.width || 1280;
 	const viewportHeight = args?.height || 800;
@@ -412,22 +492,7 @@ async function executeScreenshotUrl( args ) {
 		iframe.setAttribute( 'aria-hidden', 'true' );
 		iframe.setAttribute( 'tabindex', '-1' );
 
-		// Wait for load.
-		const loadPromise = new Promise( ( resolveLoad, rejectLoad ) => {
-			const timer = setTimeout( () => {
-				rejectLoad( new Error( 'Iframe load timed out.' ) );
-			}, IFRAME_LOAD_TIMEOUT );
-
-			iframe.addEventListener( 'load', () => {
-				clearTimeout( timer );
-				resolveLoad();
-			} );
-
-			iframe.addEventListener( 'error', () => {
-				clearTimeout( timer );
-				rejectLoad( new Error( 'Iframe failed to load.' ) );
-			} );
-		} );
+		const loadPromise = waitForIframeNavigation( iframe, targetUrl.href );
 
 		iframe.src = targetUrl.href;
 		document.body.appendChild( iframe );

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -959,6 +959,66 @@ describe( 'actions', () => {
 		}
 	} );
 
+	test( 'serializes screenshot-url calls across concurrent runner batches', async () => {
+		jest.useFakeTimers();
+		executeClientAbility.mockReset();
+		window.__sdAiAgentAbilitiesRegistering = Promise.resolve();
+		const resolvers = [];
+		let activeScreenshots = 0;
+		let maximumActiveScreenshots = 0;
+		executeClientAbility.mockImplementation( ( name, args ) => {
+			if ( name !== 'sd-ai-agent-js/screenshot-url' ) {
+				return Promise.resolve( { name, args } );
+			}
+			activeScreenshots++;
+			maximumActiveScreenshots = Math.max(
+				maximumActiveScreenshots,
+				activeScreenshots
+			);
+			return new Promise( ( resolve ) => {
+				resolvers.push( () => {
+					activeScreenshots--;
+					resolve( { screenshot: args.url } );
+				} );
+			} );
+		} );
+
+		const firstBatch = clientToolRunner.runClientTools( [
+			{
+				id: 'first-batch-screenshot',
+				name: 'sd-ai-agent-js/screenshot-url',
+				annotations: { readonly: true },
+				args: { url: '/first-batch/' },
+			},
+		] );
+		const secondBatch = clientToolRunner.runClientTools( [
+			{
+				id: 'second-batch-screenshot',
+				name: 'sd-ai-agent-js/screenshot-url',
+				annotations: { readonly: true },
+				args: { url: '/second-batch/' },
+			},
+		] );
+
+		try {
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( maximumActiveScreenshots ).toBe( 1 );
+			resolvers.shift()();
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( maximumActiveScreenshots ).toBe( 1 );
+			resolvers.shift()();
+
+			await expect(
+				Promise.all( [ firstBatch, secondBatch ] )
+			).resolves.toHaveLength( 2 );
+			expect( maximumActiveScreenshots ).toBe( 1 );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
 	test( 'pollJob posts normalized failures when the client tool runner rejects', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();
@@ -1244,7 +1304,7 @@ describe( 'actions', () => {
 		}
 	} );
 
-	test( 'pollJob gives a restored client ability its full timeout after readiness', async () => {
+	test( 'pollJob gives a restored screenshot URL ability its full timeout after readiness', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();
 		executeClientAbility.mockReset();
@@ -1293,7 +1353,7 @@ describe( 'actions', () => {
 			await jest.advanceTimersByTimeAsync( 29000 );
 			resolveReadiness();
 			await jest.advanceTimersByTimeAsync( 0 );
-			await jest.advanceTimersByTimeAsync( 29000 );
+			await jest.advanceTimersByTimeAsync( 119000 );
 
 			expect( executeClientAbility ).toHaveBeenCalledTimes( 1 );
 			expect(
@@ -1314,7 +1374,7 @@ describe( 'actions', () => {
 						{
 							id: 'readiness-window-screenshot',
 							name: 'sd-ai-agent-js/screenshot-url',
-							error: 'Client tool timed out after 30 seconds.',
+							error: 'Client tool timed out after 120 seconds.',
 						},
 					],
 				},

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -896,6 +896,69 @@ describe( 'actions', () => {
 		}
 	} );
 
+	test( 'serializes concurrent screenshot-url calls while preserving their result order', async () => {
+		jest.useFakeTimers();
+		executeClientAbility.mockReset();
+		window.__sdAiAgentAbilitiesRegistering = Promise.resolve();
+		const resolvers = [];
+		let activeScreenshots = 0;
+		let maximumActiveScreenshots = 0;
+		executeClientAbility.mockImplementation( ( name, args ) => {
+			if ( name !== 'sd-ai-agent-js/screenshot-url' ) {
+				return Promise.resolve( { name, args } );
+			}
+			activeScreenshots++;
+			maximumActiveScreenshots = Math.max(
+				maximumActiveScreenshots,
+				activeScreenshots
+			);
+			return new Promise( ( resolve ) => {
+				resolvers.push( () => {
+					activeScreenshots--;
+					resolve( { screenshot: args.url } );
+				} );
+			} );
+		} );
+
+		const resultPromise = clientToolRunner.runClientTools( [
+			...Array.from( { length: 4 }, ( _unused, index ) => ( {
+				id: `screenshot-${ index }`,
+				name: 'sd-ai-agent-js/screenshot-url',
+				annotations: { readonly: true },
+				args: { url: `/dashboard-${ index }/` },
+			} ) ),
+		] );
+
+		try {
+			await jest.advanceTimersByTimeAsync( 0 );
+			expect( maximumActiveScreenshots ).toBe( 1 );
+			for ( let index = 0; index < 4; index++ ) {
+				resolvers.shift()();
+				// Allow the queue to start only the next screenshot.
+				// eslint-disable-next-line no-await-in-loop
+				await jest.advanceTimersByTimeAsync( 0 );
+			}
+
+			await expect( resultPromise ).resolves.toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						id: 'screenshot-0',
+						result: { screenshot: '/dashboard-0/' },
+					} ),
+					expect.objectContaining( {
+						id: 'screenshot-3',
+						result: { screenshot: '/dashboard-3/' },
+					} ),
+				] )
+			);
+			expect( maximumActiveScreenshots ).toBe( 1 );
+		} finally {
+			delete window.__sdAiAgentAbilitiesRegistering;
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
 	test( 'pollJob posts normalized failures when the client tool runner rejects', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();

--- a/src/store/slices/client-tool-runner.js
+++ b/src/store/slices/client-tool-runner.js
@@ -3,6 +3,8 @@ import { executeClientAbility } from '../../abilities/registry';
 
 const SCREENSHOT_URL_ABILITY = 'sd-ai-agent-js/screenshot-url';
 const SCREENSHOT_URL_CONCURRENCY = 1;
+// This covers the 60-second iframe navigation window, render settling, and capture.
+const SCREENSHOT_URL_TIMEOUT = 120000;
 
 /**
  * Reject a promise after a bounded interval and clear the timer on settlement.
@@ -56,6 +58,9 @@ function createConcurrencyLimiter( concurrency ) {
 		} );
 }
 
+// The limiter is module-scoped so concurrent polling batches share one slot.
+const runScreenshotUrl = createConcurrencyLimiter( SCREENSHOT_URL_CONCURRENCY );
+
 /**
  * Run a server-approved batch of browser abilities with bounded readiness and
  * per-ability execution windows.
@@ -75,9 +80,6 @@ export async function runClientTools( pendingClientToolCalls ) {
 		  )
 		: null;
 
-	const runScreenshotUrl = createConcurrencyLimiter(
-		SCREENSHOT_URL_CONCURRENCY
-	);
 	const runClientTool = async ( {
 		id,
 		name,
@@ -87,10 +89,12 @@ export async function runClientTools( pendingClientToolCalls ) {
 		user_confirmed: userConfirmed,
 	} ) => {
 		const abilityName = clientName || name;
-		const timeoutMs =
-			abilityName === 'sd-ai-agent-js/validate-page-quality'
-				? 120000
-				: 30000;
+		let timeoutMs = 30000;
+		if ( abilityName === SCREENSHOT_URL_ABILITY ) {
+			timeoutMs = SCREENSHOT_URL_TIMEOUT;
+		} else if ( abilityName === 'sd-ai-agent-js/validate-page-quality' ) {
+			timeoutMs = 120000;
+		}
 
 		if ( annotations?.readonly !== true && userConfirmed !== true ) {
 			return {

--- a/src/store/slices/client-tool-runner.js
+++ b/src/store/slices/client-tool-runner.js
@@ -1,6 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { executeClientAbility } from '../../abilities/registry';
 
+const SCREENSHOT_URL_ABILITY = 'sd-ai-agent-js/screenshot-url';
+const SCREENSHOT_URL_CONCURRENCY = 1;
+
 /**
  * Reject a promise after a bounded interval and clear the timer on settlement.
  *
@@ -17,6 +20,40 @@ function withTimeout( promise, timeoutMs, message ) {
 			timeoutId = setTimeout( reject, timeoutMs, new Error( message ) );
 		} ),
 	] );
+}
+
+/**
+ * Serialize a bounded subset of client tools while leaving unrelated browser
+ * abilities free to run in parallel.
+ *
+ * @param {number} concurrency Maximum active tasks.
+ * @return {Function} Function that queues a task and returns its result.
+ */
+function createConcurrencyLimiter( concurrency ) {
+	let active = 0;
+	const queue = [];
+
+	const runNext = () => {
+		if ( active >= concurrency || queue.length === 0 ) {
+			return;
+		}
+
+		const { task, resolve, reject } = queue.shift();
+		active++;
+		Promise.resolve()
+			.then( task )
+			.then( resolve, reject )
+			.finally( () => {
+				active--;
+				runNext();
+			} );
+	};
+
+	return ( task ) =>
+		new Promise( ( resolve, reject ) => {
+			queue.push( { task, resolve, reject } );
+			runNext();
+		} );
 }
 
 /**
@@ -38,56 +75,55 @@ export async function runClientTools( pendingClientToolCalls ) {
 		  )
 		: null;
 
-	return Promise.all(
-		pendingClientToolCalls.map(
-			async ( {
+	const runScreenshotUrl = createConcurrencyLimiter(
+		SCREENSHOT_URL_CONCURRENCY
+	);
+	const runClientTool = async ( {
+		id,
+		name,
+		client_name: clientName,
+		args = {},
+		annotations,
+		user_confirmed: userConfirmed,
+	} ) => {
+		const abilityName = clientName || name;
+		const timeoutMs =
+			abilityName === 'sd-ai-agent-js/validate-page-quality'
+				? 120000
+				: 30000;
+
+		if ( annotations?.readonly !== true && userConfirmed !== true ) {
+			return {
 				id,
 				name,
-				client_name: clientName,
-				args = {},
-				annotations,
-				user_confirmed: userConfirmed,
-			} ) => {
-				const abilityName = clientName || name;
-				const timeoutMs =
-					abilityName === 'sd-ai-agent-js/validate-page-quality'
-						? 120000
-						: 30000;
+				error: __( 'Confirmation required.', 'superdav-ai-agent' ),
+			};
+		}
 
-				if (
-					annotations?.readonly !== true &&
-					userConfirmed !== true
-				) {
-					return {
-						id,
-						name,
-						error: __(
-							'Confirmation required.',
-							'superdav-ai-agent'
-						),
-					};
-				}
+		try {
+			await readiness;
+			const abilityResult = await withTimeout(
+				executeClientAbility( abilityName, args ),
+				timeoutMs,
+				`Client tool timed out after ${ timeoutMs / 1000 } seconds.`
+			);
+			return { id, name, result: abilityResult };
+		} catch ( execErr ) {
+			return {
+				id,
+				name,
+				error: String( execErr?.message || execErr || Error.name ),
+			};
+		}
+	};
 
-				try {
-					await readiness;
-					const abilityResult = await withTimeout(
-						executeClientAbility( abilityName, args ),
-						timeoutMs,
-						`Client tool timed out after ${
-							timeoutMs / 1000
-						} seconds.`
-					);
-					return { id, name, result: abilityResult };
-				} catch ( execErr ) {
-					return {
-						id,
-						name,
-						error: String(
-							execErr?.message || execErr || Error.name
-						),
-					};
-				}
-			}
-		)
+	return Promise.all(
+		pendingClientToolCalls.map( ( call ) => {
+			const abilityName = call.client_name || call.name;
+			const task = () => runClientTool( call );
+			return abilityName === SCREENSHOT_URL_ABILITY
+				? runScreenshotUrl( task )
+				: task();
+		} )
 	);
 }

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -470,6 +470,49 @@ test.describe( 'client-abilities — public schema validation', () => {
 } );
 
 // ---------------------------------------------------------------------------
+// Test suite 3b: screenshot-url execution
+// ---------------------------------------------------------------------------
+
+test.describe( 'client-abilities — screenshot-url execution', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginToWordPress( page );
+		await goToDashboard( page );
+		await requireAbilitiesApi( page );
+	} );
+
+	test( 'captures a same-origin page whose iframe load exceeds the initial window', async ( {
+		page,
+	} ) => {
+		const delayedPath = '/sd-ai-agent-e2e-delayed-screenshot/';
+		await page.route( `**${ delayedPath }`, async ( route ) => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 16000 ) );
+			await route.fulfill( {
+				contentType: 'text/html',
+				body: '<!doctype html><html><head><title>Delayed screenshot</title></head><body><main>Delayed screenshot page</main></body></html>',
+			} );
+		} );
+
+		try {
+			await waitForAbilitiesRegistered( page );
+			const result = await page.evaluate( async ( url ) => {
+				return wp.abilities.executeAbility(
+					'sd-ai-agent-js/screenshot-url',
+					{ url }
+				);
+			}, delayedPath );
+
+			expect( result ).toMatchObject( {
+				success: true,
+				error: '',
+			} );
+			expect( result.url ).toContain( delayedPath );
+		} finally {
+			await page.unroute( `**${ delayedPath }` );
+		}
+	} );
+} );
+
+// ---------------------------------------------------------------------------
 // Test suite 4: navigate-to execution
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extended screenshot-url iframe navigation to a 60-second bounded readiness window, serialized screenshot-url client-tool calls, and added delayed-load, cleanup, queue, and browser coverage.

## Files Changed

src/abilities/__tests__/screenshot.test.js, src/abilities/screenshot.js, src/store/__tests__/index.test.js, src/store/slices/client-tool-runner.js, tests/e2e/client-abilities.spec.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:js -- src/abilities/__tests__/screenshot.test.js src/store/__tests__/index.test.js --runInBand; pnpm run test:php; pnpm run verify. Playwright is blocked before test startup by local Chrome SIGTRAP.

Resolves #2679


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 32m and 361,540 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved screenshot capture for pages that load slowly, including clearer handling of loading failures and timeouts.
  - Ensured screenshot requests are processed one at a time to prevent overlapping captures and preserve results in the correct order.
  - Added safeguards to clean up screenshot resources after successful, failed, or timed-out attempts.

- **Tests**
  - Added automated coverage for delayed page loads, navigation timeouts, load failures, and concurrent screenshot requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->