### PR TITLE
fix(release): install Composer dependencies before packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress
+
       - name: Verify version matches
         run: |
           CORE_HEADER_VERSION="$(grep -m 1 ' \* Version:' superdav-ai-agent.php | sed 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')"


### PR DESCRIPTION
## Summary

- install Composer dependencies before the release workflow builds the core and Advanced ZIPs
- make the Advanced-only Plugin Update Checker dependency available in a clean GitHub Actions checkout

## Failure evidence

Release run `34070749974` failed in `Build release ZIPs` with:

```text
ERROR: Advanced updater dependency is missing; run composer install before building.
```

The workflow had installed Node dependencies but not Composer dependencies. The failure occurred before artifact upload, Advanced update-server publication, GitHub release creation, or WordPress.org deployment, so no partial release was published.

## Verification

- Inspected the failed release job and traced the missing dependency to `composer.json` `require-dev` plus the clean release checkout.
- Confirmed `.github/workflows/release.yml` now installs the locked Composer dependencies before `bin/build.sh --target=both` runs.
- No additional local verification suite was run, per maintainer instruction to skip further verification for this release.

## Release recovery

After this fix merges, repoint the unpublished failed `v1.23.0` tag to the hotfix merge commit and monitor the replacement release workflow through GitHub asset creation, Advanced update-server publication, and WordPress.org deployment.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol
