### PR TITLE
GH#2683: add backup-safe session maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Build specialized agents with the Agent Builder:
 - Search across all sessions by title or content
 - Export to JSON (reimportable) or Markdown (human-readable)
 - Per-session token usage tracking with cost estimates
+- [Backup-safe maintenance for oversized session rows](docs/session-maintenance.md)
 
 ### Memory
 - Persistent knowledge base the AI retains across sessions

--- a/docs/session-maintenance.md
+++ b/docs/session-maintenance.md
@@ -1,0 +1,74 @@
+# Backup-safe session maintenance
+
+SD AI Agent keeps each conversation in one session row. Normal session writes are
+non-destructive, but the plugin reports a maintenance threshold after a row reaches
+either 8 MiB of combined `messages`, `tool_calls`, and `paused_state` data or
+10,000 messages. Sites can override those thresholds with the
+`sd_ai_agent_session_storage_maintenance_bytes` and
+`sd_ai_agent_session_storage_maintenance_messages` filters.
+
+## Inspect candidates
+
+Administrators can call the `GET /sessions/oversized` route in the
+`sd-ai-agent/v1` REST namespace. It returns only these safe fields for each
+candidate:
+
+- session ID and status;
+- message count;
+- byte counts for messages, tool calls, paused state, and the combined payload.
+
+The inspection response does not include conversation titles, messages, tool
+calls, paused state, or user IDs. Optional `min_bytes`, `min_messages`, and
+`limit` parameters narrow the inspection without reading conversation content.
+Listing is administrative discovery only: export, compact, archive, and delete
+operations retain their normal ownership and shared-session permission checks.
+
+## Safe maintenance sequence
+
+1. Record the candidate ID and byte count from `GET /sessions/oversized`.
+2. Export the source with the existing `GET /sessions/{id}/export` route and
+   store the result outside the WordPress database. Validate the export by
+   importing it into a disposable session or restoring it on a non-production
+   site before changing the source row.
+3. Create a bounded continuation with `POST /sessions/{id}/compact`. The source
+   transcript is never overwritten: the route creates a separate session with a
+   deterministic compact context. A failed request is safe to retry because the
+   source row remains unchanged.
+4. Archive the source when it should remain visible in the session UI but is no
+   longer used for new work. Archiving and trashing retain the row and therefore
+   do **not** reduce database-export size.
+5. Only after the independent export and compact continuation are verified, use
+   the explicit `DELETE /sessions/{id}` operation to permanently remove the
+   source row. This is the only session action that removes its payload from a
+   database export.
+
+Compaction rejects active jobs and sessions with paused continuations with HTTP
+409. Finish or resume those operations before making a continuation; maintenance
+never mutates an active or recoverable session in place.
+
+## Large-row behavior
+
+Maintenance compaction reads the saved `messages` JSON in 64 KiB database slices
+and builds a bounded context as it goes. It does not decode or serialize multiple
+full copies of the original row. Tool call/result pairs are retained together or
+omitted together, preserving their ordering in the continuation context. A single
+pathological message larger than 1 MiB is represented by a bounded omission marker
+instead of being materialized in memory.
+
+## Backup and export recovery check
+
+After explicitly removing a verified source row, make a fresh database backup and
+validate it before plugin maintenance:
+
+```bash
+mariadb-dump --single-transaction --quick --routines --events --databases <database> > wordpress-pre-maintenance.sql
+mariadb <restored-database> < wordpress-pre-maintenance.sql
+mariadb <restored-database> -e "SELECT COUNT(*) FROM <table-prefix>sd_ai_agent_sessions;"
+```
+
+The dump command must exit successfully, the restore command must exit
+successfully, and the restored session count must match the expected post-removal
+count. Keep the independently exported source and the validated SQL backup until
+the compact continuation has been reviewed. Do not rely on larger MariaDB packet
+or timeout settings as the repair path; those settings do not make an oversized
+historical row operationally bounded.

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -43,6 +43,9 @@ class ConversationTrimmer {
 	/** Maximum characters copied from any single message into compact context. */
 	private const COMPACT_MAX_MESSAGE_CHARS = 2000;
 
+	/** Maximum serialized bytes held for one streamed source message. */
+	private const STREAMED_MESSAGE_MAX_BYTES = 1048576;
+
 	/** Maximum JSON characters retained for callable ability-search schemas. */
 	private const COMPACT_MAX_ABILITY_SCHEMA_RECEIPT_CHARS = 1600;
 
@@ -290,6 +293,376 @@ class ConversationTrimmer {
 				'tool_payloads_omitted'  => true,
 			),
 		);
+	}
+
+	/**
+	 * Build a bounded compact seed from JSON-array chunks without materializing the
+	 * full persisted history in PHP memory.
+	 *
+	 * Complete serialized tool call/result cycles are retained together or omitted
+	 * together. A malformed or incomplete stream is reported in meta so callers
+	 * can fail closed instead of compacting a partial conversation.
+	 *
+	 * @param iterable<int, string> $chunks     Serialized JSON-array slices.
+	 * @param int                   $max_bytes  Maximum serialized seed-message bytes.
+	 * @param int                   $max_tokens Maximum estimated seed-message tokens.
+	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
+	 */
+	public static function compact_serialized_history_chunks( iterable $chunks, int $max_bytes = self::COMPACT_MAX_BYTES, int $max_tokens = self::COMPACT_MAX_TOKENS ): array {
+		$stream_complete = false;
+		$stream_valid    = true;
+		$result          = self::compact_serialized_history_iterable(
+			self::decode_serialized_history_chunks( $chunks, $stream_complete, $stream_valid ),
+			$max_bytes,
+			$max_tokens
+		);
+
+		$result['meta']['stream_complete'] = $stream_complete;
+		$result['meta']['stream_valid']    = $stream_valid;
+
+		return $result;
+	}
+
+	/**
+	 * Build bounded compact context from a streamed serialized-message iterable.
+	 *
+	 * @param iterable<int, array<string,mixed>> $messages   Serialized messages.
+	 * @param int                                $max_bytes  Maximum serialized seed-message bytes.
+	 * @param int                                $max_tokens Maximum estimated seed-message tokens.
+	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
+	 */
+	private static function compact_serialized_history_iterable( iterable $messages, int $max_bytes, int $max_tokens ): array {
+		$max_bytes             = max( 1024, $max_bytes );
+		$max_tokens            = max( 256, $max_tokens );
+		$per_message_chars     = max( 160, min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) ) );
+		$source_count          = 0;
+		$retained_groups       = array();
+		$pending_tool_call_lines = null;
+
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$expanded     = self::serialized_message_to_compact_excerpts( $message, $per_message_chars );
+			$source_count += $expanded['source_count'];
+			$has_call     = self::serialized_message_has_function_call( $message );
+			$has_response = self::serialized_message_has_function_response( $message );
+
+			if ( null !== $pending_tool_call_lines ) {
+				if ( $has_response ) {
+					self::retain_compact_group(
+						$retained_groups,
+						array_merge( $pending_tool_call_lines, $expanded['lines'] ),
+						$source_count,
+						$max_bytes,
+						$max_tokens
+					);
+					$pending_tool_call_lines = null;
+					continue;
+				}
+
+				// Do not retain a lone call when its result is absent from the stream.
+				$pending_tool_call_lines = null;
+				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+			}
+
+			if ( $has_call ) {
+				$pending_tool_call_lines = $expanded['lines'];
+				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+				continue;
+			}
+
+			if ( $has_response ) {
+				// A result without a preceding call cannot form a complete tool cycle.
+				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+				continue;
+			}
+
+			self::retain_compact_group( $retained_groups, $expanded['lines'], $source_count, $max_bytes, $max_tokens );
+		}
+
+		if ( null !== $pending_tool_call_lines ) {
+			self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+		}
+
+		$lines          = self::flatten_compact_groups( $retained_groups );
+		$retained_count = count( $lines );
+		if ( empty( $lines ) ) {
+			$lines          = array( '[No individual message excerpt fit within the compact budget.]' );
+			$retained_count = 0;
+		}
+
+		$text       = self::build_compact_context_text( $source_count, $retained_count, $lines );
+		$message    = self::compact_text_to_message( $text );
+		$line_count = count( $lines );
+
+		while ( ! self::fits_budget( array( $message ), $max_bytes, $max_tokens ) && $line_count > 1 ) {
+			array_shift( $lines );
+			$retained_count = count( $lines );
+			$line_count     = $retained_count;
+			$text           = self::build_compact_context_text( $source_count, $retained_count, $lines );
+			$message        = self::compact_text_to_message( $text );
+		}
+
+		if ( ! self::fits_budget( array( $message ), $max_bytes, $max_tokens ) ) {
+			$retained_count = 0;
+			$text           = self::build_compact_context_text(
+				$source_count,
+				$retained_count,
+				array( '[Conversation details were omitted because the compact budget is smaller than the required metadata.]' )
+			);
+			$message        = self::compact_text_to_message( $text );
+		}
+
+		return array(
+			'messages' => array( $message->toArray() ),
+			'meta'     => array(
+				'source_message_count'   => $source_count,
+				'retained_excerpt_count' => $retained_count,
+				'boundary_omitted_count' => max( 0, $source_count - $retained_count ),
+				'estimated_bytes'        => self::estimate_bytes( $message ),
+				'estimated_tokens'       => self::estimate_tokens( $message ),
+				'max_bytes'              => $max_bytes,
+				'max_tokens'             => $max_tokens,
+				'attachments_omitted'    => true,
+				'tool_payloads_omitted'  => true,
+			),
+		);
+	}
+
+	/**
+	 * Incrementally decode an array of serialized message objects.
+	 *
+	 * @param iterable<int, string> $chunks   Serialized JSON-array slices.
+	 * @param bool                  $complete Receives whether the closing array token was read.
+	 * @param bool                  $valid    Receives whether every decoded element was valid.
+	 * @return \Generator<int, array<string,mixed>>
+	 */
+	private static function decode_serialized_history_chunks( iterable $chunks, bool &$complete, bool &$valid ): \Generator {
+		$complete      = false;
+		$valid         = true;
+		$started       = false;
+		$depth         = 0;
+		$element       = '';
+		$element_bytes = 0;
+		$in_string     = false;
+		$escaped       = false;
+		$discarding    = false;
+
+		foreach ( $chunks as $chunk ) {
+			if ( ! is_string( $chunk ) ) {
+				$valid = false;
+				continue;
+			}
+
+			for ( $index = 0, $length = strlen( $chunk ); $index < $length; ++$index ) {
+				$character = $chunk[ $index ];
+
+				if ( ! $started ) {
+					if ( ' ' === $character || "\n" === $character || "\r" === $character || "\t" === $character ) {
+						continue;
+					}
+					if ( '[' !== $character ) {
+						$valid = false;
+						return;
+					}
+
+					$started = true;
+					continue;
+				}
+
+				if ( 0 === $depth ) {
+					if ( ' ' === $character || "\n" === $character || "\r" === $character || "\t" === $character || ',' === $character ) {
+						continue;
+					}
+					if ( ']' === $character ) {
+						$complete = true;
+						return;
+					}
+					if ( '{' !== $character ) {
+						$valid = false;
+						return;
+					}
+
+					$depth         = 1;
+					$element       = '{';
+					$element_bytes = 1;
+					$in_string     = false;
+					$escaped       = false;
+					$discarding    = false;
+					continue;
+				}
+
+				++$element_bytes;
+				if ( ! $discarding ) {
+					if ( $element_bytes > self::STREAMED_MESSAGE_MAX_BYTES ) {
+						$discarding = true;
+						$element    = '';
+					} else {
+						$element .= $character;
+					}
+				}
+
+				if ( $in_string ) {
+					if ( $escaped ) {
+						$escaped = false;
+						continue;
+					}
+					if ( '\\' === $character ) {
+						$escaped = true;
+						continue;
+					}
+					if ( '"' === $character ) {
+						$in_string = false;
+					}
+					continue;
+				}
+
+				if ( '"' === $character ) {
+					$in_string = true;
+					continue;
+				}
+				if ( '{' === $character || '[' === $character ) {
+					++$depth;
+					continue;
+				}
+				if ( '}' !== $character && ']' !== $character ) {
+					continue;
+				}
+
+				--$depth;
+				if ( $depth < 0 ) {
+					$valid = false;
+					return;
+				}
+				if ( 0 !== $depth ) {
+					continue;
+				}
+
+				if ( $discarding ) {
+					yield self::oversized_streamed_message_placeholder( $element_bytes );
+				} else {
+					$decoded = json_decode( $element, true );
+					if ( ! is_array( $decoded ) ) {
+						$valid = false;
+					} else {
+						yield $decoded;
+					}
+				}
+
+				$element       = '';
+				$element_bytes = 0;
+				$in_string     = false;
+				$escaped       = false;
+				$discarding    = false;
+			}
+		}
+
+		$valid = false;
+	}
+
+	/**
+	 * Build a bounded marker for one pathological serialized message.
+	 *
+	 * @param int $bytes Source message size.
+	 * @return array<string,mixed>
+	 */
+	private static function oversized_streamed_message_placeholder( int $bytes ): array {
+		return array(
+			'role'  => 'user',
+			'parts' => array(
+				array(
+					'text' => sprintf( '[A persisted message of %d bytes was omitted during maintenance compaction.]', $bytes ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Check whether a serialized message contains a function call.
+	 *
+	 * @param array<string,mixed> $message Serialized message.
+	 */
+	private static function serialized_message_has_function_call( array $message ): bool {
+		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
+		foreach ( $parts as $part ) {
+			if ( is_array( $part ) && ( isset( $part['functionCall'] ) || isset( $part['function_call'] ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether a serialized message contains a function response.
+	 *
+	 * @param array<string,mixed> $message Serialized message.
+	 */
+	private static function serialized_message_has_function_response( array $message ): bool {
+		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
+		foreach ( $parts as $part ) {
+			if ( is_array( $part ) && ( isset( $part['functionResponse'] ) || isset( $part['function_response'] ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retain a complete compact group only while it fits the bounded seed budget.
+	 *
+	 * @param list<list<string>> $groups      Retained chronological compact groups.
+	 * @param list<string>       $lines       One logical group of excerpts.
+	 * @param int                $source_count Original source message count.
+	 * @param int                $max_bytes    Maximum serialized seed-message bytes.
+	 * @param int                $max_tokens   Maximum estimated seed-message tokens.
+	 */
+	private static function retain_compact_group( array &$groups, array $lines, int $source_count, int $max_bytes, int $max_tokens ): void {
+		$group = array();
+		foreach ( $lines as $line ) {
+			if ( is_string( $line ) && '' !== $line ) {
+				$group[] = $line;
+			}
+		}
+		if ( ! empty( $group ) ) {
+			$groups[] = $group;
+		}
+
+		self::trim_compact_groups( $groups, $source_count, $max_bytes, $max_tokens );
+	}
+
+	/**
+	 * Drop oldest whole groups until the candidate seed fits the current budget.
+	 *
+	 * @param list<list<string>> $groups       Retained chronological compact groups.
+	 * @param int                $source_count Original source message count.
+	 * @param int                $max_bytes    Maximum serialized seed-message bytes.
+	 * @param int                $max_tokens   Maximum estimated seed-message tokens.
+	 */
+	private static function trim_compact_groups( array &$groups, int $source_count, int $max_bytes, int $max_tokens ): void {
+		while ( ! empty( $groups ) && ! self::compact_lines_fit_budget( self::flatten_compact_groups( $groups ), $source_count, $max_bytes, $max_tokens ) ) {
+			array_shift( $groups );
+		}
+	}
+
+	/**
+	 * Flatten chronological compact groups without splitting their ordering.
+	 *
+	 * @param list<list<string>> $groups Retained compact groups.
+	 * @return list<string>
+	 */
+	private static function flatten_compact_groups( array $groups ): array {
+		$lines = array();
+		foreach ( $groups as $group ) {
+			foreach ( $group as $line ) {
+				$lines[] = $line;
+			}
+		}
+
+		return $lines;
 	}
 
 	/**

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -332,12 +332,17 @@ class ConversationTrimmer {
 	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
 	 */
 	private static function compact_serialized_history_iterable( iterable $messages, int $max_bytes, int $max_tokens ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic iterable value type is valid PHPStan syntax but not a native PHP type.
-		$max_bytes               = max( 1024, $max_bytes );
-		$max_tokens              = max( 256, $max_tokens );
-		$per_message_chars       = max( 160, min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) ) );
-		$source_count            = 0;
-		$retained_groups         = array();
-		$pending_tool_call_lines = null;
+		$max_bytes                    = max( 1024, $max_bytes );
+		$max_tokens                   = max( 256, $max_tokens );
+		$per_message_chars            = max( 160, min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) ) );
+		$source_count                 = 0;
+		$retained_groups              = array();
+		$pending_tool_lines           = array();
+		$pending_tool_call_ids        = array();
+		$pending_tool_response_ids    = array();
+		$pending_tool_cycle           = false;
+		$pending_tool_responses       = false;
+		$pending_tool_cycle_discarded = false;
 
 		foreach ( $messages as $message ) {
 			if ( ! is_array( $message ) ) {
@@ -346,45 +351,90 @@ class ConversationTrimmer {
 
 			$expanded      = self::serialized_message_to_compact_excerpts( $message, $per_message_chars );
 			$source_count += $expanded['source_count'];
-			$has_call      = self::serialized_message_has_function_call( $message );
-			$has_response  = self::serialized_message_has_function_response( $message );
+			$call_ids      = self::serialized_message_function_ids( $message, 'functionCall', 'function_call' );
+			$response_ids  = self::serialized_message_function_ids( $message, 'functionResponse', 'function_response' );
 
-			if ( null !== $pending_tool_call_lines ) {
-				if ( $has_response ) {
-					self::retain_compact_group(
+			if ( ! empty( $call_ids ) ) {
+				if ( $pending_tool_cycle && $pending_tool_responses ) {
+					self::flush_serialized_tool_cycle(
 						$retained_groups,
-						array_merge( $pending_tool_call_lines, $expanded['lines'] ),
+						$pending_tool_lines,
+						$pending_tool_call_ids,
+						$pending_tool_response_ids,
+						$pending_tool_cycle,
+						$pending_tool_responses,
+						$pending_tool_cycle_discarded,
 						$source_count,
 						$max_bytes,
 						$max_tokens
 					);
-					$pending_tool_call_lines = null;
+				}
+
+				$pending_tool_cycle     = true;
+				$pending_tool_responses = ! empty( $response_ids );
+				if ( $pending_tool_cycle_discarded ) {
 					continue;
 				}
 
-				// Do not retain a lone call when its result is absent from the stream.
-				$pending_tool_call_lines = null;
-				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
-			}
-
-			if ( $has_call ) {
-				$pending_tool_call_lines = $expanded['lines'];
-				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+				$pending_tool_call_ids     = array_merge( $pending_tool_call_ids, $call_ids );
+				$pending_tool_response_ids = array_merge( $pending_tool_response_ids, $response_ids );
+				$pending_tool_lines        = array_merge( $pending_tool_lines, $expanded['lines'] );
+				if ( ! self::compact_lines_fit_budget( $pending_tool_lines, $source_count, $max_bytes, $max_tokens ) ) {
+					$pending_tool_lines           = array();
+					$pending_tool_call_ids        = array();
+					$pending_tool_response_ids    = array();
+					$pending_tool_cycle_discarded = true;
+				}
 				continue;
 			}
 
-			if ( $has_response ) {
-				// A result without a preceding call cannot form a complete tool cycle.
-				self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
+			if ( ! empty( $response_ids ) ) {
+				if ( ! $pending_tool_cycle ) {
+					continue;
+				}
+
+				$pending_tool_responses = true;
+				if ( ! $pending_tool_cycle_discarded ) {
+					$pending_tool_response_ids = array_merge( $pending_tool_response_ids, $response_ids );
+					$pending_tool_lines        = array_merge( $pending_tool_lines, $expanded['lines'] );
+					if ( ! self::compact_lines_fit_budget( $pending_tool_lines, $source_count, $max_bytes, $max_tokens ) ) {
+						$pending_tool_lines           = array();
+						$pending_tool_call_ids        = array();
+						$pending_tool_response_ids    = array();
+						$pending_tool_cycle_discarded = true;
+					}
+				}
 				continue;
 			}
+
+			self::flush_serialized_tool_cycle(
+				$retained_groups,
+				$pending_tool_lines,
+				$pending_tool_call_ids,
+				$pending_tool_response_ids,
+				$pending_tool_cycle,
+				$pending_tool_responses,
+				$pending_tool_cycle_discarded,
+				$source_count,
+				$max_bytes,
+				$max_tokens
+			);
 
 			self::retain_compact_group( $retained_groups, $expanded['lines'], $source_count, $max_bytes, $max_tokens );
 		}
 
-		if ( null !== $pending_tool_call_lines ) {
-			self::trim_compact_groups( $retained_groups, $source_count, $max_bytes, $max_tokens );
-		}
+		self::flush_serialized_tool_cycle(
+			$retained_groups,
+			$pending_tool_lines,
+			$pending_tool_call_ids,
+			$pending_tool_response_ids,
+			$pending_tool_cycle,
+			$pending_tool_responses,
+			$pending_tool_cycle_discarded,
+			$source_count,
+			$max_bytes,
+			$max_tokens
+		);
 
 		$lines          = self::flatten_compact_groups( $retained_groups );
 		$retained_count = count( $lines );
@@ -440,15 +490,18 @@ class ConversationTrimmer {
 	 * @return \Generator<int, array<string,mixed>>
 	 */
 	private static function decode_serialized_history_chunks( iterable $chunks, bool &$complete, bool &$valid ): \Generator { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic iterable value type is valid PHPStan syntax but not a native PHP type.
-		$complete      = false;
-		$valid         = true;
-		$started       = false;
-		$depth         = 0;
-		$element       = '';
-		$element_bytes = 0;
-		$in_string     = false;
-		$escaped       = false;
-		$discarding    = false;
+		$complete       = false;
+		$valid          = true;
+		$started        = false;
+		$depth          = 0;
+		$element        = '';
+		$element_bytes  = 0;
+		$in_string      = false;
+		$escaped        = false;
+		$discarding     = false;
+		$containers     = '';
+		$expect_element = true;
+		$element_count  = 0;
 
 		foreach ( $chunks as $chunk ) {
 			if ( ! is_string( $chunk ) ) {
@@ -472,25 +525,43 @@ class ConversationTrimmer {
 					continue;
 				}
 
-				if ( 0 === $depth ) {
-					if ( ' ' === $character || "\n" === $character || "\r" === $character || "\t" === $character || ',' === $character ) {
-						continue;
-					}
-					if ( ']' === $character ) {
-						$complete = true;
+				if ( $complete ) {
+					if ( ' ' !== $character && "\n" !== $character && "\r" !== $character && "\t" !== $character ) {
+						$valid = false;
 						return;
 					}
-					if ( '{' !== $character ) {
+					continue;
+				}
+
+				if ( 0 === $depth ) {
+					if ( ' ' === $character || "\n" === $character || "\r" === $character || "\t" === $character ) {
+						continue;
+					}
+					if ( $expect_element && ']' === $character && 0 === $element_count ) {
+						$complete = true;
+						continue;
+					}
+					if ( ! $expect_element && ',' === $character ) {
+						$expect_element = true;
+						continue;
+					}
+					if ( ! $expect_element && ']' === $character ) {
+						$complete = true;
+						continue;
+					}
+					if ( ! $expect_element || '{' !== $character ) {
 						$valid = false;
 						return;
 					}
 
-					$depth         = 1;
-					$element       = '{';
-					$element_bytes = 1;
-					$in_string     = false;
-					$escaped       = false;
-					$discarding    = false;
+					$depth          = 1;
+					$element        = '{';
+					$element_bytes  = 1;
+					$in_string      = false;
+					$escaped        = false;
+					$discarding     = false;
+					$containers     = '{';
+					$expect_element = false;
 					continue;
 				}
 
@@ -524,6 +595,11 @@ class ConversationTrimmer {
 					continue;
 				}
 				if ( '{' === $character || '[' === $character ) {
+					if ( strlen( $containers ) >= 512 ) {
+						$valid = false;
+						return;
+					}
+					$containers .= $character;
 					++$depth;
 					continue;
 				}
@@ -531,6 +607,12 @@ class ConversationTrimmer {
 					continue;
 				}
 
+				$expected_open = '}' === $character ? '{' : '[';
+				if ( '' === $containers || $expected_open !== substr( $containers, -1 ) ) {
+					$valid = false;
+					return;
+				}
+				$containers = substr( $containers, 0, -1 );
 				--$depth;
 				if ( 0 !== $depth ) {
 					continue;
@@ -552,10 +634,13 @@ class ConversationTrimmer {
 				$in_string     = false;
 				$escaped       = false;
 				$discarding    = false;
+				++$element_count;
 			}
 		}
 
-		$valid = false;
+		if ( ! $complete ) {
+			$valid = false;
+		}
 	}
 
 	/**
@@ -599,35 +684,66 @@ class ConversationTrimmer {
 	}
 
 	/**
-	 * Check whether a serialized message contains a function call.
+	 * Extract compatibility IDs from serialized function-call or response parts.
 	 *
-	 * @param array<string,mixed> $message Serialized message.
+	 * ID-less provider parts use an empty-string compatibility ID. Distinct counts
+	 * are retained so parallel ID-less calls still require the same number of
+	 * responses before their compact excerpts can be kept.
+	 *
+	 * @param array<string,mixed> $message   Serialized message.
+	 * @param string              $camel_key Camel-case part key.
+	 * @param string              $snake_key Snake-case part key.
+	 * @return list<string>
 	 */
-	private static function serialized_message_has_function_call( array $message ): bool {
+	private static function serialized_message_function_ids( array $message, string $camel_key, string $snake_key ): array {
+		$ids   = array();
 		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
 		foreach ( $parts as $part ) {
-			if ( is_array( $part ) && ( isset( $part['functionCall'] ) || isset( $part['function_call'] ) ) ) {
-				return true;
+			if ( ! is_array( $part ) ) {
+				continue;
 			}
+			$function = $part[ $camel_key ] ?? $part[ $snake_key ] ?? null;
+			if ( ! is_array( $function ) ) {
+				continue;
+			}
+
+			$id    = $function['id'] ?? '';
+			$ids[] = is_scalar( $id ) ? (string) $id : '';
 		}
 
-		return false;
+		return $ids;
 	}
 
 	/**
-	 * Check whether a serialized message contains a function response.
+	 * Retain one complete serialized tool cycle, or omit the whole cluster.
 	 *
-	 * @param array<string,mixed> $message Serialized message.
+	 * @param list<list<string>> $groups        Retained compact groups.
+	 * @param list<string>       $lines         Pending call and response excerpts.
+	 * @param list<string>       $call_ids      Pending call IDs.
+	 * @param list<string>       $response_ids  Pending response IDs.
+	 * @param bool               $cycle         Whether a call cluster is pending.
+	 * @param bool               $responses     Whether its response cluster started.
+	 * @param bool               $discarded     Whether the cluster exceeded the budget.
+	 * @param int                $source_count  Original source message count.
+	 * @param int                $max_bytes     Maximum serialized seed-message bytes.
+	 * @param int                $max_tokens    Maximum estimated seed-message tokens.
 	 */
-	private static function serialized_message_has_function_response( array $message ): bool {
-		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
-		foreach ( $parts as $part ) {
-			if ( is_array( $part ) && ( isset( $part['functionResponse'] ) || isset( $part['function_response'] ) ) ) {
-				return true;
-			}
+	private static function flush_serialized_tool_cycle( array &$groups, array &$lines, array &$call_ids, array &$response_ids, bool &$cycle, bool &$responses, bool &$discarded, int $source_count, int $max_bytes, int $max_tokens ): void { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic list value types are valid PHPStan syntax but not native PHP types.
+		if (
+			$cycle
+			&& ! $discarded
+			&& count( $call_ids ) === count( $response_ids )
+			&& self::has_matching_tool_responses( $call_ids, $response_ids )
+		) {
+			self::retain_compact_group( $groups, $lines, $source_count, $max_bytes, $max_tokens );
 		}
 
-		return false;
+		$lines        = array();
+		$call_ids     = array();
+		$response_ids = array();
+		$cycle        = false;
+		$responses    = false;
+		$discarded    = false;
 	}
 
 	/**

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -392,6 +392,25 @@ class ConversationTrimmer {
 				if ( ! $pending_tool_cycle ) {
 					continue;
 				}
+				if (
+					! $pending_tool_cycle_discarded
+					&& count( $pending_tool_call_ids ) === count( $pending_tool_response_ids )
+					&& self::has_matching_tool_responses( $pending_tool_call_ids, $pending_tool_response_ids )
+				) {
+					self::flush_serialized_tool_cycle(
+						$retained_groups,
+						$pending_tool_lines,
+						$pending_tool_call_ids,
+						$pending_tool_response_ids,
+						$pending_tool_cycle,
+						$pending_tool_responses,
+						$pending_tool_cycle_discarded,
+						$source_count,
+						$max_bytes,
+						$max_tokens
+					);
+					continue;
+				}
 
 				$pending_tool_responses = true;
 				if ( ! $pending_tool_cycle_discarded ) {

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -308,7 +308,7 @@ class ConversationTrimmer {
 	 * @param int                   $max_tokens Maximum estimated seed-message tokens.
 	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
 	 */
-	public static function compact_serialized_history_chunks( iterable $chunks, int $max_bytes = self::COMPACT_MAX_BYTES, int $max_tokens = self::COMPACT_MAX_TOKENS ): array {
+	public static function compact_serialized_history_chunks( iterable $chunks, int $max_bytes = self::COMPACT_MAX_BYTES, int $max_tokens = self::COMPACT_MAX_TOKENS ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic iterable value type is valid PHPStan syntax but not a native PHP type.
 		$stream_complete = false;
 		$stream_valid    = true;
 		$result          = self::compact_serialized_history_iterable(
@@ -331,12 +331,12 @@ class ConversationTrimmer {
 	 * @param int                                $max_tokens Maximum estimated seed-message tokens.
 	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
 	 */
-	private static function compact_serialized_history_iterable( iterable $messages, int $max_bytes, int $max_tokens ): array {
-		$max_bytes             = max( 1024, $max_bytes );
-		$max_tokens            = max( 256, $max_tokens );
-		$per_message_chars     = max( 160, min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) ) );
-		$source_count          = 0;
-		$retained_groups       = array();
+	private static function compact_serialized_history_iterable( iterable $messages, int $max_bytes, int $max_tokens ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic iterable value type is valid PHPStan syntax but not a native PHP type.
+		$max_bytes               = max( 1024, $max_bytes );
+		$max_tokens              = max( 256, $max_tokens );
+		$per_message_chars       = max( 160, min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) ) );
+		$source_count            = 0;
+		$retained_groups         = array();
 		$pending_tool_call_lines = null;
 
 		foreach ( $messages as $message ) {
@@ -344,10 +344,10 @@ class ConversationTrimmer {
 				continue;
 			}
 
-			$expanded     = self::serialized_message_to_compact_excerpts( $message, $per_message_chars );
+			$expanded      = self::serialized_message_to_compact_excerpts( $message, $per_message_chars );
 			$source_count += $expanded['source_count'];
-			$has_call     = self::serialized_message_has_function_call( $message );
-			$has_response = self::serialized_message_has_function_response( $message );
+			$has_call      = self::serialized_message_has_function_call( $message );
+			$has_response  = self::serialized_message_has_function_response( $message );
 
 			if ( null !== $pending_tool_call_lines ) {
 				if ( $has_response ) {
@@ -439,7 +439,7 @@ class ConversationTrimmer {
 	 * @param bool                  $valid    Receives whether every decoded element was valid.
 	 * @return \Generator<int, array<string,mixed>>
 	 */
-	private static function decode_serialized_history_chunks( iterable $chunks, bool &$complete, bool &$valid ): \Generator {
+	private static function decode_serialized_history_chunks( iterable $chunks, bool &$complete, bool &$valid ): \Generator { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic iterable value type is valid PHPStan syntax but not a native PHP type.
 		$complete      = false;
 		$valid         = true;
 		$started       = false;
@@ -532,10 +532,6 @@ class ConversationTrimmer {
 				}
 
 				--$depth;
-				if ( $depth < 0 ) {
-					$valid = false;
-					return;
-				}
 				if ( 0 !== $depth ) {
 					continue;
 				}
@@ -543,8 +539,8 @@ class ConversationTrimmer {
 				if ( $discarding ) {
 					yield self::oversized_streamed_message_placeholder( $element_bytes );
 				} else {
-					$decoded = json_decode( $element, true );
-					if ( ! is_array( $decoded ) ) {
+					$decoded = self::decode_streamed_message( $element );
+					if ( null === $decoded ) {
 						$valid = false;
 					} else {
 						yield $decoded;
@@ -560,6 +556,29 @@ class ConversationTrimmer {
 		}
 
 		$valid = false;
+	}
+
+	/**
+	 * Decode one JSON object while preserving a string-keyed message shape.
+	 *
+	 * @param string $element Serialized message object.
+	 * @return array<string,mixed>|null
+	 */
+	private static function decode_streamed_message( string $element ): ?array {
+		$decoded = json_decode( $element, true );
+		if ( ! is_array( $decoded ) || array_is_list( $decoded ) ) {
+			return null;
+		}
+
+		$message = array();
+		foreach ( $decoded as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				return null;
+			}
+			$message[ $key ] = $value;
+		}
+
+		return $message;
 	}
 
 	/**
@@ -620,7 +639,7 @@ class ConversationTrimmer {
 	 * @param int                $max_bytes    Maximum serialized seed-message bytes.
 	 * @param int                $max_tokens   Maximum estimated seed-message tokens.
 	 */
-	private static function retain_compact_group( array &$groups, array $lines, int $source_count, int $max_bytes, int $max_tokens ): void {
+	private static function retain_compact_group( array &$groups, array $lines, int $source_count, int $max_bytes, int $max_tokens ): void { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic list value types are valid PHPStan syntax but not native PHP types.
 		$group = array();
 		foreach ( $lines as $line ) {
 			if ( is_string( $line ) && '' !== $line ) {
@@ -642,7 +661,7 @@ class ConversationTrimmer {
 	 * @param int                $max_bytes    Maximum serialized seed-message bytes.
 	 * @param int                $max_tokens   Maximum estimated seed-message tokens.
 	 */
-	private static function trim_compact_groups( array &$groups, int $source_count, int $max_bytes, int $max_tokens ): void {
+	private static function trim_compact_groups( array &$groups, int $source_count, int $max_bytes, int $max_tokens ): void { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic list value types are valid PHPStan syntax but not native PHP types.
 		while ( ! empty( $groups ) && ! self::compact_lines_fit_budget( self::flatten_compact_groups( $groups ), $source_count, $max_bytes, $max_tokens ) ) {
 			array_shift( $groups );
 		}
@@ -654,7 +673,7 @@ class ConversationTrimmer {
 	 * @param list<list<string>> $groups Retained compact groups.
 	 * @return list<string>
 	 */
-	private static function flatten_compact_groups( array $groups ): array {
+	private static function flatten_compact_groups( array $groups ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Generic list value types are valid PHPStan syntax but not native PHP types.
 		$lines = array();
 		foreach ( $groups as $group ) {
 			foreach ( $group as $line ) {

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -1545,6 +1545,48 @@ class Database {
 	}
 
 	/**
+	 * Return the soft thresholds used to identify session storage maintenance.
+	 *
+	 * @return array{bytes:int,messages:int}
+	 */
+	public static function get_session_storage_maintenance_limits(): array {
+		return SessionRepository::get_storage_maintenance_limits();
+	}
+
+	/**
+	 * List oversized session metadata without selecting conversation contents.
+	 *
+	 * @param int $min_bytes    Minimum combined persisted bytes. 0 uses the configured threshold.
+	 * @param int $min_messages Minimum message count. 0 uses the configured threshold.
+	 * @param int $limit        Maximum rows to return.
+	 * @return list<object>
+	 */
+	public static function list_oversized_sessions( int $min_bytes = 0, int $min_messages = 0, int $limit = 100 ): array {
+		return SessionRepository::list_oversized( $min_bytes, $min_messages, $limit );
+	}
+
+	/**
+	 * Return maintenance metadata without loading persisted conversation JSON.
+	 *
+	 * @param int $session_id Session ID.
+	 * @return object|null Metadata row, or null when not found.
+	 */
+	public static function get_session_maintenance_metadata( int $session_id ): ?object {
+		return SessionRepository::get_maintenance_metadata( $session_id );
+	}
+
+	/**
+	 * Yield a persisted message payload in bounded slices for maintenance compaction.
+	 *
+	 * @param int $session_id Session ID.
+	 * @param int $chunk_bytes Maximum bytes per slice.
+	 * @return \Generator<int, string>
+	 */
+	public static function stream_session_messages( int $session_id, int $chunk_bytes = SessionRepository::STREAM_CHUNK_BYTES ): \Generator {
+		return SessionRepository::stream_messages( $session_id, $chunk_bytes );
+	}
+
+	/**
 	 * List sessions for a user (lightweight — no messages/tool_calls).
 	 *
 	 * @param int                  $user_id WordPress user ID.

--- a/includes/REST/PermissionTrait.php
+++ b/includes/REST/PermissionTrait.php
@@ -154,6 +154,33 @@ trait PermissionTrait {
 	}
 
 	/**
+	 * Permission check for streamed maintenance compaction.
+	 *
+	 * This mirrors the ownership and shared-administrator rules for the standard
+	 * session route without selecting the potentially oversized conversation JSON
+	 * before the compaction handler can consume it in bounded slices.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 */
+	public function check_session_compaction_permission( WP_REST_Request $request ): bool {
+		if ( ! RolePermissions::current_user_has_chat_access() ) {
+			return false;
+		}
+
+		$session_id = self::get_int_param( $request, 'id' );
+		$session    = Database::get_session_maintenance_metadata( $session_id );
+		if ( ! $session ) {
+			return false;
+		}
+
+		if ( (int) $session->user_id === get_current_user_id() ) {
+			return true;
+		}
+
+		return current_user_can( 'manage_options' ) && null !== Database::get_shared_session( $session_id );
+	}
+
+	/**
 	 * Permission check for share/unshare endpoints — owner only.
 	 */
 	public function check_session_owner_permission( WP_REST_Request $request ): bool {

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1208,6 +1208,14 @@ final class SessionController {
 			);
 		}
 
+		if ( empty( $source_session->messages_valid ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_invalid_history',
+				__( 'The saved conversation could not be read safely for compaction.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
+
 		if ( (int) $source_session->message_count <= 0 ) {
 			return new WP_Error(
 				'sd_ai_agent_compact_empty_session',

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -171,6 +171,33 @@ final class SessionController {
 
 		register_rest_route(
 			RestController::NAMESPACE,
+			'/sessions/oversized',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_list_oversized_sessions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'min_bytes'    => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'min_messages' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'limit'        => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
 			'/sessions/folders',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
@@ -283,7 +310,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_compact_session' ),
-				'permission_callback' => array( $this, 'check_session_permission' ),
+				'permission_callback' => array( $this, 'check_session_compaction_permission' ),
 				'args'                => array(
 					'id'          => array(
 						'required'          => true,
@@ -903,6 +930,54 @@ final class SessionController {
 	}
 
 	/**
+	 * Handle GET /sessions/oversized — list size metadata for administrative maintenance.
+	 *
+	 * This deliberately returns no session title, owner, messages, tool calls, or
+	 * paused state. Administrators receive only IDs, counts, and byte totals needed
+	 * to select an explicit export, compaction, archive, or removal operation.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	public function handle_list_oversized_sessions( WP_REST_Request $request ): WP_REST_Response {
+		$thresholds   = $this->database->get_session_storage_maintenance_limits();
+		$min_bytes    = self::get_int_param( $request, 'min_bytes' );
+		$min_messages = self::get_int_param( $request, 'min_messages' );
+		$limit        = self::get_int_param( $request, 'limit' );
+
+		$min_bytes    = $min_bytes > 0 ? max( 1024, $min_bytes ) : $thresholds['bytes'];
+		$min_messages = $min_messages > 0 ? max( 1, $min_messages ) : $thresholds['messages'];
+		$limit        = min( 500, max( 1, $limit > 0 ? $limit : 100 ) );
+		$sessions     = $this->database->list_oversized_sessions( $min_bytes, $min_messages, $limit );
+
+		$data = array_map(
+			static function ( object $session ): array {
+				return array(
+					'id'                 => (int) $session->id,
+					'status'             => (string) $session->status,
+					'message_count'      => (int) $session->message_count,
+					'messages_bytes'     => (int) $session->messages_bytes,
+					'tool_calls_bytes'   => (int) $session->tool_calls_bytes,
+					'paused_state_bytes' => (int) $session->paused_state_bytes,
+					'total_bytes'        => (int) $session->total_bytes,
+				);
+			},
+			$sessions
+		);
+
+		return new WP_REST_Response(
+			array(
+				'thresholds' => array(
+					'bytes'    => $min_bytes,
+					'messages' => $min_messages,
+				),
+				'sessions'   => $data,
+			),
+			200
+		);
+	}
+
+	/**
 	 * Handle GET /sessions/folders — list folders for current user.
 	 *
 	 * @return WP_REST_Response
@@ -1107,7 +1182,7 @@ final class SessionController {
 	 */
 	public function handle_compact_session( WP_REST_Request $request ) {
 		$source_session_id = self::get_int_param( $request, 'id' );
-		$source_session    = $this->database->get_session( $source_session_id );
+		$source_session    = $this->database->get_session_maintenance_metadata( $source_session_id );
 
 		if ( ! $source_session ) {
 			return new WP_Error(
@@ -1117,10 +1192,23 @@ final class SessionController {
 			);
 		}
 
-		$decoded_messages = json_decode( (string) $source_session->messages, true );
-		$source_messages  = is_array( $decoded_messages ) ? array_values( array_filter( $decoded_messages, 'is_array' ) ) : array();
+		if ( null !== ActiveJobRepository::get_by_session_id( $source_session_id ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_active_job',
+				__( 'This conversation has an active job and cannot be compacted yet.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
 
-		if ( empty( $source_messages ) ) {
+		if ( ! empty( $source_session->has_paused_state ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_paused_session',
+				__( 'This conversation has a paused continuation and cannot be compacted yet.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( (int) $source_session->message_count <= 0 ) {
 			return new WP_Error(
 				'sd_ai_agent_compact_empty_session',
 				__( 'This conversation has no saved messages to compact.', 'superdav-ai-agent' ),
@@ -1144,12 +1232,19 @@ final class SessionController {
 			ConversationTrimmer::COMPACT_MAX_TOKENS,
 			max( 256, (int) floor( $request_token_budget / 2 ) )
 		);
-		$compacted            = ConversationTrimmer::compact_serialized_history(
-			$source_messages,
+		$compacted            = ConversationTrimmer::compact_serialized_history_chunks(
+			$this->database->stream_session_messages( $source_session_id ),
 			$compact_byte_budget,
 			$compact_token_budget
 		);
-		$seed_messages        = $compacted['messages'];
+		if ( empty( $compacted['meta']['stream_complete'] ) || empty( $compacted['meta']['stream_valid'] ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_invalid_history',
+				__( 'The saved conversation could not be read safely for compaction.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
+		$seed_messages = $compacted['messages'];
 		if ( empty( $seed_messages ) ) {
 			return new WP_Error(
 				'sd_ai_agent_compact_failed',

--- a/includes/Repositories/SessionRepository.php
+++ b/includes/Repositories/SessionRepository.php
@@ -24,6 +24,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class SessionRepository {
 
+	/** Soft maintenance threshold for the total persisted session payload (8 MiB). */
+	public const STORAGE_MAINTENANCE_BYTES = 8388608;
+
+	/** Soft maintenance threshold for persisted conversation messages. */
+	public const STORAGE_MAINTENANCE_MESSAGES = 10000;
+
+	/** Maximum database slice read while compacting a historical session. */
+	public const STREAM_CHUNK_BYTES = 65536;
+
 	/**
 	 * Create a new session.
 	 *
@@ -72,6 +81,150 @@ class SessionRepository {
 				$session_id
 			)
 		);
+	}
+
+	/**
+	 * Return the configurable thresholds that trigger a storage-maintenance notice.
+	 *
+	 * These are deliberately soft limits: normal persistence remains non-destructive
+	 * while an administrator chooses whether to export, compact, archive, or remove
+	 * a session that crosses the threshold.
+	 *
+	 * @return array{bytes:int,messages:int}
+	 */
+	public static function get_storage_maintenance_limits(): array {
+		$bytes = (int) apply_filters( 'sd_ai_agent_session_storage_maintenance_bytes', self::STORAGE_MAINTENANCE_BYTES );
+		$messages = (int) apply_filters( 'sd_ai_agent_session_storage_maintenance_messages', self::STORAGE_MAINTENANCE_MESSAGES );
+
+		return array(
+			'bytes'    => max( 1024, $bytes ),
+			'messages' => max( 1, $messages ),
+		);
+	}
+
+	/**
+	 * List session-storage candidates without reading their conversation payloads.
+	 *
+	 * @param int $min_bytes    Minimum combined messages, tool calls, and pause-state bytes. 0 uses the maintenance threshold.
+	 * @param int $min_messages Minimum message count. 0 uses the maintenance threshold.
+	 * @param int $limit        Maximum candidates to return.
+	 * @return list<object>
+	 */
+	public static function list_oversized( int $min_bytes = 0, int $min_messages = 0, int $limit = 100 ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$limits       = self::get_storage_maintenance_limits();
+		$min_bytes    = max( 1024, $min_bytes > 0 ? $min_bytes : $limits['bytes'] );
+		$min_messages = max( 1, $min_messages > 0 ? $min_messages : $limits['messages'] );
+		$limit        = min( 500, max( 1, $limit ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table inspection returns metadata only; caching cannot safely represent live maintenance candidates.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, status, message_count, messages_bytes, tool_calls_bytes, paused_state_bytes, total_bytes
+				FROM (
+					SELECT id, status,
+						COALESCE(JSON_LENGTH(messages), 0) AS message_count,
+						COALESCE(OCTET_LENGTH(messages), 0) AS messages_bytes,
+						COALESCE(OCTET_LENGTH(tool_calls), 0) AS tool_calls_bytes,
+						COALESCE(OCTET_LENGTH(paused_state), 0) AS paused_state_bytes,
+						COALESCE(OCTET_LENGTH(messages), 0) + COALESCE(OCTET_LENGTH(tool_calls), 0) + COALESCE(OCTET_LENGTH(paused_state), 0) AS total_bytes
+					FROM %i
+				) AS sd_ai_agent_session_sizes
+				WHERE total_bytes >= %d OR message_count >= %d
+				ORDER BY total_bytes DESC, id ASC
+				LIMIT %d",
+				Database::table_name(),
+				$min_bytes,
+				$min_messages,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Return only fields needed to safely maintain a historical session.
+	 *
+	 * Deliberately omits messages, tool_calls, and paused_state so a maintenance
+	 * request does not create a full in-memory copy before chunked compaction.
+	 *
+	 * @param int $session_id Session ID.
+	 * @return object|null Metadata row, or null when not found.
+	 */
+	public static function get_maintenance_metadata( int $session_id ): ?object {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table metadata query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT id, user_id, title, provider_id, model_id, status,
+					COALESCE(JSON_LENGTH(messages), 0) AS message_count,
+					COALESCE(OCTET_LENGTH(messages), 0) AS messages_bytes,
+					COALESCE(OCTET_LENGTH(tool_calls), 0) AS tool_calls_bytes,
+					COALESCE(OCTET_LENGTH(paused_state), 0) AS paused_state_bytes,
+					CASE WHEN paused_state IS NULL OR paused_state = '' THEN 0 ELSE 1 END AS has_paused_state
+				FROM %i WHERE id = %d",
+				Database::table_name(),
+				$session_id
+			)
+		);
+
+		return is_object( $row ) ? $row : null;
+	}
+
+	/**
+	 * Yield a session's serialized message JSON in bounded database slices.
+	 *
+	 * @param int $session_id Session ID.
+	 * @param int $chunk_bytes Maximum bytes per yielded slice.
+	 * @return \Generator<int, string>
+	 */
+	public static function stream_messages( int $session_id, int $chunk_bytes = self::STREAM_CHUNK_BYTES ): \Generator {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$session_id = absint( $session_id );
+		if ( $session_id <= 0 ) {
+			return;
+		}
+
+		$chunk_bytes = min( self::STREAM_CHUNK_BYTES, max( 1024, $chunk_bytes ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads only a scalar length before bounded custom-table slices.
+		$total_bytes = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT OCTET_LENGTH(messages) FROM %i WHERE id = %d',
+				Database::table_name(),
+				$session_id
+			)
+		);
+
+		if ( ! is_numeric( $total_bytes ) || (int) $total_bytes <= 0 ) {
+			return;
+		}
+
+		for ( $offset = 1; $offset <= (int) $total_bytes; $offset += $chunk_bytes ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded custom-table slice for maintenance compaction.
+			$chunk = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT SUBSTRING(messages, %d, %d) FROM %i WHERE id = %d',
+					$offset,
+					$chunk_bytes,
+					Database::table_name(),
+					$session_id
+				)
+			);
+
+			if ( ! is_string( $chunk ) || '' === $chunk ) {
+				return;
+			}
+
+			yield $chunk;
+		}
 	}
 
 	/**
@@ -515,13 +668,46 @@ class SessionRepository {
 		$merged_messages   = array_merge( $existing_messages, $messages );
 		$merged_tool_calls = self::append_unique_tool_call_events( $existing_tool_calls, $tool_calls );
 
-		return self::update(
+		$encoded_messages   = wp_json_encode( $merged_messages );
+		$encoded_tool_calls = wp_json_encode( $merged_tool_calls );
+		if ( ! is_string( $encoded_messages ) || ! is_string( $encoded_tool_calls ) ) {
+			return false;
+		}
+
+		$updated = self::update(
 			$session_id,
 			[
-				'messages'   => wp_json_encode( $merged_messages ),
-				'tool_calls' => wp_json_encode( $merged_tool_calls ),
+				'messages'   => $encoded_messages,
+				'tool_calls' => $encoded_tool_calls,
 			]
 		);
+
+		if ( ! $updated ) {
+			return false;
+		}
+
+		$limits             = self::get_storage_maintenance_limits();
+		$paused_state_bytes = isset( $session->paused_state ) && is_string( $session->paused_state ) ? strlen( $session->paused_state ) : 0;
+		$total_bytes        = strlen( $encoded_messages ) + strlen( $encoded_tool_calls ) + $paused_state_bytes;
+		$message_count      = count( $merged_messages );
+		if ( $total_bytes >= $limits['bytes'] || $message_count >= $limits['messages'] ) {
+			/**
+			 * Fires after a session crosses the non-destructive storage-maintenance threshold.
+			 *
+			 * @param int                                    $session_id Session ID.
+			 * @param array{message_count:int,total_bytes:int} $metrics    Safe size metadata only.
+			 */
+			do_action(
+				'sd_ai_agent_session_storage_maintenance_required',
+				$session_id,
+				array(
+					'message_count' => $message_count,
+					'total_bytes'   => $total_bytes,
+				)
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Repositories/SessionRepository.php
+++ b/includes/Repositories/SessionRepository.php
@@ -125,7 +125,7 @@ class SessionRepository {
 				'SELECT id, status, message_count, messages_bytes, tool_calls_bytes, paused_state_bytes, total_bytes
 				FROM (
 					SELECT id, status,
-						COALESCE(JSON_LENGTH(messages), 0) AS message_count,
+						CASE WHEN JSON_VALID(messages) THEN COALESCE(JSON_LENGTH(messages), 0) ELSE 0 END AS message_count,
 						COALESCE(OCTET_LENGTH(messages), 0) AS messages_bytes,
 						COALESCE(OCTET_LENGTH(tool_calls), 0) AS tool_calls_bytes,
 						COALESCE(OCTET_LENGTH(paused_state), 0) AS paused_state_bytes,
@@ -163,7 +163,8 @@ class SessionRepository {
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT id, user_id, title, provider_id, model_id, status,
-					COALESCE(JSON_LENGTH(messages), 0) AS message_count,
+					CASE WHEN JSON_VALID(messages) THEN COALESCE(JSON_LENGTH(messages), 0) ELSE 0 END AS message_count,
+					COALESCE(JSON_VALID(messages), 0) AS messages_valid,
 					COALESCE(OCTET_LENGTH(messages), 0) AS messages_bytes,
 					COALESCE(OCTET_LENGTH(tool_calls), 0) AS tool_calls_bytes,
 					COALESCE(OCTET_LENGTH(paused_state), 0) AS paused_state_bytes,

--- a/includes/Repositories/SessionRepository.php
+++ b/includes/Repositories/SessionRepository.php
@@ -93,7 +93,7 @@ class SessionRepository {
 	 * @return array{bytes:int,messages:int}
 	 */
 	public static function get_storage_maintenance_limits(): array {
-		$bytes = (int) apply_filters( 'sd_ai_agent_session_storage_maintenance_bytes', self::STORAGE_MAINTENANCE_BYTES );
+		$bytes    = (int) apply_filters( 'sd_ai_agent_session_storage_maintenance_bytes', self::STORAGE_MAINTENANCE_BYTES );
 		$messages = (int) apply_filters( 'sd_ai_agent_session_storage_maintenance_messages', self::STORAGE_MAINTENANCE_MESSAGES );
 
 		return array(
@@ -122,7 +122,7 @@ class SessionRepository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table inspection returns metadata only; caching cannot safely represent live maintenance candidates.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT id, status, message_count, messages_bytes, tool_calls_bytes, paused_state_bytes, total_bytes
+				'SELECT id, status, message_count, messages_bytes, tool_calls_bytes, paused_state_bytes, total_bytes
 				FROM (
 					SELECT id, status,
 						COALESCE(JSON_LENGTH(messages), 0) AS message_count,
@@ -134,7 +134,7 @@ class SessionRepository {
 				) AS sd_ai_agent_session_sizes
 				WHERE total_bytes >= %d OR message_count >= %d
 				ORDER BY total_bytes DESC, id ASC
-				LIMIT %d",
+				LIMIT %d',
 				Database::table_name(),
 				$min_bytes,
 				$min_messages,
@@ -211,7 +211,7 @@ class SessionRepository {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded custom-table slice for maintenance compaction.
 			$chunk = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT SUBSTRING(messages, %d, %d) FROM %i WHERE id = %d',
+					'SELECT SUBSTRING(CAST(messages AS BINARY), %d, %d) FROM %i WHERE id = %d',
 					$offset,
 					$chunk_bytes,
 					Database::table_name(),

--- a/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
@@ -112,6 +112,79 @@ class ConversationTrimmerSerializedTest extends WP_UnitTestCase {
 		);
 	}
 
+	/** Chunked compaction retains complete split parallel tool cycles as one group. */
+	public function test_chunked_compaction_preserves_parallel_tool_cycles(): void {
+		$history = array(
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'id' => 'call-a', 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'id' => 'call-b', 'name' => 'tool-b' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'call-a', 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'call-b', 'name' => 'tool-b' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'text' => 'Continue after both tools.' ) ) ),
+		);
+
+		$result = ConversationTrimmer::compact_serialized_history_chunks( str_split( (string) wp_json_encode( $history ), 11 ), 4096, 1024 );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertStringContainsString( '[tool call: tool-a]', $text );
+		$this->assertStringContainsString( '[tool call: tool-b]', $text );
+		$this->assertStringContainsString( '[tool result omitted: tool-a]', $text );
+		$this->assertStringContainsString( '[tool result omitted: tool-b]', $text );
+		$this->assertStringContainsString( 'Continue after both tools.', $text );
+	}
+
+	/** Parallel ID-less cycles use call/response cardinality for compatibility. */
+	public function test_chunked_compaction_preserves_parallel_idless_tool_cycles(): void {
+		$history = array(
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'name' => 'tool-b' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'name' => 'tool-b' ) ) ) ),
+		);
+
+		$result = ConversationTrimmer::compact_serialized_history_chunks( str_split( (string) wp_json_encode( $history ), 13 ), 4096, 1024 );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertStringContainsString( '[tool call: tool-a]', $text );
+		$this->assertStringContainsString( '[tool result omitted: tool-b]', $text );
+	}
+
+	/** Incomplete or mismatched parallel cycles are omitted as a whole. */
+	public function test_chunked_compaction_omits_mismatched_parallel_tool_cycles(): void {
+		$history = array(
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'id' => 'call-a', 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'id' => 'call-b', 'name' => 'tool-b' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'call-a', 'name' => 'tool-a' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'call-c', 'name' => 'tool-c' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'text' => 'Keep this safe boundary.' ) ) ),
+		);
+
+		$result = ConversationTrimmer::compact_serialized_history_chunks( str_split( (string) wp_json_encode( $history ), 7 ), 4096, 1024 );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertStringNotContainsString( '[tool call:', $text );
+		$this->assertStringNotContainsString( '[tool result omitted:', $text );
+		$this->assertStringContainsString( 'Keep this safe boundary.', $text );
+	}
+
+	/** Malformed array separators and trailing data fail closed. */
+	public function test_chunked_compaction_rejects_malformed_json_arrays(): void {
+		$invalid_histories = array(
+			'[{}{}]',
+			'[,{}]',
+			'[{},]',
+			'[{}]trailing',
+			'[{"parts":[}]',
+		);
+
+		foreach ( $invalid_histories as $history ) {
+			$result = ConversationTrimmer::compact_serialized_history_chunks( str_split( $history, 2 ), 4096, 1024 );
+			$this->assertFalse( $result['meta']['stream_valid'], $history );
+		}
+	}
+
 	/** A 60 MB historical fixture is compacted from bounded JSON slices. */
 	public function test_chunked_compaction_handles_a_60_mb_history_without_materializing_it(): void {
 		$message_count = 18759;

--- a/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
@@ -61,4 +61,86 @@ class ConversationTrimmerSerializedTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'SECRET_RESOURCE_VALUE', $text );
 		$this->assertStringNotContainsString( 'private.example', $text );
 	}
+
+	/** Chunked compaction keeps both sides of a persisted tool cycle in order. */
+	public function test_chunked_compaction_preserves_complete_tool_cycles(): void {
+		$history = array(
+			array(
+				'role'  => 'user',
+				'parts' => array( array( 'text' => 'Check the site before changing it.' ) ),
+			),
+			array(
+				'role'  => 'model',
+				'parts' => array(
+					array(
+						'functionCall' => array(
+							'name' => 'sd-ai-agent/site-info',
+							'args' => array( 'scope' => 'summary' ),
+						),
+					),
+				),
+			),
+			array(
+				'role'  => 'user',
+				'parts' => array(
+					array(
+						'functionResponse' => array(
+							'name'     => 'sd-ai-agent/site-info',
+							'response' => array( 'name' => 'Example Site' ),
+						),
+					),
+				),
+			),
+			array(
+				'role'  => 'user',
+				'parts' => array( array( 'text' => 'Continue with the maintenance plan.' ) ),
+			),
+		);
+
+		$encoded = (string) wp_json_encode( $history );
+		$chunks  = str_split( $encoded, 17 );
+		$result  = ConversationTrimmer::compact_serialized_history_chunks( $chunks, 4096, 1024 );
+		$text    = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_complete'] );
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertStringContainsString( '[tool call: sd-ai-agent/site-info]', $text );
+		$this->assertStringContainsString( '[tool result omitted: sd-ai-agent/site-info]', $text );
+		$this->assertLessThan(
+			strpos( $text, '[tool result omitted: sd-ai-agent/site-info]' ),
+			strpos( $text, '[tool call: sd-ai-agent/site-info]' )
+		);
+	}
+
+	/** A 60 MB historical fixture is compacted from bounded JSON slices. */
+	public function test_chunked_compaction_handles_a_60_mb_history_without_materializing_it(): void {
+		$message_count = 18759;
+		$chunks        = static function () use ( $message_count ): \Generator {
+			yield '[';
+			for ( $index = 0; $index < $message_count; ++$index ) {
+				$encoded = (string) wp_json_encode(
+					array(
+						'role'  => 'user',
+						'parts' => array(
+							array( 'text' => 'legacy-message-' . $index . ' ' . str_repeat( 'x', 3400 ) ),
+						),
+					)
+				);
+				$encoded = ( 0 === $index ? '' : ',' ) . $encoded;
+				for ( $offset = 0, $length = strlen( $encoded ); $offset < $length; $offset += 4096 ) {
+					yield substr( $encoded, $offset, 4096 );
+				}
+			}
+			yield ']';
+		};
+
+		$result = ConversationTrimmer::compact_serialized_history_chunks( $chunks(), 8192, 2048 );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_complete'] );
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertSame( $message_count, $result['meta']['source_message_count'] );
+		$this->assertLessThanOrEqual( 8192, $result['meta']['estimated_bytes'] );
+		$this->assertStringContainsString( 'legacy-message-18758', $text );
+	}
 }

--- a/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerSerializedTest.php
@@ -169,6 +169,25 @@ class ConversationTrimmerSerializedTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Keep this safe boundary.', $text );
 	}
 
+	/** A completed cycle remains available when a later orphan response is ignored. */
+	public function test_chunked_compaction_preserves_completed_cycle_before_orphan_response(): void {
+		$history = array(
+			array( 'role' => 'model', 'parts' => array( array( 'functionCall' => array( 'id' => 'call-a', 'name' => 'write-tool' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'call-a', 'name' => 'write-tool' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'functionResponse' => array( 'id' => 'orphan-b', 'name' => 'orphan-tool' ) ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'text' => 'Continue without repeating the write.' ) ) ),
+		);
+
+		$result = ConversationTrimmer::compact_serialized_history_chunks( str_split( (string) wp_json_encode( $history ), 9 ), 4096, 1024 );
+		$text   = (string) $result['messages'][0]['parts'][0]['text'];
+
+		$this->assertTrue( $result['meta']['stream_valid'] );
+		$this->assertStringContainsString( '[tool call: write-tool]', $text );
+		$this->assertStringContainsString( '[tool result omitted: write-tool]', $text );
+		$this->assertStringNotContainsString( 'orphan-tool', $text );
+		$this->assertStringContainsString( 'Continue without repeating the write.', $text );
+	}
+
 	/** Malformed array separators and trailing data fail closed. */
 	public function test_chunked_compaction_rejects_malformed_json_arrays(): void {
 		$invalid_histories = array(

--- a/tests/SdAiAgent/Core/DatabaseTest.php
+++ b/tests/SdAiAgent/Core/DatabaseTest.php
@@ -324,6 +324,103 @@ class DatabaseTest extends WP_UnitTestCase {
 		$this->assertSame( 'user', $messages[0]['role'] );
 	}
 
+	/** Storage inspection returns only IDs and size metadata, never conversation content. */
+	public function test_list_oversized_sessions_returns_safe_metadata(): void {
+		$user_id    = self::factory()->user->create();
+		$session_id = Database::create_session(
+			array(
+				'user_id' => $user_id,
+				'title'   => 'Oversized metadata test',
+			)
+		);
+		$messages   = array(
+			array( 'role' => 'user', 'content' => str_repeat( 'private conversation content ', 120 ) ),
+			array( 'role' => 'model', 'content' => str_repeat( 'private model response ', 120 ) ),
+		);
+
+		$this->assertTrue(
+			Database::update_session(
+				(int) $session_id,
+				array(
+					'messages'   => wp_json_encode( $messages ),
+					'tool_calls' => wp_json_encode( array( array( 'secret' => 'DO_NOT_RETURN_THIS' ) ) ),
+				)
+			)
+		);
+
+		$candidates = Database::list_oversized_sessions( 1024, 999999, 100 );
+		$candidate  = null;
+		foreach ( $candidates as $row ) {
+			if ( (int) $row->id === (int) $session_id ) {
+				$candidate = $row;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $candidate );
+		$this->assertSame( 2, (int) $candidate->message_count );
+		$this->assertGreaterThan( 1024, (int) $candidate->total_bytes );
+		$this->assertFalse( property_exists( $candidate, 'messages' ) );
+		$this->assertFalse( property_exists( $candidate, 'tool_calls' ) );
+	}
+
+	/** Historical messages can be read from bounded database slices for compaction. */
+	public function test_stream_session_messages_reads_bounded_slices(): void {
+		$user_id    = self::factory()->user->create();
+		$session_id = Database::create_session( array( 'user_id' => $user_id, 'title' => 'Chunked source' ) );
+		$messages   = array(
+			array( 'role' => 'user', 'content' => str_repeat( 'first chunk café 😀 ', 250 ) ),
+			array( 'role' => 'model', 'content' => str_repeat( 'second chunk ', 250 ) ),
+		);
+		$encoded    = (string) wp_json_encode( $messages, JSON_UNESCAPED_UNICODE );
+
+		$this->assertTrue( Database::update_session( (int) $session_id, array( 'messages' => $encoded ) ) );
+		$chunks = iterator_to_array( Database::stream_session_messages( (int) $session_id, 1024 ), false );
+
+		$this->assertNotEmpty( $chunks );
+		$this->assertSame( $encoded, implode( '', $chunks ) );
+		foreach ( $chunks as $chunk ) {
+			$this->assertLessThanOrEqual( 1024, strlen( $chunk ) );
+		}
+	}
+
+	/** Crossing the maintenance threshold reports safe size metadata without rejecting persistence. */
+	public function test_append_reports_storage_maintenance_without_dropping_messages(): void {
+		$user_id    = self::factory()->user->create();
+		$session_id = Database::create_session( array( 'user_id' => $user_id, 'title' => 'Threshold notice' ) );
+		$reported   = null;
+		$bytes      = static fn(): int => 1024;
+		$messages   = static fn(): int => 999999;
+		$listener   = static function ( int $reported_session_id, array $metrics ) use ( &$reported ): void {
+			$reported = array(
+				'session_id' => $reported_session_id,
+				'metrics'    => $metrics,
+			);
+		};
+
+		add_filter( 'sd_ai_agent_session_storage_maintenance_bytes', $bytes );
+		add_filter( 'sd_ai_agent_session_storage_maintenance_messages', $messages );
+		add_action( 'sd_ai_agent_session_storage_maintenance_required', $listener, 10, 2 );
+		try {
+			$this->assertTrue(
+				Database::append_to_session(
+					(int) $session_id,
+					array( array( 'role' => 'user', 'content' => str_repeat( 'persisted safely ', 100 ) ) )
+				)
+			);
+		} finally {
+			remove_filter( 'sd_ai_agent_session_storage_maintenance_bytes', $bytes );
+			remove_filter( 'sd_ai_agent_session_storage_maintenance_messages', $messages );
+			remove_action( 'sd_ai_agent_session_storage_maintenance_required', $listener, 10 );
+		}
+
+		$this->assertIsArray( $reported );
+		$this->assertSame( (int) $session_id, $reported['session_id'] );
+		$this->assertGreaterThanOrEqual( 1024, $reported['metrics']['total_bytes'] );
+		$session = Database::get_session( (int) $session_id );
+		$this->assertStringContainsString( 'persisted safely', (string) $session->messages );
+	}
+
 	/**
 	 * Tool-call events with the same type, ID, and sequence are persisted once.
 	 */

--- a/tests/SdAiAgent/Core/DatabaseTest.php
+++ b/tests/SdAiAgent/Core/DatabaseTest.php
@@ -9,6 +9,7 @@
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Database;
 use WP_UnitTestCase;
 
@@ -368,20 +369,24 @@ class DatabaseTest extends WP_UnitTestCase {
 	public function test_stream_session_messages_reads_bounded_slices(): void {
 		$user_id    = self::factory()->user->create();
 		$session_id = Database::create_session( array( 'user_id' => $user_id, 'title' => 'Chunked source' ) );
-		$messages   = array(
-			array( 'role' => 'user', 'content' => str_repeat( 'first chunk café 😀 ', 250 ) ),
-			array( 'role' => 'model', 'content' => str_repeat( 'second chunk ', 250 ) ),
-		);
+		$template   = (string) wp_json_encode( array( array( 'role' => 'user', 'parts' => array( array( 'text' => 'MARKER' ) ) ) ), JSON_UNESCAPED_UNICODE );
+		$padding    = 65535 - (int) strpos( $template, 'MARKER' );
+		$messages   = array( array( 'role' => 'user', 'parts' => array( array( 'text' => str_repeat( 'x', $padding ) . '😀 boundary' ) ) ) );
 		$encoded    = (string) wp_json_encode( $messages, JSON_UNESCAPED_UNICODE );
 
 		$this->assertTrue( Database::update_session( (int) $session_id, array( 'messages' => $encoded ) ) );
-		$chunks = iterator_to_array( Database::stream_session_messages( (int) $session_id, 1024 ), false );
+		$chunks = iterator_to_array( Database::stream_session_messages( (int) $session_id ), false );
 
 		$this->assertNotEmpty( $chunks );
+		$this->assertSame( 65535, strpos( $encoded, '😀' ) );
 		$this->assertSame( $encoded, implode( '', $chunks ) );
 		foreach ( $chunks as $chunk ) {
-			$this->assertLessThanOrEqual( 1024, strlen( $chunk ) );
+			$this->assertLessThanOrEqual( 65536, strlen( $chunk ) );
 		}
+
+		$compacted = ConversationTrimmer::compact_serialized_history_chunks( $chunks, 4096, 1024 );
+		$this->assertTrue( $compacted['meta']['stream_complete'] );
+		$this->assertTrue( $compacted['meta']['stream_valid'] );
 	}
 
 	/** Crossing the maintenance threshold reports safe size metadata without rejecting persistence. */

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -187,6 +187,7 @@ class RestControllerTest extends WP_UnitTestCase {
 			'/sd-ai-agent/v1/skills',
 			'/sd-ai-agent/v1/skills/(?P<id>\d+)',
 			'/sd-ai-agent/v1/sessions',
+			'/sd-ai-agent/v1/sessions/oversized',
 			'/sd-ai-agent/v1/sessions/(?P<id>\d+)',
 			'/sd-ai-agent/v1/sessions/(?P<id>\d+)/compact',
 			'/sd-ai-agent/v1/sessions/(?P<id>\d+)/resume',
@@ -769,6 +770,94 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $stored_messages );
 		$source_messages_after = json_decode( (string) Database::get_session( (int) $session_id )->messages, true );
 		$this->assertSame( $source_messages_before, $source_messages_after );
+	}
+
+	/** Administrators can inspect oversized session metadata without conversation content. */
+	public function test_list_oversized_sessions_returns_only_size_metadata(): void {
+		wp_set_current_user( $this->admin_id );
+		$session_id = Database::create_session(
+			array(
+				'user_id' => $this->admin_id,
+				'title'   => 'Private oversized conversation title',
+			)
+		);
+		Database::update_session(
+			(int) $session_id,
+			array(
+				'messages' => wp_json_encode(
+					array(
+						array( 'role' => 'user', 'content' => str_repeat( 'PRIVATE_SESSION_CONTENT ', 100 ) ),
+					)
+				),
+			)
+		);
+
+		$response = $this->dispatch(
+			'GET',
+			'/sd-ai-agent/v1/sessions/oversized',
+			array(
+				'min_bytes'    => 1024,
+				'min_messages' => 999999,
+			)
+		);
+
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'sessions', $data );
+		$candidate = null;
+		foreach ( $data['sessions'] as $session ) {
+			if ( (int) $session['id'] === (int) $session_id ) {
+				$candidate = $session;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $candidate );
+		$this->assertGreaterThan( 1024, $candidate['total_bytes'] );
+		$this->assertArrayNotHasKey( 'messages', $candidate );
+		$this->assertArrayNotHasKey( 'tool_calls', $candidate );
+		$this->assertArrayNotHasKey( 'title', $candidate );
+	}
+
+	/** Oversized-session metadata is restricted to administrators. */
+	public function test_list_oversized_sessions_requires_administrator(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/sessions/oversized' );
+
+		$this->assertStatus( 403, $response );
+	}
+
+	/** Compaction leaves active jobs and paused continuations untouched. */
+	public function test_compact_session_rejects_active_or_paused_sessions(): void {
+		wp_set_current_user( $this->admin_id );
+		$paused_session_id = Database::create_session( array( 'user_id' => $this->admin_id, 'title' => 'Paused source' ) );
+		Database::append_to_session( (int) $paused_session_id, array( array( 'role' => 'user', 'content' => 'Do not compact this yet.' ) ) );
+		Database::save_paused_state( (int) $paused_session_id, array( 'history' => array( array( 'role' => 'user' ) ) ) );
+
+		$paused_response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$paused_session_id}/compact" );
+		$this->assertStatus( 409, $paused_response );
+		$this->assertSame( 'sd_ai_agent_compact_paused_session', $paused_response->get_data()['code'] );
+
+		$active_session_id = Database::create_session( array( 'user_id' => $this->admin_id, 'title' => 'Active source' ) );
+		Database::append_to_session( (int) $active_session_id, array( array( 'role' => 'user', 'content' => 'Do not compact this job.' ) ) );
+		$this->assertNotFalse( ActiveJobRepository::create( (int) $active_session_id, wp_generate_uuid4(), $this->admin_id ) );
+
+		$active_response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$active_session_id}/compact" );
+		$this->assertStatus( 409, $active_response );
+		$this->assertSame( 'sd_ai_agent_compact_active_job', $active_response->get_data()['code'] );
+	}
+
+	/** Streamed compaction keeps the existing session ownership boundary. */
+	public function test_compact_session_rejects_an_unshared_session_owned_by_another_user(): void {
+		$other_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$session_id  = Database::create_session( array( 'user_id' => $other_admin, 'title' => 'Other user source' ) );
+		Database::append_to_session( (int) $session_id, array( array( 'role' => 'user', 'content' => 'Private source.' ) ) );
+
+		wp_set_current_user( $this->admin_id );
+		$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/compact" );
+
+		$this->assertStatus( 403, $response );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -848,6 +848,19 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_compact_active_job', $active_response->get_data()['code'] );
 	}
 
+	/** Malformed persisted JSON fails closed without loading or replacing the source row. */
+	public function test_compact_session_rejects_malformed_persisted_history(): void {
+		wp_set_current_user( $this->admin_id );
+		$session_id = Database::create_session( array( 'user_id' => $this->admin_id, 'title' => 'Malformed source' ) );
+		$this->assertTrue( Database::update_session( (int) $session_id, array( 'messages' => '[{"role":"user"}' ) ) );
+
+		$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/compact" );
+
+		$this->assertStatus( 409, $response );
+		$this->assertSame( 'sd_ai_agent_compact_invalid_history', $response->get_data()['code'] );
+		$this->assertSame( '[{"role":"user"}', Database::get_session( (int) $session_id )->messages );
+	}
+
 	/** Streamed compaction keeps the existing session ownership boundary. */
 	public function test_compact_session_rejects_an_unshared_session_owned_by_another_user(): void {
 		$other_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
## Summary

- Adds metadata-only inspection for oversized persisted sessions without returning conversation content.
- Streams historical message JSON in bounded database slices and creates a separate compacted session, leaving the source unchanged.
- Fails closed for malformed histories, active jobs, paused continuations, incomplete tool cycles, and unauthorized access.
- Documents backup-safe export, compact, archive, and deletion procedures.

## Safety and review

- Verified a generated 60 MB / 18,759-message history under bounded streamed compaction.
- Preserves complete parallel and ID-less tool call/response cycles while omitting incomplete or orphaned cycles.
- Handles UTF-8 code points split across the 64 KiB database slice boundary.
- Independent closeout review found no blocking findings at `222ba35e` (evidence bundle `72bda7f5efdbdf7c23dbae120e2ca14842fa33c15d44a05972882698f79c2cdc`).

## Worker self-verification
- PHPUnit: Tests: 4402, Assertions: 20488, Errors: 0, Failures: 0, Skipped: 139, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Closes #2683

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 53m and 1,295,416 tokens on this with the user in an interactive session.