### PR TITLE
GH#2682: classify gateway provider rejections

### DIFF
--- a/includes/Bootstrap/HttpTraceHandler.php
+++ b/includes/Bootstrap/HttpTraceHandler.php
@@ -24,7 +24,6 @@ use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Infrastructure\Schema\EmptyJsonObject;
 use SdAiAgent\Infrastructure\Schema\SchemaNormalizer;
-use SdAiAgent\Models\ProviderTrace;
 use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
 
@@ -40,10 +39,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * calls can originate from admin (manual runs), REST (webhook triggers), CLI,
  * and cron (scheduled tasks).
  *
- * The trace callbacks are no-ops when WP_DEBUG is not active; the cache
- * marker injection is always active (cache hints are a runtime cost
- * optimisation, not a debug feature) but is gated on the
- * `prompt_caching_enabled` setting so operators can opt out.
+	 * Full request/response traces remain debug-only. For an active provider
+	 * request, the callbacks also carry bounded runtime metadata in production;
+	 * the cache-marker injection remains gated on `prompt_caching_enabled`.
  */
 #[Handler(
 	container: 'sd-ai-agent',
@@ -65,9 +63,9 @@ final class HttpTraceHandler {
 	/**
 	 * Capture outgoing request details before the HTTP call is made.
 	 *
-	 * Returns `$preempt` unchanged — this filter is used only for its
-	 * side-effect of recording in-flight request metadata. No-op when
-	 * WP_DEBUG is not active.
+	 * Returns `$preempt` unchanged. The logger stays a no-op for unrelated
+	 * traffic, preserves full traces behind debug mode, and retains only bounded
+	 * runtime metrics for an active provider request outside debug mode.
 	 *
 	 * @param false|array<string,mixed>|\WP_Error $preempt     A preemptive return value. Default false.
 	 * @param array<string,mixed>                 $parsed_args HTTP request arguments.
@@ -76,18 +74,15 @@ final class HttpTraceHandler {
 	 */
 	#[Filter( tag: 'pre_http_request', priority: 10 )]
 	public function on_pre_http_request( mixed $preempt, array $parsed_args, string $url ): mixed {
-		if ( ! ProviderTrace::is_debug_mode() ) {
-			return $preempt;
-		}
 		return ProviderTraceLogger::on_pre_http_request( $preempt, $parsed_args, $url );
 	}
 
 	/**
 	 * Capture response details and write a trace record.
 	 *
-	 * Returns `$response` unchanged — this filter is used only for its
-	 * side-effect of persisting the completed trace row. No-op when
-	 * WP_DEBUG is not active.
+	 * Returns `$response` unchanged. Full trace persistence remains debug-only,
+	 * while an active provider request can retain only bounded failure metadata
+	 * for a safe terminal diagnostic in production.
 	 *
 	 * @param array<string,mixed> $response    HTTP response array.
 	 * @param array<string,mixed> $parsed_args HTTP request arguments.
@@ -96,9 +91,6 @@ final class HttpTraceHandler {
 	 */
 	#[Filter( tag: 'http_response', priority: 10 )]
 	public function on_http_response( array $response, array $parsed_args, string $url ): array {
-		if ( ! ProviderTrace::is_debug_mode() ) {
-			return $response;
-		}
 		return ProviderTraceLogger::on_http_response( $response, $parsed_args, $url );
 	}
 

--- a/includes/Core/ActiveJobFailureDiagnostic.php
+++ b/includes/Core/ActiveJobFailureDiagnostic.php
@@ -34,6 +34,9 @@ final class ActiveJobFailureDiagnostic {
 	/** Failure caused by an upstream provider timeout. */
 	public const REASON_PROVIDER_TIMEOUT = 'provider_timeout';
 
+	/** Failure caused by an upstream security gateway or WAF rejection. */
+	public const REASON_GATEWAY_REJECTION = 'gateway_rejection';
+
 	/** The managed Superdav provider requires additional account credit. */
 	public const REASON_CREDIT_EXHAUSTED = 'credit_exhausted';
 
@@ -60,6 +63,7 @@ final class ActiveJobFailureDiagnostic {
 		self::REASON_LOCAL_PAYLOAD_GUARD,
 		self::REASON_UPSTREAM_PAYLOAD_REJECTION,
 		self::REASON_PROVIDER_TIMEOUT,
+		self::REASON_GATEWAY_REJECTION,
 		self::REASON_CREDIT_EXHAUSTED,
 		self::REASON_WORKER_TERMINATED,
 		self::REASON_APPROVAL_WAIT,
@@ -86,7 +90,11 @@ final class ActiveJobFailureDiagnostic {
 		return array(
 			'version'            => self::VERSION,
 			'reason'             => $reason,
+			'status_code'        => self::sanitize_status_code( (int) ( $context['status_code'] ?? 0 ) ),
+			'failure_class'      => self::sanitize_failure_class( (string) ( $context['failure_class'] ?? '' ), $reason ),
+			'failure_source'     => self::sanitize_failure_source( (string) ( $context['failure_source'] ?? '' ) ),
 			'last_safe_phase'    => self::sanitize_phase( (string) ( $context['last_safe_phase'] ?? '' ) ),
+			'attempts'           => min( 10, max( 0, (int) ( $context['attempts'] ?? 0 ) ) ),
 			'resume_count'       => max( 0, (int) ( $context['resume_count'] ?? 0 ) ),
 			'provider_id'        => self::sanitize_identifier( (string) ( $context['provider_id'] ?? '' ) ),
 			'model_id'           => self::sanitize_identifier( (string) ( $context['model_id'] ?? '' ) ),
@@ -135,9 +143,9 @@ final class ActiveJobFailureDiagnostic {
 	/**
 	 * Classify a provider or loop WP_Error without retaining its message.
 	 *
-	 * Error messages are inspected only to recognize a timeout when an upstream
-	 * library does not supply a stable code. They are never returned, persisted,
-	 * or added to the diagnostic context.
+	 * Error messages are inspected only for bounded classifications when an
+	 * upstream library does not supply a stable code. They are never returned,
+	 * persisted, or added to the diagnostic context.
 	 *
 	 * @param \WP_Error $error Provider or loop error.
 	 * @return string Normalized diagnostic reason.
@@ -147,11 +155,19 @@ final class ActiveJobFailureDiagnostic {
 		$data        = $error->get_error_data();
 		$data        = is_array( $data ) ? $data : array();
 		$provider_id = sanitize_key( $provider_id );
+		$status_code = (int) ( $data['status_code'] ?? ProviderErrorClassifier::extract_status_code( $error ) );
+
+		if (
+			ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION === ( $data['failure_class'] ?? '' ) ||
+			ProviderErrorClassifier::is_gateway_rejection( $error, $status_code )
+		) {
+			return self::REASON_GATEWAY_REJECTION;
+		}
 
 		// HTTP 402 only gets the managed-credit recovery path for the provider
 		// that owns that account. Other providers may use 402 for unrelated
 		// billing states and must remain safely classified as unknown.
-		if ( 'sd-ai-agent-cloud' === $provider_id && 402 === (int) ( $data['status_code'] ?? 0 ) ) {
+		if ( 'sd-ai-agent-cloud' === $provider_id && 402 === $status_code ) {
 			return self::REASON_CREDIT_EXHAUSTED;
 		}
 
@@ -162,13 +178,13 @@ final class ActiveJobFailureDiagnostic {
 			return self::REASON_LOCAL_PAYLOAD_GUARD;
 		}
 
-		if ( 'sd_ai_agent_provider_payload_too_large' === $code || 413 === (int) ( $data['status_code'] ?? 0 ) ) {
+		if ( 'sd_ai_agent_provider_payload_too_large' === $code || 413 === $status_code ) {
 			return self::REASON_UPSTREAM_PAYLOAD_REJECTION;
 		}
 
 		if (
 			in_array( $code, array( 'sd_ai_agent_provider_timeout', 'sd_ai_agent_provider_retry_failed', 'timeout', 'timed_out', 'deadline_exceeded' ), true ) ||
-			in_array( (int) ( $data['status_code'] ?? 0 ), array( 408, 504, 524 ), true )
+			in_array( $status_code, array( 408, 504, 524 ), true )
 		) {
 			return self::REASON_PROVIDER_TIMEOUT;
 		}
@@ -185,13 +201,17 @@ final class ActiveJobFailureDiagnostic {
 	 * Extract allowlisted diagnostic context from a WP_Error data payload.
 	 *
 	 * @param array<string, mixed> $data Error data.
-	 * @return array<string, string>
+	 * @return array<string, int|string>
 	 */
 	public static function context_from_error_data( array $data ): array {
 		$context = array(
 			'provider_id'        => (string) ( $data['provider_id'] ?? '' ),
 			'model_id'           => (string) ( $data['model_id'] ?? '' ),
 			'request_size_class' => (string) ( $data['request_size_class'] ?? '' ),
+			'status_code'        => (int) ( $data['status_code'] ?? 0 ),
+			'failure_class'      => (string) ( $data['failure_class'] ?? '' ),
+			'failure_source'     => (string) ( $data['failure_source'] ?? '' ),
+			'attempts'           => (int) ( $data['attempts'] ?? 0 ),
 		);
 
 		if ( '' === $context['request_size_class'] ) {
@@ -213,7 +233,11 @@ final class ActiveJobFailureDiagnostic {
 	public static function to_rest( array $diagnostic ): array {
 		return array(
 			'reason'             => (string) $diagnostic['reason'],
+			'status_code'        => (int) $diagnostic['status_code'],
+			'failure_class'      => (string) $diagnostic['failure_class'],
+			'failure_source'     => (string) $diagnostic['failure_source'],
 			'last_safe_phase'    => (string) $diagnostic['last_safe_phase'],
+			'attempts'           => (int) $diagnostic['attempts'],
 			'resume_count'       => (int) $diagnostic['resume_count'],
 			'provider_id'        => (string) $diagnostic['provider_id'],
 			'model_id'           => (string) $diagnostic['model_id'],
@@ -232,6 +256,7 @@ final class ActiveJobFailureDiagnostic {
 			self::REASON_LOCAL_PAYLOAD_GUARD => __( 'This request is too large to send safely. Compact the conversation, shorten the latest message, or remove large attachments before retrying.', 'superdav-ai-agent' ),
 			self::REASON_UPSTREAM_PAYLOAD_REJECTION => __( 'The selected AI provider rejected this request because it exceeds its payload limit. Start a smaller continuation and retry.', 'superdav-ai-agent' ),
 			self::REASON_PROVIDER_TIMEOUT => __( 'The AI provider timed out before finishing. Retry the request shortly.', 'superdav-ai-agent' ),
+			self::REASON_GATEWAY_REJECTION => __( 'The AI request was rejected by an upstream security gateway. Verify that the provider endpoint is allowed by your hosting or network policy, then retry. If it continues, contact support with the correlation ID.', 'superdav-ai-agent' ),
 			self::REASON_CREDIT_EXHAUSTED => __( 'Your Superdav account needs more credits to continue. Purchase credits in your account settings.', 'superdav-ai-agent' ),
 			self::REASON_WORKER_TERMINATED => __( 'The background worker stopped before the job could finish. Retry the job or start a continuation from the saved conversation.', 'superdav-ai-agent' ),
 			self::REASON_APPROVAL_WAIT => __( 'This job is waiting for approval before it can continue.', 'superdav-ai-agent' ),
@@ -256,7 +281,9 @@ final class ActiveJobFailureDiagnostic {
 				'session_id'         => max( 0, $session_id ),
 				'code'               => (string) $diagnostic['reason'],
 				'reason'             => (string) $diagnostic['reason'],
+				'status_code'        => (int) $diagnostic['status_code'],
 				'phase'              => (string) $diagnostic['last_safe_phase'],
+				'attempts'           => (int) $diagnostic['attempts'],
 				'resume_count'       => (int) $diagnostic['resume_count'],
 				'provider_id'        => (string) $diagnostic['provider_id'],
 				'model_id'           => (string) $diagnostic['model_id'],
@@ -296,6 +323,7 @@ final class ActiveJobFailureDiagnostic {
 			self::REASON_UPSTREAM_PAYLOAD_REJECTION => 'compact',
 			self::REASON_PROVIDER_TIMEOUT,
 			self::REASON_WORKER_TERMINATED => 'retry',
+			self::REASON_GATEWAY_REJECTION => 'contact_support',
 			self::REASON_CREDIT_EXHAUSTED => 'purchase_credits',
 			self::REASON_APPROVAL_WAIT => 'approve_review',
 			self::REASON_APPROVAL_EXPIRED,
@@ -310,6 +338,32 @@ final class ActiveJobFailureDiagnostic {
 		$phase = sanitize_key( $phase );
 
 		return substr( $phase, 0, 60 );
+	}
+
+	/** Keep a provider status code to a valid HTTP error range. */
+	private static function sanitize_status_code( int $status_code ): int {
+		return $status_code >= 400 && $status_code <= 599 ? $status_code : 0;
+	}
+
+	/** Keep a failure class to the diagnostic's explicit allowlist. */
+	private static function sanitize_failure_class( string $failure_class, string $reason ): string {
+		$failure_class = sanitize_key( $failure_class );
+
+		if (
+			self::REASON_GATEWAY_REJECTION === $reason ||
+			ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION === $failure_class
+		) {
+			return ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION;
+		}
+
+		return '';
+	}
+
+	/** Keep a failure source to a small set of provider-boundary tokens. */
+	private static function sanitize_failure_source( string $failure_source ): string {
+		$failure_source = sanitize_key( $failure_source );
+
+		return in_array( $failure_source, array( 'http', 'transport' ), true ) ? $failure_source : '';
 	}
 
 	/** Keep provider and model identifiers free of free-text request content. */

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3053,13 +3053,18 @@ PROMPT;
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
 			$request_envelope = array();
+			$provider_phase   = $this->get_provider_trace_phase();
 			ProviderTraceLogger::set_runtime_context(
 				$provider_id,
 				$model_id,
 				$this->session_id,
 				$this->provider_retry_baseline_envelope_bytes,
 				$journey_id,
-				$idempotency_key
+				$idempotency_key,
+				'',
+				$attempt,
+				$this->active_job_id,
+				$provider_phase
 			);
 			try {
 				$result = $builder->generate_text_result();
@@ -3073,6 +3078,7 @@ PROMPT;
 				$last_error = $e;
 			} finally {
 				$request_envelope = ProviderTraceLogger::get_runtime_envelope_metrics();
+				$request_envelope = array_merge( $request_envelope, ProviderTraceLogger::get_runtime_failure_metadata() );
 				ProviderTraceLogger::clear_runtime_context();
 			}
 
@@ -3082,7 +3088,7 @@ PROMPT;
 
 			$status_code = $this->extract_provider_error_status( $last_error );
 			if ( ! $this->is_retryable_provider_error( $last_error, $status_code ) ) {
-				return $this->provider_error_to_wp_error( $last_error, $status_code, $provider_id );
+				return $this->provider_error_to_wp_error( $last_error, $status_code, $provider_id, $model_id, $attempt );
 			}
 
 			if ( $attempt >= $this->provider_retry_max_attempts ) {
@@ -3111,7 +3117,14 @@ PROMPT;
 			$this->active_job_id,
 			$request_envelope
 		);
-		return $this->build_provider_retry_failed_error( $last_error, $elapsed_seconds );
+		return $this->build_provider_retry_failed_error(
+			$last_error,
+			$elapsed_seconds,
+			$status_code,
+			$provider_id,
+			$model_id,
+			$this->provider_retry_max_attempts
+		);
 	}
 
 	/** Return the bounded provider invocation phase stored in terminal traces. */
@@ -3143,6 +3156,11 @@ PROMPT;
 			'request_safety_margin_bytes',
 			'request_size_class',
 			'request_size_source',
+			'status_code',
+			'failure_class',
+			'failure_source',
+			'attempts',
+			'correlation_id',
 		);
 		foreach ( $safe_keys as $key ) {
 			if ( isset( $metrics[ $key ] ) && is_scalar( $metrics[ $key ] ) ) {
@@ -3153,6 +3171,60 @@ PROMPT;
 		$error->add_data( $data );
 
 		return $error;
+	}
+
+	/**
+	 * Copy only bounded provider failure metadata onto a terminal error.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unavailable.
+	 * @param string                   $provider_id Runtime provider ID.
+	 * @param string                   $model_id    Runtime model ID.
+	 * @param int                      $attempts    Completed provider attempts.
+	 * @return array<string, int|string> Prompt-free terminal context.
+	 */
+	private function provider_failure_context( $error, int $status_code, string $provider_id, string $model_id, int $attempts ): array {
+		$error_data = $error instanceof WP_Error ? $error->get_error_data() : array();
+		$error_data = is_array( $error_data ) ? $error_data : array();
+		$source     = sanitize_key( (string) ( $error_data['failure_source'] ?? '' ) );
+		if ( ! in_array( $source, array( 'http', 'transport' ), true ) ) {
+			$source = $status_code >= 400 ? 'http' : 'transport';
+		}
+
+		$context = array(
+			'status_code'    => max( 0, $status_code ),
+			'provider_id'    => sanitize_key( $provider_id ),
+			'model_id'       => sanitize_text_field( $model_id ),
+			'failure_source' => $source,
+			'attempts'       => min( 10, max( 1, $attempts ) ),
+		);
+		$failure_class = ProviderErrorClassifier::get_safe_failure_class( $error, $status_code );
+		if ( '' !== $failure_class ) {
+			$context['failure_class'] = $failure_class;
+		}
+
+		foreach ( array( 'request_bytes', 'request_tokens_estimate', 'request_provider_limit_bytes', 'request_budget_bytes', 'request_safety_margin_bytes' ) as $key ) {
+			if ( isset( $error_data[ $key ] ) && is_numeric( $error_data[ $key ] ) ) {
+				$context[ $key ] = max( 0, (int) $error_data[ $key ] );
+			}
+		}
+		$request_size_class = sanitize_key( (string) ( $error_data['request_size_class'] ?? '' ) );
+		if ( in_array( $request_size_class, array( 'small', 'medium', 'large', 'very_large' ), true ) ) {
+			$context['request_size_class'] = $request_size_class;
+		}
+		$request_size_source = sanitize_key( (string) ( $error_data['request_size_source'] ?? '' ) );
+		if ( in_array( $request_size_source, array( 'complete_envelope', 'http_body', 'history_estimate' ), true ) ) {
+			$context['request_size_source'] = $request_size_source;
+		}
+		if (
+			isset( $error_data['correlation_id'] ) &&
+			is_string( $error_data['correlation_id'] ) &&
+			(bool) preg_match( '/^job-(?:[a-f0-9]{12}|unknown)$/', $error_data['correlation_id'] )
+		) {
+			$context['correlation_id'] = $error_data['correlation_id'];
+		}
+
+		return $context;
 	}
 
 	/**
@@ -3347,8 +3419,10 @@ PROMPT;
 	 * @param WP_Error|\Throwable|null $error       Last provider error.
 	 * @param int                      $status_code HTTP status code, or 0 when unknown.
 	 * @param string                   $provider_id Runtime-selected provider ID.
+	 * @param string                   $model_id    Runtime-selected model ID.
+	 * @param int                      $attempts    Completed provider attempts.
 	 */
-	private function provider_error_to_wp_error( $error, int $status_code, string $provider_id = '' ): WP_Error {
+	private function provider_error_to_wp_error( $error, int $status_code, string $provider_id = '', string $model_id = '', int $attempts = 1 ): WP_Error {
 		if ( 413 === $status_code ) {
 			$data = array( 'status_code' => $status_code );
 			if ( '' !== $provider_id ) {
@@ -3398,12 +3472,10 @@ PROMPT;
 			// without retaining that message.
 			$error_data = $error->get_error_data();
 			$error_data = is_array( $error_data ) ? $error_data : array();
-			if ( $status_code > 0 && empty( $error_data['status_code'] ) ) {
-				$error_data['status_code'] = $status_code;
-			}
-			if ( '' !== $provider_id && empty( $error_data['provider_id'] ) ) {
-				$error_data['provider_id'] = $provider_id;
-			}
+			$error_data = array_merge(
+				$error_data,
+				$this->provider_failure_context( $error, $status_code, $provider_id, $model_id, $attempts )
+			);
 			$error->add_data( $error_data );
 
 			return $error;
@@ -3414,10 +3486,7 @@ PROMPT;
 			$message = __( 'AI provider request failed.', 'superdav-ai-agent' );
 		}
 
-		$error_data = array( 'status_code' => $status_code );
-		if ( '' !== $provider_id ) {
-			$error_data['provider_id'] = $provider_id;
-		}
+		$error_data = $this->provider_failure_context( $error, $status_code, $provider_id, $model_id, $attempts );
 
 		return new WP_Error(
 			'sd_ai_agent_provider_error',
@@ -3431,8 +3500,24 @@ PROMPT;
 	 *
 	 * @param WP_Error|\Throwable|null $error           Last provider error.
 	 * @param int                      $elapsed_seconds Total elapsed seconds.
+	 * @param int                      $status_code     HTTP status code, or 0 when unavailable.
+	 * @param string                   $provider_id     Runtime provider ID.
+	 * @param string                   $model_id        Runtime model ID.
+	 * @param int                      $attempts        Completed provider attempts.
 	 */
-	private function build_provider_retry_failed_error( $error, int $elapsed_seconds ): WP_Error {
+	private function build_provider_retry_failed_error( $error, int $elapsed_seconds, int $status_code = 0, string $provider_id = '', string $model_id = '', int $attempts = 0 ): WP_Error {
+		if ( 0 === $status_code ) {
+			$status_code = $this->extract_provider_error_status( $error );
+		}
+		if ( '' === $provider_id ) {
+			$provider_id = $this->resolve_provider_id();
+		}
+		if ( '' === $model_id ) {
+			$model_id = $this->model_id;
+		}
+		if ( $attempts <= 0 ) {
+			$attempts = $this->provider_retry_max_attempts;
+		}
 		$serialized_history = is_array( $this->providerPersistenceHistory )
 			? ConversationSerializer::serialize( $this->providerPersistenceHistory )
 			: $this->serialize_history();
@@ -3474,14 +3559,16 @@ PROMPT;
 			'sd_ai_agent_provider_retry_failed',
 			$message,
 			$this->with_result_logs(
-				[
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-					'history'         => $serialized_history,
-					'elapsed_seconds' => $elapsed_seconds,
-				]
+				array_merge(
+					[
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'history'         => $serialized_history,
+						'elapsed_seconds' => $elapsed_seconds,
+					],
+					$this->provider_failure_context( $error, $status_code, $provider_id, $model_id, $attempts )
+				)
 			)
 		);
 	}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3084,6 +3084,8 @@ PROMPT;
 
 			if ( $last_error instanceof WP_Error && ! empty( $request_envelope ) ) {
 				$last_error = $this->with_request_envelope_metadata( $last_error, $request_envelope );
+			} elseif ( $last_error instanceof \Throwable ) {
+				$last_error = $this->normalize_runtime_gateway_exception( $last_error, $request_envelope );
 			}
 
 			$status_code = $this->extract_provider_error_status( $last_error );
@@ -3174,6 +3176,30 @@ PROMPT;
 	}
 
 	/**
+	 * Replace a classified gateway exception before its unsafe message can escape.
+	 *
+	 * Some provider SDKs throw after WordPress has observed the HTTP response.
+	 * Their exception message can be arbitrary upstream HTML, while the runtime
+	 * envelope carries the safe classification from that response.
+	 *
+	 * @param \Throwable                $error   Provider exception.
+	 * @param array<string, int|string> $metrics Prompt-free runtime metrics.
+	 * @return WP_Error|\Throwable A safe error for classified gateway failures.
+	 */
+	private function normalize_runtime_gateway_exception( \Throwable $error, array $metrics ): WP_Error|\Throwable {
+		if ( ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION !== ( $metrics['failure_class'] ?? '' ) ) {
+			return $error;
+		}
+
+		$gateway_error = new WP_Error(
+			'sd_ai_agent_provider_gateway_rejection',
+			ActiveJobFailureDiagnostic::message_for( ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION )
+		);
+
+		return $this->with_request_envelope_metadata( $gateway_error, $metrics );
+	}
+
+	/**
 	 * Copy only bounded provider failure metadata onto a terminal error.
 	 *
 	 * @param WP_Error|\Throwable|null $error       Provider error.
@@ -3191,7 +3217,7 @@ PROMPT;
 			$source = $status_code >= 400 ? 'http' : 'transport';
 		}
 
-		$context = array(
+		$context       = array(
 			'status_code'    => max( 0, $status_code ),
 			'provider_id'    => sanitize_key( $provider_id ),
 			'model_id'       => sanitize_text_field( $model_id ),
@@ -3462,6 +3488,17 @@ PROMPT;
 					? __( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' )
 					: __( 'The selected AI provider or intermediary rejected this request because it exceeds its payload limit. Start a new chat and send a smaller request. If you attached files, remove or reduce them before retrying.', 'superdav-ai-agent' ),
 				$data
+			);
+		}
+
+		// Security gateways can return HTML that echoes request content or
+		// credentials. Classify that evidence transiently, then replace the
+		// provider error before it can reach a caller, recovery state, or REST path.
+		if ( ProviderErrorClassifier::is_gateway_rejection( $error, $status_code ) ) {
+			return new WP_Error(
+				'sd_ai_agent_provider_gateway_rejection',
+				ActiveJobFailureDiagnostic::message_for( ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION ),
+				$this->provider_failure_context( $error, $status_code, $provider_id, $model_id, $attempts )
 			);
 		}
 

--- a/includes/Core/ProviderErrorClassifier.php
+++ b/includes/Core/ProviderErrorClassifier.php
@@ -18,6 +18,12 @@ final class ProviderErrorClassifier {
 	/** Retryable upstream/network statuses. */
 	public const RETRYABLE_STATUS_CODES = array( 408, 429, 500, 502, 503, 504 );
 
+	/** Stable, prompt-free class for an upstream security-gateway rejection. */
+	public const FAILURE_CLASS_GATEWAY_REJECTION = 'gateway_rejection';
+
+	/** Maximum transient error evidence inspected for gateway classification. */
+	private const GATEWAY_EVIDENCE_MAX_BYTES = 8192;
+
 	/**
 	 * Extract an HTTP status code from provider errors produced by SDK layers.
 	 *
@@ -70,6 +76,10 @@ final class ProviderErrorClassifier {
 	public static function is_retryable( $error, int $status_code = 0 ): bool {
 		if ( 0 === $status_code ) {
 			$status_code = self::extract_status_code( $error );
+		}
+
+		if ( self::is_gateway_rejection( $error, $status_code ) ) {
+			return false;
 		}
 
 		if ( in_array( $status_code, self::RETRYABLE_STATUS_CODES, true ) ) {
@@ -154,6 +164,10 @@ final class ProviderErrorClassifier {
 			$status_code = self::extract_status_code( $error );
 		}
 
+		if ( self::is_gateway_rejection( $error, $status_code ) ) {
+			return 'provider_gateway_rejection';
+		}
+
 		if ( 429 === $status_code ) {
 			return 'provider_rate_limited';
 		}
@@ -182,6 +196,81 @@ final class ProviderErrorClassifier {
 		}
 
 		return 'provider_error';
+	}
+
+	/**
+	 * Return the bounded gateway-rejection class, if transient error evidence
+	 * identifies a known upstream security gateway.
+	 *
+	 * Provider messages may contain request content. This method uses them only
+	 * while the error is in memory; callers must persist only the returned token.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unavailable.
+	 * @return string Safe failure class, or an empty string when unclassified.
+	 */
+	public static function get_safe_failure_class( $error, int $status_code = 0 ): string {
+		if ( self::is_gateway_rejection( $error, $status_code ) ) {
+			return self::FAILURE_CLASS_GATEWAY_REJECTION;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Determine whether a provider error identifies a security-gateway block.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unavailable.
+	 * @return bool Whether the error is a recognized gateway rejection.
+	 */
+	public static function is_gateway_rejection( $error, int $status_code = 0 ): bool {
+		if ( $error instanceof WP_Error ) {
+			$data = $error->get_error_data();
+			if ( is_array( $data ) && self::FAILURE_CLASS_GATEWAY_REJECTION === ( $data['failure_class'] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		if ( 0 === $status_code ) {
+			$status_code = self::extract_status_code( $error );
+		}
+
+		return self::has_gateway_rejection_evidence( $status_code, self::get_message( $error ) );
+	}
+
+	/**
+	 * Classify a raw HTTP response body without retaining it.
+	 *
+	 * @param int    $status_code   HTTP status code.
+	 * @param string $response_body Transient response body.
+	 * @return bool Whether the body identifies a recognized gateway rejection.
+	 */
+	public static function is_gateway_rejection_response( int $status_code, string $response_body ): bool {
+		return self::has_gateway_rejection_evidence( $status_code, $response_body );
+	}
+
+	/**
+	 * Inspect bounded transient evidence for a recognized WAF/gateway marker.
+	 *
+	 * The vendor-specific Imunify360 marker remains useful even when an SDK lost
+	 * the HTTP status. Broader WAF phrases require a 4xx/5xx status so a provider
+	 * cannot cause a false classification merely by echoing request text.
+	 */
+	private static function has_gateway_rejection_evidence( int $status_code, string $evidence ): bool {
+		$evidence = strtolower( substr( $evidence, 0, self::GATEWAY_EVIDENCE_MAX_BYTES ) );
+		if ( str_contains( $evidence, 'imunify360' ) ) {
+			return true;
+		}
+
+		if ( $status_code < 400 || $status_code > 599 ) {
+			return false;
+		}
+
+		return (bool) preg_match(
+			'/\b(?:web\s+application\s+firewall|security\s+gateway|waf\s+(?:block|denied)|blocked\s+by\s+(?:a\s+)?(?:waf|firewall)|access\s+denied\s+by\s+(?:a\s+)?(?:waf|firewall))\b/i',
+			$evidence
+		);
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -49,7 +49,13 @@ class ProviderTraceLogger {
 	 *     request_provider_limit_bytes:int,
 	 *     request_budget_bytes:int,
 	 *     request_safety_margin_bytes:int,
-	 *     operation:string
+	 *     operation:string,
+	 *     attempt:int,
+	 *     phase:string,
+	 *     correlation_id:string,
+	 *     failure_status_code:int,
+	 *     failure_class:string,
+	 *     failure_source:string
 	 * }
 	 */
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
@@ -66,6 +72,12 @@ class ProviderTraceLogger {
 		'request_budget_bytes'         => 0,
 		'request_safety_margin_bytes'  => 0,
 		'operation'                    => '',
+		'attempt'                      => 0,
+		'phase'                        => '',
+		'correlation_id'               => '',
+		'failure_status_code'          => 0,
+		'failure_class'                => '',
+		'failure_source'               => '',
 	);
 
 	/**
@@ -134,10 +146,25 @@ class ProviderTraceLogger {
 	 * @param string $journey_id                   Validated managed journey ID, if active.
 	 * @param string $idempotency_key              Stable logical-request UUID, if active.
 	 * @param string $operation                    Content-sensitive operation category, if any.
+	 * @param int    $attempt                      One-based provider attempt, if available.
+	 * @param string $job_id                       Active job UUID, if available.
+	 * @param string $phase                        Safe provider invocation phase, if available.
 	 */
-	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0, string $journey_id = '', string $idempotency_key = '', string $operation = '' ): void {
+	public static function set_runtime_context(
+		string $provider_id,
+		string $model_id,
+		int $session_id = 0,
+		int $retry_baseline_request_bytes = 0,
+		string $journey_id = '',
+		string $idempotency_key = '',
+		string $operation = '',
+		int $attempt = 0,
+		string $job_id = '',
+		string $phase = ''
+	): void {
 		$has_valid_managed_attribution = SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
 			&& SuperdavManagedRequestIdentifiers::is_idempotency_key( $idempotency_key );
+		$allowed_phases                 = array( 'initial_provider_call', 'client_tool_resume', 'provider_followup_call' );
 		self::$runtimeContext          = array(
 			'provider_id'                  => sanitize_key( $provider_id ),
 			'model_id'                     => sanitize_text_field( $model_id ),
@@ -151,6 +178,12 @@ class ProviderTraceLogger {
 			'request_budget_bytes'         => 0,
 			'request_safety_margin_bytes'  => 0,
 			'operation'                    => 'speech' === $operation ? 'speech' : '',
+			'attempt'                      => min( 10, max( 0, $attempt ) ),
+			'phase'                        => in_array( $phase, $allowed_phases, true ) ? $phase : '',
+			'correlation_id'               => self::job_correlation_id( $job_id ),
+			'failure_status_code'          => 0,
+			'failure_class'                => '',
+			'failure_source'               => '',
 		);
 	}
 
@@ -186,6 +219,12 @@ class ProviderTraceLogger {
 			'request_budget_bytes'         => 0,
 			'request_safety_margin_bytes'  => 0,
 			'operation'                    => '',
+			'attempt'                      => 0,
+			'phase'                        => '',
+			'correlation_id'               => '',
+			'failure_status_code'          => 0,
+			'failure_class'                => '',
+			'failure_source'               => '',
 		);
 	}
 
@@ -215,6 +254,36 @@ class ProviderTraceLogger {
 	}
 
 	/**
+	 * Return safe metadata captured from a provider HTTP failure.
+	 *
+	 * Response bodies and provider messages are deliberately excluded. The
+	 * returned scalars can be copied onto the terminal error for the durable-job
+	 * diagnostic after the runtime context is cleared.
+	 *
+	 * @return array<string, int|string> Prompt-free failure metadata.
+	 */
+	public static function get_runtime_failure_metadata(): array {
+		$metadata = array();
+		if ( self::$runtimeContext['failure_status_code'] > 0 ) {
+			$metadata['status_code'] = self::$runtimeContext['failure_status_code'];
+		}
+		if ( '' !== self::$runtimeContext['failure_class'] ) {
+			$metadata['failure_class'] = self::$runtimeContext['failure_class'];
+		}
+		if ( '' !== self::$runtimeContext['failure_source'] ) {
+			$metadata['failure_source'] = self::$runtimeContext['failure_source'];
+		}
+		if ( self::$runtimeContext['attempt'] > 0 ) {
+			$metadata['attempts'] = self::$runtimeContext['attempt'];
+		}
+		if ( '' !== self::$runtimeContext['correlation_id'] ) {
+			$metadata['correlation_id'] = self::$runtimeContext['correlation_id'];
+		}
+
+		return $metadata;
+	}
+
+	/**
 	 * Hook: pre_http_request — capture outgoing request details.
 	 *
 	 * @param false|array<string, mixed>|\WP_Error $response    A preemptive return value of an HTTP request. Default false.
@@ -227,15 +296,16 @@ class ProviderTraceLogger {
 			return $response;
 		}
 
-		$request_body  = is_string( $parsed_args['body'] ?? null )
-			? $parsed_args['body']
-			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
 		$trace_enabled = ProviderTrace::is_enabled();
 		$has_context   = '' !== self::$runtimeContext['provider_id'];
 
 		if ( ! $trace_enabled && ! $has_context ) {
 			return $response;
 		}
+
+		$request_body = is_string( $parsed_args['body'] ?? null )
+			? $parsed_args['body']
+			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
 
 		// Runtime attribution is set only around the synchronous SDK provider
 		// invocation. Trust it for local enforcement so a trace callback cannot
@@ -358,6 +428,10 @@ class ProviderTraceLogger {
 		self::$inflight[ $url ] = [
 			'provider_id'     => $provider_id,
 			'model_id'        => $model_id,
+			'session_id'      => self::$runtimeContext['session_id'],
+			'attempt'         => self::$runtimeContext['attempt'],
+			'phase'           => self::$runtimeContext['phase'],
+			'correlation_id'  => self::$runtimeContext['correlation_id'],
 			'url'             => $url,
 			'method'          => strtoupper( $parsed_args['method'] ?? 'POST' ),
 			'request_headers' => self::extract_headers( $parsed_args['headers'] ?? [] ),
@@ -385,59 +459,81 @@ class ProviderTraceLogger {
 	 * @return array<string, mixed> Unchanged response.
 	 */
 	public static function on_http_response( array $response, array $parsed_args, string $url ): array {
+		$trace_enabled          = ProviderTrace::is_enabled();
+		$has_context            = '' !== self::$runtimeContext['provider_id'];
+		$canonical_provider_id  = self::match_provider( $url );
+		if ( ! $trace_enabled && ! $has_context && '' === $canonical_provider_id ) {
+			return $response;
+		}
+
 		$request_body = is_string( $parsed_args['body'] ?? null )
 			? $parsed_args['body']
 			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
-		$has_context  = '' !== self::$runtimeContext['provider_id'];
+		$status_code  = (int) wp_remote_retrieve_response_code( $response );
+		$response_body_for_classification = $status_code >= 400
+			? (string) wp_remote_retrieve_body( $response )
+			: '';
+		$failure_class = $status_code >= 400 && ProviderErrorClassifier::is_gateway_rejection_response( $status_code, $response_body_for_classification )
+			? ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION
+			: '';
+
+		if ( $has_context && $status_code >= 400 ) {
+			self::$runtimeContext['failure_status_code'] = $status_code;
+			self::$runtimeContext['failure_class']       = $failure_class;
+			self::$runtimeContext['failure_source']      = 'http';
+		}
 
 		// Lightweight error-log path: emit a greppable line for 4xx/5xx
 		// responses from canonical AI providers regardless of debug mode.
 		// Uses the strict allowlist so unrelated 4xx responses (update
 		// checks, WP.org, etc.) never produce noise here.
-		$canonical_provider_id = self::match_provider( $url );
-		$request_provider_id   = $has_context ? self::$runtimeContext['provider_id'] : $canonical_provider_id;
-		if ( '' !== $request_provider_id ) {
-			$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
-			if ( $status_code_for_log >= 400 ) {
-				$model_id_for_log = self::$runtimeContext['model_id'];
-				if ( '' === $model_id_for_log ) {
-					$model_id_for_log = self::extract_model_id( $request_body );
-				}
-				$request_bytes = strlen( $request_body );
-				$byte_budget   = ConversationTrimmer::get_request_envelope_byte_budget( $request_provider_id, $model_id_for_log );
+		$request_provider_id = $has_context ? self::$runtimeContext['provider_id'] : $canonical_provider_id;
+		if ( '' !== $request_provider_id && $status_code >= 400 ) {
+			$model_id_for_log = self::$runtimeContext['model_id'];
+			if ( '' === $model_id_for_log ) {
+				$model_id_for_log = self::extract_model_id( $request_body );
+			}
+			$request_bytes = strlen( $request_body );
+			$byte_budget   = ConversationTrimmer::get_request_envelope_byte_budget( $request_provider_id, $model_id_for_log );
 
-				if ( 413 === $status_code_for_log ) {
-					self::record_payload_limit(
-						$request_provider_id,
-						$model_id_for_log,
-						$status_code_for_log,
-						$request_bytes,
-						(int) ceil( $request_bytes / 4 ),
-						$byte_budget,
-						false,
-						false,
-						false,
-						'upstream_413'
-					);
-				} else {
-					AgentEventLog::log(
-						'provider_http_error',
-						AgentEventLog::SEVERITY_ERROR,
-						array(
-							'provider_id'             => $request_provider_id,
-							'model_id'                => $model_id_for_log,
-							'status_code'             => $status_code_for_log,
-							'request_bytes'           => $request_bytes,
-							'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
-							'request_size_class'      => self::classify_request_size( $request_bytes ),
-							'request_size_source'     => 'http_body',
-						)
-					);
+			if ( 413 === $status_code ) {
+				self::record_payload_limit(
+					$request_provider_id,
+					$model_id_for_log,
+					$status_code,
+					$request_bytes,
+					(int) ceil( $request_bytes / 4 ),
+					$byte_budget,
+					false,
+					false,
+					false,
+					'upstream_413'
+				);
+			} else {
+				$log_context = array(
+					'provider_id'             => $request_provider_id,
+					'model_id'                => $model_id_for_log,
+					'status_code'             => $status_code,
+					'request_bytes'           => $request_bytes,
+					'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
+					'request_size_class'      => self::classify_request_size( $request_bytes ),
+					'request_size_source'     => 'http_body',
+				);
+				if ( $has_context && self::$runtimeContext['attempt'] > 0 ) {
+					$log_context['attempts'] = self::$runtimeContext['attempt'];
 				}
+				if ( $has_context && '' !== self::$runtimeContext['correlation_id'] ) {
+					$log_context['correlation_id'] = self::$runtimeContext['correlation_id'];
+				}
+				if ( '' !== $failure_class ) {
+					$log_context['reason'] = $failure_class;
+				}
+
+				AgentEventLog::log( 'provider_http_error', AgentEventLog::SEVERITY_ERROR, $log_context );
 			}
 		}
 
-		if ( ! ProviderTrace::is_enabled() ) {
+		if ( ! $trace_enabled ) {
 			return $response;
 		}
 
@@ -455,8 +551,9 @@ class ProviderTraceLogger {
 		$start_time  = (float) ( $inflight['start_time'] ?? microtime( true ) );
 		$duration_ms = (int) round( ( microtime( true ) - $start_time ) * 1000 );
 
-		$status_code      = (int) wp_remote_retrieve_response_code( $response );
-		$response_body    = wp_remote_retrieve_body( $response );
+		$response_body    = '' !== $response_body_for_classification
+			? $response_body_for_classification
+			: (string) wp_remote_retrieve_body( $response );
 		$response_headers = wp_remote_retrieve_headers( $response );
 
 		// Extract model_id from request body if possible.
@@ -523,7 +620,7 @@ class ProviderTraceLogger {
 		$trace_request_body     = $inflight['request_body'] ?? '';
 		$trace_response_headers = $response_headers_json;
 		$trace_response_body    = $response_body;
-		if ( 413 === $status_code ) {
+		if ( 413 === $status_code || ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION === $failure_class ) {
 			$request_bytes          = strlen( (string) $trace_request_body );
 			$trace_url              = self::safe_trace_url( (string) $trace_url );
 			$trace_request_headers  = '{}';
@@ -536,7 +633,29 @@ class ProviderTraceLogger {
 			);
 			$trace_response_headers = '{}';
 			$trace_response_body    = '';
-			$error                  = 'HTTP 413';
+
+			if ( ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION === $failure_class ) {
+				$gateway_diagnostic = array(
+					'event'           => 'provider_gateway_rejection',
+					'failure_class'   => $failure_class,
+					'failure_source'  => 'http',
+					'status_code'     => $status_code,
+					'session_id'      => max( 0, (int) ( $inflight['session_id'] ?? 0 ) ),
+				);
+				if ( (int) ( $inflight['attempt'] ?? 0 ) > 0 ) {
+					$gateway_diagnostic['attempts'] = min( 10, (int) $inflight['attempt'] );
+				}
+				if ( '' !== (string) ( $inflight['phase'] ?? '' ) ) {
+					$gateway_diagnostic['phase'] = (string) $inflight['phase'];
+				}
+				if ( '' !== (string) ( $inflight['correlation_id'] ?? '' ) ) {
+					$gateway_diagnostic['correlation_id'] = (string) $inflight['correlation_id'];
+				}
+				$trace_response_body = (string) wp_json_encode( $gateway_diagnostic );
+				$error               = 'provider_gateway_rejection';
+			} else {
+				$error = 'HTTP 413';
+			}
 		}
 
 		ProviderTrace::insert(
@@ -715,6 +834,7 @@ class ProviderTraceLogger {
 		$diagnostics = array(
 			'event'                  => 'provider_retry_exhausted',
 			'error_code'             => ProviderErrorClassifier::get_safe_error_code( $error, $status_code ),
+			'failure_source'         => $status_code >= 400 ? 'http' : 'transport',
 			'attempts'               => max( 1, $attempts ),
 			'elapsed_ms'             => max( 0, $elapsed_ms ),
 			'phase'                  => $phase,
@@ -724,8 +844,13 @@ class ProviderTraceLogger {
 		if ( null !== $retry_after_seconds ) {
 			$diagnostics['retry_after_seconds'] = min( 60, max( 0, $retry_after_seconds ) );
 		}
+		$failure_class = ProviderErrorClassifier::get_safe_failure_class( $error, $status_code );
+		if ( '' !== $failure_class ) {
+			$diagnostics['failure_class'] = $failure_class;
+		}
 		if ( '' !== $job_id ) {
 			$diagnostics['job_id'] = sanitize_text_field( $job_id );
+			$diagnostics['correlation_id'] = self::job_correlation_id( $job_id );
 		}
 
 		ProviderTrace::insert(
@@ -758,6 +883,13 @@ class ProviderTraceLogger {
 		}
 
 		return 'very_large';
+	}
+
+	/** Build a stable, non-reversible support correlation ID for an active job. */
+	private static function job_correlation_id( string $job_id ): string {
+		$job_id = sanitize_text_field( $job_id );
+
+		return '' === $job_id ? '' : 'job-' . substr( hash( 'sha256', $job_id ), 0, 12 );
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -164,7 +164,7 @@ class ProviderTraceLogger {
 	): void {
 		$has_valid_managed_attribution = SuperdavManagedRequestIdentifiers::is_journey_id( $journey_id )
 			&& SuperdavManagedRequestIdentifiers::is_idempotency_key( $idempotency_key );
-		$allowed_phases                 = array( 'initial_provider_call', 'client_tool_resume', 'provider_followup_call' );
+		$allowed_phases                = array( 'initial_provider_call', 'client_tool_resume', 'provider_followup_call' );
 		self::$runtimeContext          = array(
 			'provider_id'                  => sanitize_key( $provider_id ),
 			'model_id'                     => sanitize_text_field( $model_id ),
@@ -459,21 +459,21 @@ class ProviderTraceLogger {
 	 * @return array<string, mixed> Unchanged response.
 	 */
 	public static function on_http_response( array $response, array $parsed_args, string $url ): array {
-		$trace_enabled          = ProviderTrace::is_enabled();
-		$has_context            = '' !== self::$runtimeContext['provider_id'];
-		$canonical_provider_id  = self::match_provider( $url );
+		$trace_enabled         = ProviderTrace::is_enabled();
+		$has_context           = '' !== self::$runtimeContext['provider_id'];
+		$canonical_provider_id = self::match_provider( $url );
 		if ( ! $trace_enabled && ! $has_context && '' === $canonical_provider_id ) {
 			return $response;
 		}
 
-		$request_body = is_string( $parsed_args['body'] ?? null )
+		$request_body                     = is_string( $parsed_args['body'] ?? null )
 			? $parsed_args['body']
 			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
-		$status_code  = (int) wp_remote_retrieve_response_code( $response );
+		$status_code                      = (int) wp_remote_retrieve_response_code( $response );
 		$response_body_for_classification = $status_code >= 400
 			? (string) wp_remote_retrieve_body( $response )
 			: '';
-		$failure_class = $status_code >= 400 && ProviderErrorClassifier::is_gateway_rejection_response( $status_code, $response_body_for_classification )
+		$failure_class                    = $status_code >= 400 && ProviderErrorClassifier::is_gateway_rejection_response( $status_code, $response_body_for_classification )
 			? ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION
 			: '';
 
@@ -636,11 +636,11 @@ class ProviderTraceLogger {
 
 			if ( ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION === $failure_class ) {
 				$gateway_diagnostic = array(
-					'event'           => 'provider_gateway_rejection',
-					'failure_class'   => $failure_class,
-					'failure_source'  => 'http',
-					'status_code'     => $status_code,
-					'session_id'      => max( 0, (int) ( $inflight['session_id'] ?? 0 ) ),
+					'event'          => 'provider_gateway_rejection',
+					'failure_class'  => $failure_class,
+					'failure_source' => 'http',
+					'status_code'    => $status_code,
+					'session_id'     => max( 0, (int) ( $inflight['session_id'] ?? 0 ) ),
 				);
 				if ( (int) ( $inflight['attempt'] ?? 0 ) > 0 ) {
 					$gateway_diagnostic['attempts'] = min( 10, (int) $inflight['attempt'] );
@@ -849,7 +849,7 @@ class ProviderTraceLogger {
 			$diagnostics['failure_class'] = $failure_class;
 		}
 		if ( '' !== $job_id ) {
-			$diagnostics['job_id'] = sanitize_text_field( $job_id );
+			$diagnostics['job_id']         = sanitize_text_field( $job_id );
 			$diagnostics['correlation_id'] = self::job_correlation_id( $job_id );
 		}
 

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3846,7 +3846,7 @@ final class SessionController {
 			$diagnostic = $this->persist_active_job_failure(
 				$job_id,
 				$job,
-				ActiveJobFailureDiagnostic::reason_from_error( $result, $failure_data['provider_id'] ),
+				ActiveJobFailureDiagnostic::reason_from_error( $result, (string) $failure_data['provider_id'] ),
 				$failure_data
 			);
 			$this->record_public_chat_review_status( $job, 'failed', (string) $diagnostic['reason'] );

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -69,6 +69,7 @@ const {
 const { buildFailedJobActivityMessage } = require( '../slices/jobSlice' );
 const {
 	buildActiveJobFailureCard,
+	getActiveJobFailureMessage,
 	normalizeActiveJobFailureDiagnostic,
 } = require( '../slices/active-job-failure-diagnostic' );
 const apiFetch = require( '@wordpress/api-fetch' );
@@ -774,6 +775,28 @@ describe( 'actions', () => {
 			next_action: 'contact_support',
 			correlation_id: '',
 		} );
+	} );
+
+	test( 'gateway rejection uses a safe support action without security-disable guidance', () => {
+		const diagnostic = normalizeActiveJobFailureDiagnostic( {
+			reason: 'gateway_rejection',
+			next_action: 'contact_support',
+			message: 'PRIVATE_PROVIDER_MESSAGE',
+			response_body: '<html>Imunify360 PRIVATE_PROVIDER_RESPONSE</html>',
+			prompt: 'PRIVATE_PROMPT_CONTENT',
+		} );
+
+		expect( diagnostic ).toEqual( {
+			reason: 'gateway_rejection',
+			last_safe_phase: '',
+			retryable: false,
+			next_action: 'contact_support',
+			correlation_id: '',
+		} );
+		const message = getActiveJobFailureMessage( diagnostic );
+		expect( message ).toContain( 'security gateway' );
+		expect( message ).not.toContain( 'disable' );
+		expect( message ).not.toContain( 'PRIVATE_PROVIDER' );
 	} );
 
 	test( 'pollJob starts only one poller for the same session and job', async () => {

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -770,7 +770,11 @@ describe( 'actions', () => {
 			} )
 		).toEqual( {
 			reason: 'unknown',
+			status_code: 0,
+			failure_class: '',
+			failure_source: '',
 			last_safe_phase: '',
+			attempts: 0,
 			retryable: false,
 			next_action: 'contact_support',
 			correlation_id: '',
@@ -780,6 +784,10 @@ describe( 'actions', () => {
 	test( 'gateway rejection uses a safe support action without security-disable guidance', () => {
 		const diagnostic = normalizeActiveJobFailureDiagnostic( {
 			reason: 'gateway_rejection',
+			status_code: 403,
+			failure_class: 'gateway_rejection',
+			failure_source: 'http',
+			attempts: 1,
 			next_action: 'contact_support',
 			message: 'PRIVATE_PROVIDER_MESSAGE',
 			response_body: '<html>Imunify360 PRIVATE_PROVIDER_RESPONSE</html>',
@@ -788,7 +796,11 @@ describe( 'actions', () => {
 
 		expect( diagnostic ).toEqual( {
 			reason: 'gateway_rejection',
+			status_code: 403,
+			failure_class: 'gateway_rejection',
+			failure_source: 'http',
 			last_safe_phase: '',
+			attempts: 1,
 			retryable: false,
 			next_action: 'contact_support',
 			correlation_id: '',

--- a/src/store/slices/active-job-failure-diagnostic.js
+++ b/src/store/slices/active-job-failure-diagnostic.js
@@ -17,6 +17,7 @@ const ACTIVE_JOB_FAILURE_REASONS = [
 	'local_payload_guard',
 	'upstream_payload_rejection',
 	'provider_timeout',
+	'gateway_rejection',
 	'credit_exhausted',
 	'worker_terminated',
 	'approval_wait',
@@ -121,6 +122,11 @@ export function getActiveJobFailureMessage( diagnostic ) {
 		case 'provider_timeout':
 			return __(
 				'The AI provider timed out before finishing. Retry the request shortly.',
+				'superdav-ai-agent'
+			);
+		case 'gateway_rejection':
+			return __(
+				'The AI request was rejected by an upstream security gateway. Verify that the provider endpoint is allowed by your hosting or network policy, then retry. If it continues, contact support with the correlation ID.',
 				'superdav-ai-agent'
 			);
 		case 'credit_exhausted':

--- a/src/store/slices/active-job-failure-diagnostic.js
+++ b/src/store/slices/active-job-failure-diagnostic.js
@@ -68,10 +68,35 @@ export function normalizeActiveJobFailureDiagnostic( diagnostic ) {
 		/^job-(?:[a-f0-9]{12}|unknown)$/.test( source.correlation_id )
 			? source.correlation_id
 			: '';
+	const statusCode =
+		Number.isInteger( source.status_code ) &&
+		source.status_code >= 400 &&
+		source.status_code <= 599
+			? source.status_code
+			: 0;
+	const failureClass =
+		source.failure_class === 'gateway_rejection'
+			? source.failure_class
+			: '';
+	const failureSource = [ 'http', 'transport' ].includes(
+		source.failure_source
+	)
+		? source.failure_source
+		: '';
+	const attempts =
+		Number.isInteger( source.attempts ) &&
+		source.attempts >= 0 &&
+		source.attempts <= 10
+			? source.attempts
+			: 0;
 
 	return {
 		reason,
+		status_code: statusCode,
+		failure_class: failureClass,
+		failure_source: failureSource,
 		last_safe_phase: phase,
+		attempts,
 		retryable: source.retryable === true,
 		next_action: nextAction,
 		correlation_id: correlationId,

--- a/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
@@ -99,6 +99,14 @@ class ActiveJobFailureDiagnosticTest extends WP_UnitTestCase {
 				),
 				ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT,
 			),
+			'gateway rejection'         => array(
+				new \WP_Error(
+					'provider_http_error',
+					'<html><title>Imunify360</title>Request blocked. PRIVATE_PROMPT_CONTENT Authorization: Bearer PRIVATE_TOKEN</html>',
+					array( 'status_code' => 403 )
+				),
+				ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION,
+			),
 			'unknown provider error'    => array(
 				new \WP_Error(
 					'provider_unexpected_error',
@@ -106,6 +114,65 @@ class ActiveJobFailureDiagnosticTest extends WP_UnitTestCase {
 				),
 				ActiveJobFailureDiagnostic::REASON_UNKNOWN,
 			),
+		);
+	}
+
+	public function test_gateway_rejection_diagnostic_keeps_only_allowlisted_metadata(): void {
+		$job_id = '88888888-9999-0000-1111-222222222222';
+		$error  = new \WP_Error(
+			'provider_http_error',
+			'<html><title>Imunify360</title>Blocked PRIVATE_PROMPT_CONTENT Authorization: Bearer PRIVATE_TOKEN</html>',
+			array(
+				'status_code'     => 403,
+				'failure_class'   => 'gateway_rejection',
+				'failure_source'  => 'http',
+				'attempts'        => 1,
+				'provider_id'     => 'sd-ai-agent-cloud',
+				'model_id'        => 'managed-model',
+				'response_body'   => 'PRIVATE_PROVIDER_RESPONSE',
+				'prompt'          => 'PRIVATE_PROMPT_CONTENT',
+				'authorization'   => 'Bearer PRIVATE_TOKEN',
+				'exception_trace' => '/private/path.php:99',
+			)
+		);
+		$context = ActiveJobFailureDiagnostic::context_from_error_data( (array) $error->get_error_data() );
+		$context['last_safe_phase'] = 'before_provider_call';
+		$diagnostic                  = ActiveJobFailureDiagnostic::create(
+			$job_id,
+			ActiveJobFailureDiagnostic::reason_from_error( $error, 'sd-ai-agent-cloud' ),
+			$context
+		);
+		$encoded                     = ActiveJobFailureDiagnostic::encode( $job_id, $diagnostic );
+		$rest                        = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION, $rest['reason'] );
+		$this->assertSame( 403, $rest['status_code'] );
+		$this->assertSame( 'gateway_rejection', $rest['failure_class'] );
+		$this->assertSame( 'http', $rest['failure_source'] );
+		$this->assertSame( 1, $rest['attempts'] );
+		$this->assertFalse( $rest['retryable'] );
+		$this->assertSame( 'contact_support', $rest['next_action'] );
+		$this->assertStringNotContainsString( 'PRIVATE_PROVIDER_RESPONSE', $encoded );
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', $encoded );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $encoded );
+		$this->assertStringNotContainsString( '/private/path.php', $encoded );
+		$this->assertSame(
+			array(
+				'reason',
+				'status_code',
+				'failure_class',
+				'failure_source',
+				'last_safe_phase',
+				'attempts',
+				'resume_count',
+				'provider_id',
+				'model_id',
+				'request_size_class',
+				'retryable',
+				'next_action',
+				'correlation_id',
+			),
+			array_keys( $rest )
 		);
 	}
 
@@ -131,6 +198,7 @@ class ActiveJobFailureDiagnosticTest extends WP_UnitTestCase {
 			ActiveJobFailureDiagnostic::REASON_LOCAL_PAYLOAD_GUARD        => array( 'compact', false ),
 			ActiveJobFailureDiagnostic::REASON_UPSTREAM_PAYLOAD_REJECTION => array( 'compact', false ),
 			ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT           => array( 'retry', true ),
+			ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION          => array( 'contact_support', false ),
 			ActiveJobFailureDiagnostic::REASON_CREDIT_EXHAUSTED           => array( 'purchase_credits', false ),
 			ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED          => array( 'retry', true ),
 			ActiveJobFailureDiagnostic::REASON_APPROVAL_WAIT              => array( 'approve_review', true ),

--- a/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
@@ -107,6 +107,14 @@ class ActiveJobFailureDiagnosticTest extends WP_UnitTestCase {
 				),
 				ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION,
 			),
+			'generic WAF rejection'     => array(
+				new \WP_Error(
+					'provider_http_error',
+					'Web application firewall blocked PRIVATE_PROMPT_CONTENT.',
+					array( 'status_code' => 403 )
+				),
+				ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION,
+			),
 			'unknown provider error'    => array(
 				new \WP_Error(
 					'provider_unexpected_error',

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1255,6 +1255,38 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $retry_entries );
 	}
 
+	public function test_run_classifies_imunify_gateway_rejection_without_retrying(): void {
+		$this->skip_if_sdk_unavailable();
+		$call_count = 0;
+		$this->mock_ai_response_sequence(
+			[
+				[
+					'status'  => 403,
+					'message' => 'Forbidden',
+					'body'    => '<html><title>Imunify360</title>Security gateway blocked PRIVATE_PROMPT_CONTENT Authorization: Bearer PRIVATE_TOKEN</html>',
+				],
+			],
+			$call_count
+		);
+
+		$result = ( new AgentLoop( 'PRIVATE_PROMPT_CONTENT', [], [], $this->no_sleep_retry_options( 3 ) ) )->run();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 1, $call_count, 'A security-gateway rejection must not use timeout retries.' );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 403, $data['status_code'] );
+		$this->assertSame( 'gateway_rejection', $data['failure_class'] );
+		$this->assertSame( 'http', $data['failure_source'] );
+		$this->assertSame( 1, $data['attempts'] );
+		$this->assertSame(
+			ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION,
+			ActiveJobFailureDiagnostic::reason_from_error( $result )
+		);
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', (string) wp_json_encode( $data ) );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', (string) wp_json_encode( $data ) );
+	}
+
 	/** A large exhausted request compacts and retries without browser recovery. */
 	public function test_large_provider_retry_exhaustion_compacts_and_recovers_automatically(): void {
 		$session_id = Database::create_session(

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1272,6 +1272,10 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$result = ( new AgentLoop( 'PRIVATE_PROMPT_CONTENT', [], [], $this->no_sleep_retry_options( 3 ) ) )->run();
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_gateway_rejection', $result->get_error_code() );
+		$this->assertStringContainsString( 'upstream security gateway', $result->get_error_message() );
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', $result->get_error_message() );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $result->get_error_message() );
 		$this->assertSame( 1, $call_count, 'A security-gateway rejection must not use timeout retries.' );
 		$data = $result->get_error_data();
 		$this->assertIsArray( $data );
@@ -1285,6 +1289,32 @@ class AgentLoopTest extends WP_UnitTestCase {
 		);
 		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', (string) wp_json_encode( $data ) );
 		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', (string) wp_json_encode( $data ) );
+	}
+
+	public function test_runtime_gateway_metadata_replaces_opaque_provider_exception(): void {
+		$method = new \ReflectionMethod( AgentLoop::class, 'normalize_runtime_gateway_exception' );
+		$method->setAccessible( true );
+		$result = $method->invoke(
+			new AgentLoop( 'PRIVATE_PROMPT_CONTENT' ),
+			new \RuntimeException( 'PRIVATE_PROVIDER_EXCEPTION with Authorization: Bearer PRIVATE_TOKEN' ),
+			array(
+				'status_code'    => 403,
+				'failure_class'  => 'gateway_rejection',
+				'failure_source' => 'http',
+				'attempts'       => 1,
+				'correlation_id' => 'job-0123456789ab',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_gateway_rejection', $result->get_error_code() );
+		$this->assertStringContainsString( 'upstream security gateway', $result->get_error_message() );
+		$this->assertStringNotContainsString( 'PRIVATE_PROVIDER_EXCEPTION', $result->get_error_message() );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', (string) wp_json_encode( $data ) );
+		$this->assertSame( 403, $data['status_code'] );
+		$this->assertSame( 'gateway_rejection', $data['failure_class'] );
 	}
 
 	/** A large exhausted request compacts and retries without browser recovery. */

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Bootstrap\HttpTraceHandler;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Models\ProviderTrace;
@@ -387,6 +388,110 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 			)
 		);
 		$this->assertNull( $body_seen, 'Disabled tracing must not pass 413 prompt bodies to trace resolution filters.' );
+	}
+
+	public function test_gateway_response_writes_only_bounded_terminal_trace_metadata(): void {
+		ProviderTrace::set_enabled( true );
+		ProviderTrace::clear();
+		$job_id       = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+		$request_body = (string) wp_json_encode(
+			array(
+				'model'    => 'gpt-test',
+				'messages' => array( array( 'content' => 'PRIVATE_HTTP_PROMPT' ) ),
+			)
+		);
+		$url          = 'https://api.openai.com/v1/chat/completions';
+		$response     = array(
+			'headers'  => array( 'server' => 'imunify360', 'x-private-token' => 'PRIVATE_HEADER_TOKEN' ),
+			'body'     => '<html><title>Imunify360</title>Security gateway blocked PRIVATE_PROVIDER_RESPONSE Authorization: Bearer PRIVATE_TOKEN</html>',
+			'response' => array( 'code' => 403, 'message' => 'Forbidden' ),
+			'cookies'  => array(),
+			'filename' => '',
+		);
+
+		ProviderTraceLogger::set_runtime_context(
+			'openai',
+			'gpt-test',
+			73,
+			0,
+			'',
+			'',
+			'',
+			1,
+			$job_id,
+			'initial_provider_call'
+		);
+		ProviderTraceLogger::on_pre_http_request( false, array( 'body' => $request_body ), $url );
+		ProviderTraceLogger::on_http_response( $response, array( 'body' => $request_body ), $url );
+
+		$metadata = ProviderTraceLogger::get_runtime_failure_metadata();
+		$this->assertSame( 403, $metadata['status_code'] );
+		$this->assertSame( 'gateway_rejection', $metadata['failure_class'] );
+		$this->assertSame( 'http', $metadata['failure_source'] );
+		$this->assertSame( 1, $metadata['attempts'] );
+		$this->assertMatchesRegularExpression( '/^job-[a-f0-9]{12}$/', $metadata['correlation_id'] );
+
+		$rows = ProviderTrace::list( array( 'limit' => 1 ) );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 403, $rows[0]->status_code );
+		$this->assertSame( 'provider_gateway_rejection', $rows[0]->error );
+		$trace = ProviderTrace::get( $rows[0]->id );
+		$this->assertNotNull( $trace );
+		$this->assertSame( '{}', $trace->request_headers );
+		$this->assertSame( '{}', $trace->response_headers );
+		$terminal_metadata = json_decode( $trace->response_body, true );
+		$this->assertIsArray( $terminal_metadata );
+		$this->assertSame( 'provider_gateway_rejection', $terminal_metadata['event'] );
+		$this->assertSame( 'gateway_rejection', $terminal_metadata['failure_class'] );
+		$this->assertSame( 'http', $terminal_metadata['failure_source'] );
+		$this->assertSame( 1, $terminal_metadata['attempts'] );
+		$this->assertMatchesRegularExpression( '/^job-[a-f0-9]{12}$/', $terminal_metadata['correlation_id'] );
+		$persisted_trace = (string) wp_json_encode( $trace );
+		$this->assertStringNotContainsString( 'PRIVATE_HTTP_PROMPT', $persisted_trace );
+		$this->assertStringNotContainsString( 'PRIVATE_PROVIDER_RESPONSE', $persisted_trace );
+		$this->assertStringNotContainsString( 'PRIVATE_HEADER_TOKEN', $persisted_trace );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $persisted_trace );
+	}
+
+	public function test_http_trace_handler_captures_gateway_metadata_without_debug_tracing(): void {
+		ProviderTrace::set_enabled( false );
+		ProviderTraceLogger::set_runtime_context(
+			'openai',
+			'gpt-test',
+			73,
+			0,
+			'',
+			'',
+			'',
+			2,
+			'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+			'provider_followup_call'
+		);
+
+		$handler = new HttpTraceHandler();
+		$handler->on_http_response(
+			array(
+				'headers'  => array(),
+				'body'     => 'Imunify360 rejected PRIVATE_PROVIDER_RESPONSE.',
+				'response' => array( 'code' => 403, 'message' => 'Forbidden' ),
+				'cookies'  => array(),
+				'filename' => '',
+			),
+			array( 'body' => '{"model":"gpt-test"}' ),
+			'https://api.openai.com/v1/chat/completions'
+		);
+
+		$this->assertSame(
+			array(
+				'status_code'    => 403,
+				'failure_class'  => 'gateway_rejection',
+				'failure_source' => 'http',
+				'attempts'       => 2,
+				'correlation_id' => 'job-' . substr( hash( 'sha256', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' ), 0, 12 ),
+			),
+			ProviderTraceLogger::get_runtime_failure_metadata()
+		);
+		$this->assertCount( 0, ProviderTrace::list( array( 'limit' => 1 ) ) );
 	}
 
 	/** Retry exhaustion has one prompt-free terminal trace even when transport callbacks never run. */

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -437,8 +437,8 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 		$this->assertSame( 'provider_gateway_rejection', $rows[0]->error );
 		$trace = ProviderTrace::get( $rows[0]->id );
 		$this->assertNotNull( $trace );
-		$this->assertSame( '{}', $trace->request_headers );
-		$this->assertSame( '{}', $trace->response_headers );
+		$this->assertSame( '[]', $trace->request_headers );
+		$this->assertSame( '[]', $trace->response_headers );
 		$terminal_metadata = json_decode( $trace->response_body, true );
 		$this->assertIsArray( $terminal_metadata );
 		$this->assertSame( 'provider_gateway_rejection', $terminal_metadata['event'] );

--- a/tests/SdAiAgent/REST/SessionControllerTest.php
+++ b/tests/SdAiAgent/REST/SessionControllerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Core\BackgroundJobDispatcher;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\DurablePlanRunner;
 use SdAiAgent\Models\ActiveJobRepository;
@@ -550,6 +551,51 @@ class SessionControllerTest extends WP_UnitTestCase {
 			$this->assertSame( $case['plan_status'], $updated['status'] );
 			$this->assertSame( $case['step_status'], $updated['steps'][0]['status'] );
 		}
+	}
+
+	public function test_gateway_failure_job_status_returns_only_the_allowlisted_diagnostic(): void {
+		$session_id = $this->create_session();
+		$job_id     = '00000000-0000-4000-8000-000000000104';
+		$this->assertNotFalse( ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' ) );
+		ActiveJobRepository::record_failure(
+			$job_id,
+			'error',
+			ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION,
+			array(
+				'last_safe_phase' => 'before_provider_call',
+				'provider_id'     => 'sd-ai-agent-cloud',
+				'model_id'        => 'managed-model',
+				'status_code'     => 403,
+				'failure_class'   => 'gateway_rejection',
+				'failure_source'  => 'http',
+				'attempts'        => 1,
+				'response_body'   => '<html>Imunify360 PRIVATE_PROVIDER_RESPONSE</html>',
+				'prompt'          => 'PRIVATE_PROMPT_CONTENT',
+				'authorization'   => 'Bearer PRIVATE_TOKEN',
+				'trace'           => '/private/path.php:99',
+			)
+		);
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $response );
+		$data = $response->get_data();
+
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_GATEWAY_REJECTION, $data['diagnostic']['reason'] );
+		$this->assertSame( 403, $data['diagnostic']['status_code'] );
+		$this->assertSame( 'gateway_rejection', $data['diagnostic']['failure_class'] );
+		$this->assertSame( 'http', $data['diagnostic']['failure_source'] );
+		$this->assertSame( 1, $data['diagnostic']['attempts'] );
+		$this->assertSame( 'contact_support', $data['diagnostic']['next_action'] );
+		$this->assertFalse( $data['diagnostic']['retryable'] );
+		$this->assertStringContainsString( 'security gateway', $data['message'] );
+		$this->assertStringNotContainsString( 'disable', strtolower( $data['message'] ) );
+		$payload = (string) wp_json_encode( $data );
+		$this->assertStringNotContainsString( 'PRIVATE_PROVIDER_RESPONSE', $payload );
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', $payload );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $payload );
+		$this->assertStringNotContainsString( '/private/path.php', $payload );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
 
 	/** Completed job and persisted-session display projections hide textual reasoning. */


### PR DESCRIPTION
Closes #2682

## Summary

- Classify upstream Imunify360/WAF gateway rejections instead of reporting them as provider timeouts.
- Return bounded, allowlisted diagnostics and actionable support guidance without exposing prompts, tokens, response bodies, or private provider data.
- Preserve safe gateway metadata in traces and job-status responses while preventing retries for blocked requests.

## Verification

- PHP: 4,387 tests, 20,454 assertions passed.
- JavaScript: 64 suites, 618 tests passed.
- PHPCS and PHPStan passed.
- JavaScript lint, production build, and bundle-size checks passed.
- GitHub PHPUnit, static analysis, lint, build, and all three Playwright shards passed.

## Safety

Raw upstream response content remains transient and is excluded from durable diagnostics and UI payloads.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 13h 6m and 1,748,463 tokens on this with the user in an interactive session.