### PR TITLE
GH#2694: fix: make schema upgrades idempotent

### DIFF
--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -484,7 +484,10 @@ class Database {
 			KEY enabled (enabled)
 		) {$charset};
 
-		CREATE TABLE {$automations_table} (
+		";
+
+		if ( ! self::table_exists( $automations_table ) ) {
+			$sql .= "CREATE TABLE {$automations_table} (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			name varchar(255) NOT NULL,
 			description text NOT NULL DEFAULT '',
@@ -523,9 +526,11 @@ class Database {
 			KEY owner_user_id (owner_user_id),
 			KEY active_run_id (active_run_id),
 			KEY lease_status (execution_status, lease_expires_at)
-		) ENGINE=InnoDB {$charset};
+		) ENGINE=InnoDB {$charset};";
+		}
 
-		CREATE TABLE {$automation_logs_table} (
+		if ( ! self::table_exists( $automation_logs_table ) ) {
+			$sql .= "\n\nCREATE TABLE {$automation_logs_table} (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			automation_id bigint(20) unsigned NOT NULL DEFAULT 0,
 			run_id char(36) NOT NULL DEFAULT '',
@@ -552,7 +557,10 @@ class Database {
 			KEY monitor_outcome (monitor_outcome),
 			KEY created_at (created_at),
 			KEY lifecycle_lease (lifecycle_status, lease_expires_at)
-		) ENGINE=InnoDB {$charset};
+		) ENGINE=InnoDB {$charset};";
+		}
+
+		$sql .= "
 
 		CREATE TABLE {$monitor_wakes_table} (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -1053,6 +1061,7 @@ class Database {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+		$automation_schema_ready = self::ensure_automation_schema( $automations_table, $automation_logs_table );
 		self::backfill_session_trash_timestamps();
 		// Automation execution fails closed independently through
 		// has_transactional_automation_storage(), so a failed conversion must not
@@ -1090,8 +1099,219 @@ class Database {
 		// Seed built-in agents (onboarding, general, content-creator, seo, ecommerce).
 		Agent::seed_defaults();
 
-		update_option( self::DB_VERSION_OPTION, self::DB_VERSION, true );
+		if ( $automation_schema_ready ) {
+			update_option( self::DB_VERSION_OPTION, self::DB_VERSION, true );
+		}
 		self::ensure_customer_conversation_review_cleanup();
+	}
+
+	/**
+	 * Check whether an internal table already exists before handing its schema to dbDelta.
+	 *
+	 * The dbDelta helper can issue duplicate ALTER statements for the automation lifecycle
+	 * tables when a previous request created only part of their current schema.
+	 * Existing tables use the explicit, introspection-backed migration below instead.
+	 */
+	private static function table_exists( string $table ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal schema introspection for a fixed plugin table.
+		return $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table ) ) );
+	}
+
+	/**
+	 * Add the automation lifecycle columns and indexes only when they are missing.
+	 *
+	 * @param string $automations_table Automation definitions table.
+	 * @param string $automation_logs_table Automation execution log table.
+	 */
+	private static function ensure_automation_schema( string $automations_table, string $automation_logs_table ): bool {
+		return self::ensure_table_columns(
+			$automations_table,
+			[
+				'mode'                        => "varchar(20) NOT NULL DEFAULT 'task'",
+				'monitor_scratch'             => "longtext NOT NULL DEFAULT ''",
+				'monitor_event_wakes_enabled' => 'tinyint(1) NOT NULL DEFAULT 0',
+				'monitor_event_sources'       => "longtext NOT NULL DEFAULT ''",
+				'monitor_wake_cooldown_until' => 'datetime DEFAULT NULL',
+				'monitor_wake_dropped_count'  => 'int(11) unsigned NOT NULL DEFAULT 0',
+				'monitor_wake_deferred_count' => 'int(11) unsigned NOT NULL DEFAULT 0',
+				'owner_user_id'               => 'bigint(20) unsigned NOT NULL DEFAULT 0',
+				'active_run_id'               => "char(36) NOT NULL DEFAULT ''",
+				'execution_status'            => "varchar(20) NOT NULL DEFAULT 'idle'",
+				'lease_expires_at'            => 'datetime DEFAULT NULL',
+				'last_run_id'                 => "char(36) NOT NULL DEFAULT ''",
+				'last_run_status'             => "varchar(20) NOT NULL DEFAULT ''",
+				'last_run_error'              => "text NOT NULL DEFAULT ''",
+				'last_monitor_outcome'        => "varchar(20) NOT NULL DEFAULT ''",
+				'last_monitor_summary'        => "text NOT NULL DEFAULT ''",
+			],
+		)
+			&& self::ensure_table_indexes(
+				$automations_table,
+				[
+					'mode_enabled'  => [
+						'columns' => [ 'mode', 'enabled' ],
+						'unique'  => false,
+					],
+					'owner_user_id' => [
+						'columns' => [ 'owner_user_id' ],
+						'unique'  => false,
+					],
+					'active_run_id' => [
+						'columns' => [ 'active_run_id' ],
+						'unique'  => false,
+					],
+					'lease_status'  => [
+						'columns' => [ 'execution_status', 'lease_expires_at' ],
+						'unique'  => false,
+					],
+				],
+			)
+			&& self::ensure_table_columns(
+				$automation_logs_table,
+				[
+					'run_id'           => "char(36) NOT NULL DEFAULT ''",
+					'owner_user_id'    => 'bigint(20) unsigned NOT NULL DEFAULT 0',
+					'lifecycle_status' => "varchar(20) NOT NULL DEFAULT ''",
+					'monitor_outcome'  => "varchar(20) NOT NULL DEFAULT ''",
+					'lease_expires_at' => 'datetime DEFAULT NULL',
+					'started_at'       => 'datetime DEFAULT NULL',
+					'finished_at'      => 'datetime DEFAULT NULL',
+				],
+			)
+			&& self::ensure_table_indexes(
+				$automation_logs_table,
+				[
+					'run_id'          => [
+						'columns' => [ 'run_id' ],
+						'unique'  => false,
+					],
+					'monitor_outcome' => [
+						'columns' => [ 'monitor_outcome' ],
+						'unique'  => false,
+					],
+					'lifecycle_lease' => [
+						'columns' => [ 'lifecycle_status', 'lease_expires_at' ],
+						'unique'  => false,
+					],
+				],
+			);
+	}
+
+	/**
+	 * Add missing columns using a fixed, internal schema definition.
+	 *
+	 * @param string                $table Fully-qualified plugin table name.
+	 * @param array<string, string> $columns Column names keyed to SQL definitions.
+	 */
+	private static function ensure_table_columns( string $table, array $columns ): bool {
+		global $wpdb;
+
+		foreach ( $columns as $column => $definition ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal schema introspection for fixed plugin column names.
+			$existing = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i WHERE Field = %s', $table, $column ) );
+			if ( null !== $existing ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Adds one verified-missing lifecycle column from a fixed internal schema map.
+			if ( false === $wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN {$column} {$definition}", $table ) ) ) {
+				// A concurrent request may have completed this fixed migration after the
+				// preceding introspection. Accept only that already-present outcome.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms a concurrent fixed schema migration completed.
+				if ( null === $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i WHERE Field = %s', $table, $column ) ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add missing indexes using a fixed, internal schema definition.
+	 *
+	 * @param string                                                    $table Fully-qualified plugin table name.
+	 * @param array<string, array{columns: list<string>, unique: bool}> $indexes Required index definitions keyed by name.
+	 */
+	private static function ensure_table_indexes( string $table, array $indexes ): bool {
+		global $wpdb;
+
+		foreach ( $indexes as $index => $definition ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Internal schema introspection for fixed plugin index names.
+			$existing = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i WHERE Key_name = %s', $table, $index ), ARRAY_A );
+			if ( self::index_matches_definition( $existing, $definition ) ) {
+				continue;
+			}
+			if ( [] !== $existing ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Replaces a fixed internal index whose definition does not match the required lifecycle schema.
+				if ( false === $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, $index ) ) ) {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms a concurrent fixed index repair completed.
+					$after_failed_drop = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i WHERE Key_name = %s', $table, $index ), ARRAY_A );
+					if ( ! self::index_matches_definition( $after_failed_drop, $definition ) ) {
+						return false;
+					}
+					continue;
+				}
+			}
+
+			$index_type = $definition['unique'] ? 'UNIQUE KEY' : 'KEY';
+			$columns    = implode( ', ', $definition['columns'] );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Adds one verified-missing lifecycle index from a fixed internal schema map.
+			if ( false === $wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD {$index_type} {$index} ({$columns})", $table ) ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Confirms a concurrent fixed index migration completed.
+				$after_failed_add = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i WHERE Key_name = %s', $table, $index ), ARRAY_A );
+				if ( ! self::index_matches_definition( $after_failed_add, $definition ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determine whether an existing index has the required columns, order, and uniqueness.
+	 *
+	 * @param mixed                                      $existing Existing SHOW INDEX rows.
+	 * @param array{columns: list<string>, unique: bool} $definition Required index definition.
+	 */
+	private static function index_matches_definition( mixed $existing, array $definition ): bool {
+		if ( ! is_array( $existing ) ) {
+			return false;
+		}
+
+		foreach ( $existing as $row ) {
+			if ( ! is_array( $row ) ) {
+				return false;
+			}
+		}
+
+		if ( count( $definition['columns'] ) !== count( $existing ) ) {
+			return false;
+		}
+
+		usort(
+			$existing,
+			static function ( mixed $left, mixed $right ): int {
+				if ( ! is_array( $left ) || ! is_array( $right ) ) {
+					return 0;
+				}
+
+				return (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index'];
+			}
+		);
+		$expected_non_unique = $definition['unique'] ? 0 : 1;
+
+		foreach ( $definition['columns'] as $position => $column ) {
+			if ( $column !== $existing[ $position ]['Column_name'] || $expected_non_unique !== (int) $existing[ $position ]['Non_unique'] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/** Backfill the dedicated Trash-entry timestamp for pre-19.16.0 rows. */

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -752,6 +752,97 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
 	}
 
+	/** Existing automation lifecycle fields do not make a stale upgrade emit duplicate DDL errors. */
+	public function test_install_upgrades_existing_automation_lifecycle_schema_without_duplicate_errors(): void {
+		global $wpdb;
+
+		Database::install();
+		$automations_table = Database::automations_table_name();
+		$colliding_table   = preg_replace( '/_/', '0', $automations_table, 1 );
+		$this->assertIsString( $colliding_table );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only table whose name matches an unescaped LIKE pattern for the automation table.
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'CREATE TABLE %i (id bigint(20) unsigned NOT NULL)', $colliding_table ) ) );
+		update_option( Database::DB_VERSION_OPTION, '19.12.0' );
+
+		try {
+			Database::install();
+		} finally {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only collision fixture cleanup.
+			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $colliding_table ) );
+		}
+
+		$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
+		$this->assertContains( 'last_monitor_summary', $this->get_column_names( $automations_table ) );
+	}
+
+	/** Missing lifecycle fields and indexes are added once without re-adding existing schema. */
+	public function test_install_repairs_partial_automation_lifecycle_schema(): void {
+		global $wpdb;
+
+		Database::install();
+		$automations_table = Database::automations_table_name();
+		$logs_table        = Database::automation_logs_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only simulation of a partially completed automation upgrade.
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN last_monitor_summary', $automations_table ) ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only simulation of a partially completed automation upgrade.
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX monitor_outcome', $logs_table ) ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only malformed lifecycle index fixture.
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX lifecycle_lease', $logs_table ) ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only malformed lifecycle index fixture.
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY lifecycle_lease (run_id)', $logs_table ) ) );
+		update_option( Database::DB_VERSION_OPTION, '19.12.0' );
+
+		Database::install();
+
+		$this->assertContains( 'last_monitor_summary', $this->get_column_names( $automations_table ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only schema introspection.
+		$this->assertNotNull( $wpdb->get_var( "SHOW INDEX FROM {$logs_table} WHERE Key_name = 'monitor_outcome'" ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only assertion of repaired monitor outcome index fields and uniqueness.
+		$monitor_outcome_index = $wpdb->get_results( "SHOW INDEX FROM {$logs_table} WHERE Key_name = 'monitor_outcome'", ARRAY_A );
+		usort(
+			$monitor_outcome_index,
+			static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index']
+		);
+		$this->assertSame( [ 'monitor_outcome' ], array_column( $monitor_outcome_index, 'Column_name' ) );
+		$this->assertSame( [ '1' ], array_column( $monitor_outcome_index, 'Non_unique' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only assertion of repaired lifecycle index fields and uniqueness.
+		$lifecycle_index = $wpdb->get_results( "SHOW INDEX FROM {$logs_table} WHERE Key_name = 'lifecycle_lease'", ARRAY_A );
+		usort(
+			$lifecycle_index,
+			static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index']
+		);
+		$this->assertSame( [ 'lifecycle_status', 'lease_expires_at' ], array_column( $lifecycle_index, 'Column_name' ) );
+		$this->assertSame( [ '1', '1' ], array_column( $lifecycle_index, 'Non_unique' ) );
+		$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
+	}
+
+	/** Each multisite subsite upgrades its own stale automation schema on first use. */
+	public function test_runtime_handler_upgrades_stale_automation_schema_on_a_subsite(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		global $wpdb;
+		$main_prefix = $wpdb->prefix;
+		$site_id     = self::factory()->blog->create();
+
+		switch_to_blog( $site_id );
+		try {
+			$handler = new CustomerAgentRuntimeHandler();
+			$handler->ensure_database_schema();
+			update_option( Database::DB_VERSION_OPTION, '19.12.0' );
+
+			$handler->ensure_database_schema();
+
+			$this->assertNotSame( $main_prefix, $wpdb->prefix );
+			$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
+			$this->assertContains( 'last_monitor_summary', $this->get_column_names( Database::automations_table_name() ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
 	/**
 	 * The global runtime handler upgrades an existing install before runtime use.
 	 */


### PR DESCRIPTION
## Summary

Repairs the schema upgrade using add-only introspection, validates index definitions, and handles concurrent repairs without duplicate lifecycle DDL.

## Files Changed

includes/Core/Database.php, tests/SdAiAgent/Core/DatabaseSchemaTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run verify (Tests: 4379, Assertions: 20384, Errors: 0, Failures: 0, Skipped: 138, Incomplete: 4)

Resolves #2694


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 3h 24m and 389,053 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when automation tables already exist.
  * Existing automation databases with incomplete or outdated schema are now repaired automatically.
  * Prevented duplicate database setup errors during upgrades.
  * Automation schema updates are applied correctly across individual sites in multisite installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->