### PR TITLE
GH#2677: Restore least-privilege Dokan vendor chat

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -97,6 +97,13 @@ Never set a custom font family. The plugin must feel native to the admin environ
 ### General rule
 Use `@wordpress/components` for every interactive element. Do not reach for raw `<button>` or `<input>` elements unless unavoidable (e.g. hidden file inputs). Using WordPress components ensures keyboard accessibility, focus management, and visual consistency come for free.
 
+### Embedded marketplace assistant
+- Place vendor chat inside the marketplace dashboard content column rather than floating over navigation or store controls.
+- Use the same chat panel, message, input, and branding components as the main product; embedding changes layout, not visual identity.
+- Embedded panels fill the available content width, use a bounded viewport-relative height, and retain a usable minimum height on short screens.
+- Hide admin-oriented session, agent, model, proposal, change-log, resize, minimize, and dismiss controls in vendor-simple mode. The vendor surface should present only assistant status, conversation content, voice controls when available, and message composition.
+- Never expose a dashboard link when the current vendor lacks an explicit non-empty ability allowlist. Permission errors replace the mount rather than rendering a disabled or misleading assistant shell.
+
 ### Privacy review screens
 - Use a compact filterable summary list with an explicit detail selection; never place transcript text, profile identifiers, tokens, hashes, tool data, or raw provider payloads in list rows.
 - Keep transcript detail text-only, bounded, and visibly separate from its summary. Use pagination to load earlier retained messages instead of rendering an unbounded conversation at once.

--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -69,14 +69,14 @@ class FloatingWidget {
 	 *
 	 * Only loads for logged-in users with configured chat access.
 	 */
-	public static function enqueue_assets_frontend(): void {
+	public static function enqueue_assets_frontend( bool $force_display = false, string $display_mode = 'floating', string $chat_ui_mode = 'admin' ): void {
 		$settings         = Settings::instance()->get();
 		$force_onboarding = isset( $_GET['sd_ai_agent_onboarding'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&& '1' === sanitize_text_field( wp_unslash( $_GET['sd_ai_agent_onboarding'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Only when the frontend display setting is enabled.
 		// @phpstan-ignore-next-line
-		if ( empty( $settings['show_on_frontend'] ) && ! $force_onboarding ) {
+		if ( empty( $settings['show_on_frontend'] ) && ! $force_onboarding && ! $force_display ) {
 			return;
 		}
 
@@ -89,15 +89,17 @@ class FloatingWidget {
 		// The floating widget UI (FAB + panel) renders independently of the AI
 		// client. The REST API handles provider availability at message-send time.
 
-		self::enqueue_widget_assets( 'frontend' );
+		self::enqueue_widget_assets( 'frontend', $display_mode, $chat_ui_mode );
 	}
 
 	/**
 	 * Shared asset enqueueing logic for both admin and frontend contexts.
 	 *
-	 * @param string $context Either 'admin' or 'frontend'.
+	 * @param string $context       Either 'admin' or 'frontend'.
+	 * @param string $display_mode  Either 'floating' or 'embedded'.
+	 * @param string $chat_ui_mode  Chat control mode exposed to the client.
 	 */
-	private static function enqueue_widget_assets( string $context = 'admin' ): void {
+	private static function enqueue_widget_assets( string $context = 'admin', string $display_mode = 'floating', string $chat_ui_mode = 'admin' ): void {
 		$build_dir  = (string) apply_filters( 'sd_ai_agent_build_dir', SD_AI_AGENT_DIR . '/build' );
 		$asset_file = $build_dir . '/floating-widget.asset.php';
 
@@ -207,6 +209,8 @@ class FloatingWidget {
 				'viewedPostId'        => $viewed_post_id,
 				'viewedPostType'      => $viewed_post_type,
 				'viewedTitle'         => $viewed_title,
+				'displayMode'         => 'embedded' === $display_mode ? 'embedded' : 'floating',
+				'chatUiMode'          => sanitize_key( $chat_ui_mode ),
 			]
 		);
 	}

--- a/includes/Bootstrap/DokanVendorDashboardHandler.php
+++ b/includes/Bootstrap/DokanVendorDashboardHandler.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Dokan vendor dashboard integration for the authenticated chat widget.
+ *
+ * @package SdAiAgent\Bootstrap
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Bootstrap;
+
+use SdAiAgent\Admin\FloatingWidget;
+use SdAiAgent\Core\RolePermissions;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Filter;
+use XWP\DI\Decorators\Handler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an AI Assistant screen to the public Dokan vendor dashboard.
+ */
+#[Handler(
+	container: 'sd-ai-agent',
+	// Rewrite registration also runs from wp-admin and WP-CLI, so the Dokan
+	// endpoint filter must not disappear outside frontend request context.
+	context: Handler::CTX_GLOBAL,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class DokanVendorDashboardHandler {
+
+	private const ENDPOINT = 'ai-assistant';
+
+	/**
+	 * Add the assistant endpoint to Dokan's rewrite endpoint list.
+	 *
+	 * @param array<int|string, string> $query_vars Registered Dokan endpoint query variables.
+	 * @return array<int|string, string> Updated endpoint query variables.
+	 */
+	#[Filter( tag: 'dokan_query_var_filter', priority: 10 )]
+	public function add_query_var( array $query_vars ): array {
+		if ( ! in_array( self::ENDPOINT, $query_vars, true ) ) {
+			$query_vars[] = self::ENDPOINT;
+		}
+
+		return $query_vars;
+	}
+
+	/**
+	 * Add the assistant to the current vendor's dashboard navigation.
+	 *
+	 * @param array<string, array<string, mixed>> $menus Dokan dashboard menu entries.
+	 * @return array<string, array<string, mixed>> Updated dashboard menu entries.
+	 */
+	#[Filter( tag: 'dokan_get_dashboard_nav', priority: 40 )]
+	public function add_dashboard_navigation( array $menus ): array {
+		if ( ! $this->current_user_can_use_vendor_chat() || ! function_exists( 'dokan_get_navigation_url' ) ) {
+			return $menus;
+		}
+
+		$menus[ self::ENDPOINT ] = array(
+			'title'      => __( 'AI Assistant', 'superdav-ai-agent' ),
+			'icon'       => '<i class="fas fa-robot" aria-hidden="true"></i>',
+			'icon_name'  => 'Bot',
+			'url'        => dokan_get_navigation_url( self::ENDPOINT ),
+			'pos'        => 40,
+			'permission' => 'read',
+		);
+
+		return $menus;
+	}
+
+	/** Enqueue the existing widget bundle only on the assistant dashboard screen. */
+	#[Action( tag: 'wp_enqueue_scripts', priority: 20 )]
+	public function enqueue_assets(): void {
+		if ( ! $this->is_assistant_request() || ! $this->current_user_can_use_vendor_chat() ) {
+			return;
+		}
+
+		FloatingWidget::enqueue_assets_frontend( true, 'embedded', 'vendor_simple' );
+	}
+
+	/**
+	 * Render the Dokan dashboard shell and the React mount point.
+	 *
+	 * @param array<string, mixed> $query_vars Current Dokan endpoint query variables.
+	 */
+	#[Action( tag: 'dokan_load_custom_template', priority: 10 )]
+	public function render_dashboard( array $query_vars ): void {
+		if ( ! isset( $query_vars[ self::ENDPOINT ] ) ) {
+			return;
+		}
+
+		if ( ! $this->current_user_can_use_vendor_chat() ) {
+			if ( function_exists( 'dokan_get_template_part' ) ) {
+				dokan_get_template_part( 'global/no-permission' );
+				return;
+			}
+
+			echo esc_html__( 'You do not have permission to use the AI Assistant.', 'superdav-ai-agent' );
+			return;
+		}
+
+		do_action( 'dokan_dashboard_wrap_start' );
+		echo '<div class="dokan-dashboard-wrap">';
+		do_action( 'dokan_dashboard_content_before' );
+		echo '<div class="dokan-dashboard-content sd-ai-agent-dokan-dashboard">';
+		do_action( 'dokan_dashboard_content_inside_before' );
+		printf(
+			'<article class="dashboard-content-area"><header class="dokan-dashboard-header"><h1>%s</h1></header><div id="sdaa-floating-root" class="sd-ai-agent-dokan-chat" data-display-mode="embedded"></div></article>',
+			esc_html__( 'AI Assistant', 'superdav-ai-agent' )
+		);
+		do_action( 'dokan_dashboard_content_inside_after' );
+		echo '</div>';
+		do_action( 'dokan_dashboard_content_after' );
+		echo '</div>';
+		do_action( 'dokan_dashboard_wrap_end' );
+	}
+
+	/** Determine whether the current request targets the assistant endpoint. */
+	private function is_assistant_request(): bool {
+		$request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_path   = wp_parse_url( $request_uri, PHP_URL_PATH );
+		$dashboard_url  = function_exists( 'dokan_get_navigation_url' ) ? dokan_get_navigation_url() : '';
+		$dashboard_path = wp_parse_url( $dashboard_url, PHP_URL_PATH );
+		$expected_path  = is_string( $dashboard_path )
+			? untrailingslashit( $dashboard_path ) . '/' . self::ENDPOINT
+			: '';
+
+		$is_request = is_string( $request_path )
+			&& '' !== $expected_path
+			&& $expected_path === untrailingslashit( $request_path );
+
+		return (bool) apply_filters( 'sd_ai_agent_is_dokan_assistant_request', $is_request );
+	}
+
+	/** Require both a real Dokan vendor and an explicit restricted chat policy. */
+	private function current_user_can_use_vendor_chat(): bool {
+		$is_vendor = function_exists( 'dokan_is_user_seller' )
+			&& dokan_is_user_seller( get_current_user_id() );
+		$is_vendor = (bool) apply_filters( 'sd_ai_agent_is_dokan_vendor', $is_vendor, get_current_user_id() );
+
+		if ( ! $is_vendor || ! RolePermissions::current_user_has_chat_access() ) {
+			return false;
+		}
+
+		$allowed = RolePermissions::get_allowed_abilities_for_current_user();
+
+		return is_array( $allowed ) && [] !== $allowed;
+	}
+}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4153,6 +4153,10 @@ PROMPT;
 			return array();
 		}
 
+		$role_allowed = ToolDiscovery::is_anonymous_ability_mode() || ! is_user_logged_in()
+			? null
+			: RolePermissions::get_allowed_abilities_for_current_user();
+
 		// Explicit per-instance override (e.g. from tests or CLI --abilities).
 		// When set, bypass the auto-discovery layer and return exactly what was asked for.
 		if ( ! empty( $this->abilities ) ) {
@@ -4168,23 +4172,28 @@ PROMPT;
 			}
 			// Append client ability stubs even in explicit-abilities mode.
 			return $this->deduplicate_by_function_name(
-				array_merge( $resolved, $this->client_router->build_stubs() )
+				self::filter_abilities_by_role(
+					array_merge( $resolved, $this->client_router->build_stubs() ),
+					$role_allowed
+				)
 			);
 		}
 
 		if ( $this->should_use_native_tool_search() ) {
 			return $this->deduplicate_by_function_name(
-				array_merge(
-					ToolDiscovery::visible_ai_chat_abilities(),
-					$this->client_router->build_stubs()
+				self::filter_abilities_by_role(
+					array_merge(
+						ToolDiscovery::visible_ai_chat_abilities(),
+						$this->client_router->build_stubs()
+					),
+					$role_allowed
 				)
 			);
 		}
 
 		$tier_1 = ToolDiscovery::tier_1_for_run( $this->agent_tier_1_tools );
 
-		$role_allowed = ToolDiscovery::is_anonymous_ability_mode() ? null : RolePermissions::get_allowed_abilities_for_current_user();
-		$perms        = $this->tool_permissions;
+		$perms = $this->tool_permissions;
 
 		$resolved = array();
 		foreach ( array_merge( $tier_1, $this->approved_once_abilities ) as $name ) {
@@ -4209,7 +4218,30 @@ PROMPT;
 
 		// Append synthetic stubs for validated client-side abilities.
 		return $this->deduplicate_by_function_name(
-			array_merge( $resolved, $this->client_router->build_stubs() )
+			self::filter_abilities_by_role(
+				array_merge( $resolved, $this->client_router->build_stubs() ),
+				$role_allowed
+			)
+		);
+	}
+
+	/**
+	 * Apply role restrictions to direct and browser-side ability stubs.
+	 *
+	 * @param \WP_Ability[] $abilities    Candidate abilities.
+	 * @param string[]|null $role_allowed Null when unrestricted.
+	 * @return \WP_Ability[]
+	 */
+	private static function filter_abilities_by_role( array $abilities, ?array $role_allowed ): array {
+		if ( null === $role_allowed ) {
+			return $abilities;
+		}
+
+		return array_values(
+			array_filter(
+				$abilities,
+				static fn( \WP_Ability $ability ): bool => in_array( $ability->get_name(), $role_allowed, true )
+			)
 		);
 	}
 

--- a/includes/Core/RolePermissions.php
+++ b/includes/Core/RolePermissions.php
@@ -44,6 +44,15 @@ class RolePermissions {
 	const ALWAYS_ALLOWED_ROLES = [ 'administrator' ];
 
 	/**
+	 * Roles that must always have a non-empty ability allowlist.
+	 *
+	 * Dokan vendors operate on a shared marketplace site. Treating an empty
+	 * list as unrestricted for that role would turn a settings omission into
+	 * store-wide agent access.
+	 */
+	const EXPLICIT_ALLOWLIST_ROLES = [ 'seller' ];
+
+	/**
 	 * Get the default role permissions configuration.
 	 *
 	 * By default:
@@ -53,7 +62,7 @@ class RolePermissions {
 	 *  - contributor: no chat access
 	 *  - subscriber: no chat access
 	 *
-	 * @return array<string, array<string, mixed>>
+	 * @return array<string, array{chat_access: bool, allowed_abilities: list<string>}>
 	 */
 	public static function get_defaults(): array {
 		return [
@@ -79,7 +88,7 @@ class RolePermissions {
 	/**
 	 * Get all role permissions, merged with defaults.
 	 *
-	 * @return array<string, array<string, mixed>>
+	 * @return array<string, array{chat_access: bool, allowed_abilities: list<string>}>
 	 */
 	public static function get(): array {
 		$saved    = get_option( self::OPTION_NAME, [] );
@@ -164,11 +173,36 @@ class RolePermissions {
 
 		$user        = wp_get_current_user();
 		$permissions = self::get();
+		$roles       = (array) $user->roles;
 
-		foreach ( (array) $user->roles as $role ) {
-			if ( isset( $permissions[ $role ] ) && true === $permissions[ $role ]['chat_access'] ) {
-				return true;
+		// A marketplace role is a restrictive boundary, not one grant among many.
+		// Ignore permissive secondary roles so adding `editor` to a seller cannot
+		// turn an omitted seller allowlist into unrestricted agent access.
+		$explicit_roles = self::get_explicit_allowlist_roles( $roles );
+		if ( [] !== $explicit_roles ) {
+			foreach ( $explicit_roles as $role ) {
+				if (
+					isset( $permissions[ $role ] )
+					&& true === $permissions[ $role ]['chat_access']
+					&& ! empty( $permissions[ $role ]['allowed_abilities'] )
+				) {
+					return true;
+				}
 			}
+
+			return false;
+		}
+
+		foreach ( $roles as $role ) {
+			if ( ! isset( $permissions[ $role ] ) || true !== $permissions[ $role ]['chat_access'] ) {
+				continue;
+			}
+
+			if ( self::role_requires_explicit_allowlist( (string) $role ) && empty( $permissions[ $role ]['allowed_abilities'] ) ) {
+				continue;
+			}
+
+			return true;
 		}
 
 		return false;
@@ -192,21 +226,48 @@ class RolePermissions {
 
 		$user        = wp_get_current_user();
 		$permissions = self::get();
+		$roles       = (array) $user->roles;
+
+		// Marketplace-role restrictions override permissive secondary roles.
+		// Only explicitly configured marketplace-role abilities are available.
+		$explicit_roles = self::get_explicit_allowlist_roles( $roles );
+		if ( [] !== $explicit_roles ) {
+			$allowed = [];
+			foreach ( $explicit_roles as $role ) {
+				if (
+					! isset( $permissions[ $role ] )
+					|| true !== $permissions[ $role ]['chat_access']
+					|| empty( $permissions[ $role ]['allowed_abilities'] )
+				) {
+					continue;
+				}
+
+				$allowed = array_merge( $allowed, $permissions[ $role ]['allowed_abilities'] );
+			}
+
+			return array_values( array_unique( $allowed ) );
+		}
 
 		// Collect the union of allowed abilities across all user roles.
 		// An empty allowed_abilities array for a role means "all abilities".
 		$has_restriction = false;
 		$allowed         = [];
 
-		foreach ( (array) $user->roles as $role ) {
+		foreach ( $roles as $role ) {
 			if ( ! isset( $permissions[ $role ] ) ) {
 				continue;
 			}
 
 			$role_config = $permissions[ $role ];
 
-			// If any role grants unrestricted abilities, the user is unrestricted.
+			// Marketplace roles fail closed when an administrator has not saved an
+			// explicit allowlist. Other historical roles retain the existing empty
+			// list = unrestricted behavior.
 			if ( empty( $role_config['allowed_abilities'] ) ) {
+				if ( self::role_requires_explicit_allowlist( (string) $role ) ) {
+					$has_restriction = true;
+					continue;
+				}
 				return null;
 			}
 
@@ -222,6 +283,37 @@ class RolePermissions {
 
 		// @phpstan-ignore-next-line
 		return array_values( array_unique( $allowed ) );
+	}
+
+	/**
+	 * Determine whether a role must fail closed without an explicit allowlist.
+	 *
+	 * @param string $role Role slug.
+	 */
+	private static function role_requires_explicit_allowlist( string $role ): bool {
+		/**
+		 * Filter roles that require an explicit non-empty ability allowlist.
+		 *
+		 * @param string[] $roles Role slugs.
+		 */
+		$roles = apply_filters( 'sd_ai_agent_explicit_ability_allowlist_roles', self::EXPLICIT_ALLOWLIST_ROLES );
+
+		return in_array( $role, array_filter( (array) $roles, 'is_string' ), true );
+	}
+
+	/**
+	 * Return the current user's roles that enforce an explicit allowlist.
+	 *
+	 * @param string[] $roles WordPress role slugs.
+	 * @return string[]
+	 */
+	private static function get_explicit_allowlist_roles( array $roles ): array {
+		return array_values(
+			array_filter(
+				$roles,
+				static fn( string $role ): bool => self::role_requires_explicit_allowlist( $role )
+			)
+		);
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -35,6 +35,7 @@ use SdAiAgent\Bootstrap\AutomationsHandler;
 use SdAiAgent\Bootstrap\ChangeLoggingHandler;
 use SdAiAgent\Bootstrap\CliHandler;
 use SdAiAgent\Bootstrap\CustomerAgentRuntimeHandler;
+use SdAiAgent\Bootstrap\DokanVendorDashboardHandler;
 use SdAiAgent\Bootstrap\FrontendAssetsHandler;
 use SdAiAgent\Bootstrap\HealthEndpointHandler;
 use SdAiAgent\Bootstrap\HttpTraceHandler;
@@ -122,6 +123,7 @@ use XWP\DI\Decorators\Module;
 		CustomerAgentRuntimeHandler::class,
 		CachePolicy::class,
 		FrontendAssetsHandler::class,
+		DokanVendorDashboardHandler::class,
 		PublicSpeechCorsHandler::class,
 		MemoryController::class,
 		SkillController::class,

--- a/includes/REST/PermissionTrait.php
+++ b/includes/REST/PermissionTrait.php
@@ -12,6 +12,7 @@ namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\RolePermissions;
+use SdAiAgent\Models\ActiveJobRepository;
 use WP_Error;
 use WP_REST_Request;
 
@@ -60,6 +61,77 @@ trait PermissionTrait {
 	}
 
 	/**
+	 * Permission check for starting an authenticated chat run.
+	 *
+	 * A chat-enabled user may start a new session. Continuing an existing
+	 * session additionally requires ownership; administrators may continue a
+	 * session that was explicitly shared with administrators. Non-admin users
+	 * cannot start durable plans through the general chat route.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error
+	 */
+	public function check_chat_run_permission( WP_REST_Request $request ): bool|WP_Error {
+		$chat_permission = $this->check_chat_permission();
+		if ( true !== $chat_permission ) {
+			return $chat_permission;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) && true === $request->get_param( 'durable_plan' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Your user role does not have permission to create durable plans.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$session_id = self::get_int_param( $request, 'session_id' );
+		if ( 0 === $session_id ) {
+			return true;
+		}
+
+		return $this->current_user_can_access_session( $session_id );
+	}
+
+	/**
+	 * Permission check for authenticated job status and control routes.
+	 *
+	 * Job UUIDs are bearer-like identifiers and are not authorization. Resolve
+	 * the persisted owner from the transient first and the active-job table as a
+	 * durable fallback, then require the real current user to match it.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error
+	 */
+	public function check_chat_job_permission( WP_REST_Request $request ): bool|WP_Error {
+		$chat_permission = $this->check_chat_permission();
+		if ( true !== $chat_permission ) {
+			return $chat_permission;
+		}
+
+		// Preserve the existing administrator support/debugging contract while
+		// requiring every non-admin chat user to own the requested job.
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$job_id = self::get_string_param( $request, 'id' );
+		if ( '' === $job_id ) {
+			return false;
+		}
+
+		$job      = get_transient( RestController::JOB_PREFIX . $job_id );
+		$owner_id = is_array( $job ) ? absint( $job['user_id'] ?? 0 ) : 0;
+
+		if ( 0 === $owner_id ) {
+			$row      = ActiveJobRepository::get_by_job_id( $job_id );
+			$owner_id = $row->user_id ?? 0;
+		}
+
+		return $owner_id > 0 && $owner_id === get_current_user_id();
+	}
+
+	/**
 	 * Permission check for the browser tool-result callback endpoint.
 	 *
 	 * The endpoint mutates session state by consuming paused_state and appending
@@ -93,12 +165,7 @@ trait PermissionTrait {
 			);
 		}
 
-		$is_owner = (int) $session->user_id === get_current_user_id();
-		if ( $is_owner ) {
-			return true;
-		}
-
-		if ( Database::get_shared_session( $session_id ) ) {
+		if ( $this->current_user_can_access_session( $session_id ) ) {
 			return true;
 		}
 
@@ -133,7 +200,14 @@ trait PermissionTrait {
 			return true;
 		}
 
-		// Non-owners may access shared sessions (read + continue), but not delete/trash/archive.
+		// Shared sessions are an administrator collaboration feature. A globally
+		// shared row must never expose one vendor's conversation to another vendor.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		// Non-owner administrators may access shared sessions (read + continue),
+		// but not delete/trash/archive.
 		$method = $request->get_method();
 		if ( 'DELETE' === $method ) {
 			return false;
@@ -169,6 +243,25 @@ trait PermissionTrait {
 		}
 
 		return (int) $session->user_id === get_current_user_id();
+	}
+
+	/**
+	 * Check whether the current user owns a session or is an administrator with
+	 * access to a session explicitly shared for administrator collaboration.
+	 *
+	 * @param int $session_id Session ID.
+	 */
+	private function current_user_can_access_session( int $session_id ): bool {
+		$session = Database::get_session( $session_id );
+		if ( ! $session ) {
+			return false;
+		}
+
+		if ( (int) $session->user_id === get_current_user_id() ) {
+			return true;
+		}
+
+		return current_user_can( 'manage_options' ) && null !== Database::get_shared_session( $session_id );
 	}
 
 	/**

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -111,7 +111,7 @@ final class SessionController {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'handle_list_sessions' ),
-					'permission_callback' => array( $this, 'check_permission' ),
+					'permission_callback' => array( $this, 'check_chat_permission' ),
 					'args'                => array(
 						'status' => array(
 							'required'          => false,
@@ -138,7 +138,7 @@ final class SessionController {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'handle_create_session' ),
-					'permission_callback' => array( $this, 'check_permission' ),
+					'permission_callback' => array( $this, 'check_chat_permission' ),
 					'args'                => array(
 						'title'       => array(
 							'required'          => false,
@@ -175,7 +175,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'handle_list_folders' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 			)
 		);
 
@@ -185,7 +185,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_bulk_sessions' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 				'args'                => array(
 					'ids'    => array(
 						'required' => true,
@@ -211,7 +211,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'handle_empty_trash' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 			)
 		);
 
@@ -335,7 +335,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_import_session' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 			)
 		);
 
@@ -389,7 +389,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'handle_job_status' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_job_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -430,7 +430,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_run' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_run_permission' ),
 				'args'                => array(
 					'message'            => array(
 						'required'          => true,
@@ -585,7 +585,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_confirm_tool' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_job_permission' ),
 				'args'                => array(
 					'id'           => array(
 						'required'          => true,
@@ -607,7 +607,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_reject_tool' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_job_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -625,7 +625,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_interrupt' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_job_permission' ),
 				'args'                => array(
 					'id'      => array(
 						'required'          => true,
@@ -666,7 +666,7 @@ final class SessionController {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'handle_list_active_jobs' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 			)
 		);
 
@@ -3035,11 +3035,20 @@ final class SessionController {
 			return new WP_Error( 'sd_ai_agent_forbidden', __( 'Not authorized.', 'superdav-ai-agent' ), array( 'status' => 403 ) );
 		}
 
+		$always_allow = true === $request->get_param( 'always_allow' );
+		if ( $always_allow && ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_always_allow_forbidden',
+				__( 'Only administrators can persist tool approval settings.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		// "Always allow" — persist permission so this tool auto-executes in future.
 		// For sd-ai-agent/ability-call confirmations, `ability` is the nested
 		// target ability whose policy triggered the pause; `name` remains the
 		// executable meta-tool function name so the confirmed resume can run.
-		if ( $request->get_param( 'always_allow' ) && ! empty( $job['pending_tools'] ) ) {
+		if ( $always_allow && ! empty( $job['pending_tools'] ) ) {
 			// @phpstan-ignore-next-line
 			foreach ( $job['pending_tools'] as $tool ) {
 				/** @var array<string, mixed> $tool */

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -87,7 +87,7 @@ final class SettingsController {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'handle_providers' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 			)
 		);
 
@@ -121,7 +121,7 @@ final class SettingsController {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'handle_get_settings' ),
-					'permission_callback' => array( $this, 'check_permission' ),
+					'permission_callback' => array( $this, 'check_chat_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -538,6 +538,13 @@ final class SettingsController {
 	 */
 	public function handle_get_settings(): WP_REST_Response {
 		$settings = $this->settings->get();
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_REST_Response( $this->chat_settings( $settings ), 200 );
+		}
 
 		// Include built-in defaults so the UI can show them as placeholders.
 		// @phpstan-ignore-next-line
@@ -584,6 +591,31 @@ final class SettingsController {
 		$settings['_features'] = Features::all();
 
 		return new WP_REST_Response( $settings, 200 );
+	}
+
+	/**
+	 * Return only presentation settings needed by authenticated chat clients.
+	 *
+	 * @param array<string, mixed> $settings Full plugin settings.
+	 * @return array<string, mixed>
+	 */
+	private function chat_settings( array $settings ): array {
+		$allowed_keys  = array_flip(
+			array(
+				'keyboard_shortcut',
+				'greeting_message',
+				'show_token_costs',
+				'show_tool_call_details',
+				'context_window_default',
+			)
+		);
+		$chat_settings = array_intersect_key( $settings, $allowed_keys );
+
+		$chat_settings['_defaults'] = array(
+			'greeting_message' => __( 'Send a message to start a conversation.', 'superdav-ai-agent' ),
+		);
+
+		return $chat_settings;
 	}
 
 	/**
@@ -1547,7 +1579,11 @@ final class SettingsController {
 			return new WP_REST_Response( $providers, 200 );
 		}
 
-		$this->maybe_auto_provision_superdav_provider();
+		// Provisioning mutates site credentials and remains administrator-only.
+		// Chat-enabled non-admins may discover already configured providers.
+		if ( current_user_can( 'manage_options' ) ) {
+			$this->maybe_auto_provision_superdav_provider();
+		}
 		ProviderCredentialLoader::load();
 
 		foreach ( $provider_ids as $provider_id ) {
@@ -1608,7 +1644,9 @@ final class SettingsController {
 
 				if ( SuperdavAiProvider::PROVIDER_ID === $provider_id ) {
 					$provider_response['default_model'] = SuperdavAiProvider::default_model_id();
-					$provider_response['status']        = ( new SuperdavSiteConnectionService() )->get_status();
+					if ( current_user_can( 'manage_options' ) ) {
+						$provider_response['status'] = ( new SuperdavSiteConnectionService() )->get_status();
+					}
 				}
 
 				$providers[] = $provider_response;

--- a/src/components/chat-widget/__tests__/index.test.js
+++ b/src/components/chat-widget/__tests__/index.test.js
@@ -50,4 +50,22 @@ describe( 'ChatWidget deferred panel', () => {
 
 		await act( async () => root.unmount() );
 	} );
+
+	test( 'loads the embedded panel even when floating state is closed', async () => {
+		useSelect.mockImplementation( ( callback ) =>
+			callback( () => ( { isFloatingOpen: () => false } ) )
+		);
+		const container = document.createElement( 'div' );
+		const root = createRoot( container );
+
+		await act( async () => {
+			root.render( createElement( ChatWidget, { embedded: true } ) );
+			await Promise.resolve();
+		} );
+
+		expect( container.querySelector( 'button' )?.textContent ).toBe(
+			'Retry opening AI Agent'
+		);
+		await act( async () => root.unmount() );
+	} );
 } );

--- a/src/components/chat-widget/index.js
+++ b/src/components/chat-widget/index.js
@@ -32,9 +32,10 @@ import './widget-launcher.css';
  * @param {Object}      root0                        Component props.
  * @param {string|null} root0.frontendOnboardingMode Frontend onboarding layout mode.
  * @param {string}      root0.uiMode                 Chat UI mode.
+ * @param {boolean}     root0.embedded               Whether the panel is embedded in a page.
  * @return {JSX.Element|null} Loaded panel, retry launcher, or loading fallback.
  */
-function DeferredWidgetPanel( { frontendOnboardingMode, uiMode } ) {
+function DeferredWidgetPanel( { frontendOnboardingMode, uiMode, embedded } ) {
 	const [ WidgetPanel, setWidgetPanel ] = useState( null );
 	const [ failed, setFailed ] = useState( false );
 	const [ attempt, setAttempt ] = useState( 0 );
@@ -77,6 +78,7 @@ function DeferredWidgetPanel( { frontendOnboardingMode, uiMode } ) {
 		<WidgetPanel
 			frontendOnboardingMode={ frontendOnboardingMode }
 			uiMode={ uiMode }
+			embedded={ embedded }
 		/>
 	);
 }
@@ -84,15 +86,19 @@ function DeferredWidgetPanel( { frontendOnboardingMode, uiMode } ) {
 /**
  * @param {Object}      root0                        Component props.
  * @param {string|null} root0.frontendOnboardingMode Frontend onboarding layout mode.
+ * @param {boolean}     root0.embedded               Whether the panel is embedded in a page.
  */
-export default function ChatWidget( { frontendOnboardingMode = null } ) {
+export default function ChatWidget( {
+	frontendOnboardingMode = null,
+	embedded = false,
+} ) {
 	const uiMode = getChatUiMode();
 	const isOpen = useSelect(
 		( sel ) => sel( STORE_NAME ).isFloatingOpen(),
 		[]
 	);
 
-	if ( ! isOpen ) {
+	if ( ! isOpen && ! embedded ) {
 		return <WidgetLauncher />;
 	}
 
@@ -100,6 +106,7 @@ export default function ChatWidget( { frontendOnboardingMode = null } ) {
 		<DeferredWidgetPanel
 			frontendOnboardingMode={ frontendOnboardingMode }
 			uiMode={ uiMode }
+			embedded={ embedded }
 		/>
 	);
 }

--- a/src/components/chat-widget/widget-header.js
+++ b/src/components/chat-widget/widget-header.js
@@ -81,6 +81,7 @@ function relativeTime( dateStr ) {
  * @param {*}       root0.onToggleMinimize
  * @param {*}       root0.onDragHandleMouseDown
  * @param {boolean} root0.isSimpleMode
+ * @param {boolean} root0.embedded
  * @param {Object}  root0.voiceConversation
  */
 export default function WidgetHeader( {
@@ -88,6 +89,7 @@ export default function WidgetHeader( {
 	onToggleMinimize,
 	onDragHandleMouseDown,
 	isSimpleMode = false,
+	embedded = false,
 	voiceConversation = {},
 } ) {
 	const {
@@ -402,36 +404,40 @@ export default function WidgetHeader( {
 						<Microphone />
 					</button>
 				) }
-				<button
-					type="button"
-					className="sdaa-w-icon-btn"
-					onClick={ onToggleMinimize }
-					aria-label={
-						isMinimized
-							? __( 'Expand', 'sd-ai-agent' )
-							: __( 'Minimize', 'sd-ai-agent' )
-					}
-					title={
-						isMinimized
-							? __( 'Expand', 'sd-ai-agent' )
-							: __( 'Minimize', 'sd-ai-agent' )
-					}
-				>
-					<MinimizeIcon />
-				</button>
-				<button
-					type="button"
-					className="sdaa-w-icon-btn"
-					data-dismiss-only="true"
-					onClick={ ( e ) => {
-						e.stopPropagation();
-						setFloatingOpen( false );
-					} }
-					aria-label={ __( 'Close', 'sd-ai-agent' ) }
-					title={ __( 'Close', 'sd-ai-agent' ) }
-				>
-					<Icon icon={ close } size={ 16 } />
-				</button>
+				{ ! embedded && (
+					<>
+						<button
+							type="button"
+							className="sdaa-w-icon-btn"
+							onClick={ onToggleMinimize }
+							aria-label={
+								isMinimized
+									? __( 'Expand', 'sd-ai-agent' )
+									: __( 'Minimize', 'sd-ai-agent' )
+							}
+							title={
+								isMinimized
+									? __( 'Expand', 'sd-ai-agent' )
+									: __( 'Minimize', 'sd-ai-agent' )
+							}
+						>
+							<MinimizeIcon />
+						</button>
+						<button
+							type="button"
+							className="sdaa-w-icon-btn"
+							data-dismiss-only="true"
+							onClick={ ( e ) => {
+								e.stopPropagation();
+								setFloatingOpen( false );
+							} }
+							aria-label={ __( 'Close', 'sd-ai-agent' ) }
+							title={ __( 'Close', 'sd-ai-agent' ) }
+						>
+							<Icon icon={ close } size={ 16 } />
+						</button>
+					</>
+				) }
 			</div>
 		</div>
 	);

--- a/src/components/chat-widget/widget-panel.css
+++ b/src/components/chat-widget/widget-panel.css
@@ -29,6 +29,23 @@
 	animation: sdaa-w-panel-in 180ms ease;
 }
 
+.sdaa-w-panel.is-embedded {
+	position: relative;
+	top: auto;
+	right: auto;
+	bottom: auto;
+	left: auto;
+	width: 100%;
+	height: min(760px, calc(100vh - 180px));
+	min-height: 520px;
+	max-width: none;
+	margin: 0;
+}
+
+.sd-ai-agent-dokan-chat {
+	width: 100%;
+}
+
 .sdaa-w-panel.is-minimized {
 	width: 320px;
 	height: auto;

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -59,10 +59,12 @@ const inactiveVoiceConversation = {
  * @param {Object}      root0                        Component props.
  * @param {string|null} root0.frontendOnboardingMode Frontend onboarding layout mode.
  * @param {string}      root0.uiMode                 Chat UI mode.
+ * @param {boolean}     root0.embedded               Whether the panel is embedded in a page.
  */
 export default function WidgetPanel( {
 	frontendOnboardingMode = null,
 	uiMode = 'admin',
+	embedded = false,
 } ) {
 	const isSimpleMode = isCustomerSimpleMode( uiMode );
 	const { confirmToolCall, rejectToolCall, setFloatingMinimized } =
@@ -169,7 +171,7 @@ export default function WidgetPanel( {
 	const showEmpty = messageCount === 0 && ! sending;
 
 	const panelStyle = {};
-	if ( position && ! frontendOnboardingMode ) {
+	if ( position && ! frontendOnboardingMode && ! embedded ) {
 		// Bottom-anchored so minimizing keeps the pill visually at the
 		// bottom of its previous rect (the input row sits where it was).
 		panelStyle.left = `${ position.x }px`;
@@ -177,7 +179,7 @@ export default function WidgetPanel( {
 		panelStyle.right = 'auto';
 		panelStyle.top = 'auto';
 	}
-	if ( size && ! isMinimized && ! frontendOnboardingMode ) {
+	if ( size && ! isMinimized && ! frontendOnboardingMode && ! embedded ) {
 		panelStyle.width = `${ size.w }px`;
 		panelStyle.height = `${ size.h }px`;
 	}
@@ -207,7 +209,7 @@ export default function WidgetPanel( {
 					isResizing ? ' is-resizing' : ''
 				}${ onboardingClass }${
 					isSimpleMode ? ' is-customer-simple' : ''
-				}` }
+				}${ embedded ? ' is-embedded' : '' }` }
 				style={ panelStyle }
 				role="presentation"
 				data-drag-target="true"
@@ -221,8 +223,9 @@ export default function WidgetPanel( {
 					isMinimized={ isMinimized }
 					onToggleMinimize={ toggleMinimize }
 					isSimpleMode={ isSimpleMode }
+					embedded={ embedded }
 					onDragHandleMouseDown={
-						frontendOnboardingMode
+						frontendOnboardingMode || embedded
 							? undefined
 							: handlePanelDragStart
 					}
@@ -305,7 +308,7 @@ export default function WidgetPanel( {
 					</ErrorBoundary>
 				) }
 
-				{ ! isMinimized && ! frontendOnboardingMode && (
+				{ ! isMinimized && ! frontendOnboardingMode && ! embedded && (
 					<>
 						<div
 							className="sdaa-w-resize-handle sdaa-w-resize-handle--right"

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -52,6 +52,7 @@ function FloatingWidget() {
 
 	const frontendOnboardingEnabled =
 		!! window.sdAiAgentData?.frontendOnboarding;
+	const embedded = window.sdAiAgentData?.displayMode === 'embedded';
 	const [ frontendOnboardingMode, setFrontendOnboardingMode ] = useState(
 		frontendOnboardingEnabled ? 'intro' : null
 	);
@@ -130,6 +131,15 @@ function FloatingWidget() {
 		setFloatingOpen( true );
 		setFloatingMinimized( false );
 	}, [ frontendOnboardingEnabled, setFloatingOpen, setFloatingMinimized ] );
+
+	useEffect( () => {
+		if ( ! embedded ) {
+			return;
+		}
+
+		setFloatingOpen( true );
+		setFloatingMinimized( false );
+	}, [ embedded, setFloatingOpen, setFloatingMinimized ] );
 
 	// Keep the public widget attached to the same active/latest conversation as
 	// the dedicated chat page after reloads or frontend navigation. Invalidate
@@ -305,7 +315,12 @@ function FloatingWidget() {
 		return null;
 	}
 
-	return <ChatWidget frontendOnboardingMode={ frontendOnboardingMode } />;
+	return (
+		<ChatWidget
+			frontendOnboardingMode={ frontendOnboardingMode }
+			embedded={ embedded }
+		/>
+	);
 }
 
 /**
@@ -396,9 +411,12 @@ function gatherPageContext() {
 // Admin shell plugins can load WordPress screens in an iframe. The parent
 // screen owns the floating widget, so avoid rendering a duplicate in the frame.
 if ( window.self === window.top ) {
-	const wrapper = document.createElement( 'div' );
-	wrapper.id = 'sdaa-floating-root';
-	document.body.appendChild( wrapper );
+	let wrapper = document.getElementById( 'sdaa-floating-root' );
+	if ( ! wrapper ) {
+		wrapper = document.createElement( 'div' );
+		wrapper.id = 'sdaa-floating-root';
+		document.body.appendChild( wrapper );
+	}
 
 	const root = createRoot( wrapper );
 	root.render(

--- a/src/utils/__tests__/chat-ui-mode.test.js
+++ b/src/utils/__tests__/chat-ui-mode.test.js
@@ -20,6 +20,7 @@ describe( 'chat UI mode helpers', () => {
 		expect( isCustomerSimpleMode( { embed: { uiMode: 'simple' } } ) ).toBe(
 			true
 		);
+		expect( isCustomerSimpleMode( 'vendor-simple' ) ).toBe( true );
 	} );
 
 	test( 'supports localized window data and public chat boolean flags', () => {

--- a/src/utils/chat-ui-mode.js
+++ b/src/utils/chat-ui-mode.js
@@ -14,6 +14,7 @@ const SIMPLE_MODE_ALIASES = new Set( [
 	'public_chat',
 	'customer',
 	'simple',
+	'vendor_simple',
 ] );
 
 /**

--- a/tests/SdAiAgent/Admin/FloatingWidgetTest.php
+++ b/tests/SdAiAgent/Admin/FloatingWidgetTest.php
@@ -222,6 +222,22 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 		$this->assertSame( '', $data['settingsPageUrl'] );
 	}
 
+	/** Forced dashboard embedding localizes a fixed vendor-simple panel. */
+	public function test_enqueue_assets_frontend_supports_forced_embedded_mode(): void {
+		wp_set_current_user( $this->editor_id );
+		Settings::instance()->update( [ 'show_on_frontend' => false ] );
+		$fixture_dir = dirname( __DIR__, 2 ) . '/fixtures/assets';
+		add_filter( 'sd_ai_agent_build_dir', static fn() => $fixture_dir );
+
+		FloatingWidget::enqueue_assets_frontend( true, 'embedded', 'vendor_simple' );
+		remove_all_filters( 'sd_ai_agent_build_dir' );
+
+		$this->assertTrue( wp_script_is( 'sd-ai-agent-floating-widget', 'enqueued' ) );
+		$data = $this->get_localized_widget_data();
+		$this->assertSame( 'embedded', $data['displayMode'] );
+		$this->assertSame( 'vendor_simple', $data['chatUiMode'] );
+	}
+
 	/** The widget receives separate normalized user and site speech hints. */
 	public function test_enqueue_assets_frontend_localizes_speech_locale_hints(): void {
 		wp_set_current_user( $this->editor_id );

--- a/tests/SdAiAgent/Bootstrap/DokanVendorDashboardHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/DokanVendorDashboardHandlerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the Dokan vendor dashboard assistant integration.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Bootstrap
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Bootstrap;
+
+use SdAiAgent\Bootstrap\DokanVendorDashboardHandler;
+use SdAiAgent\Core\RolePermissions;
+use WP_UnitTestCase;
+
+final class DokanVendorDashboardHandlerTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		delete_option( RolePermissions::OPTION_NAME );
+		remove_role( 'seller' );
+		remove_all_filters( 'sd_ai_agent_is_dokan_vendor' );
+
+		parent::tear_down();
+	}
+
+	/** The integration registers a stable Dokan query variable. */
+	public function test_add_query_var_registers_assistant_endpoint(): void {
+		$handler    = new DokanVendorDashboardHandler();
+		$query_vars = $handler->add_query_var( array( 'products' ) );
+		$query_vars = $handler->add_query_var( $query_vars );
+
+		$this->assertContains( 'ai-assistant', $query_vars );
+		$this->assertSame( 1, array_count_values( $query_vars )['ai-assistant'] );
+	}
+
+	/** A configured vendor receives the embedded React assistant mount. */
+	public function test_render_dashboard_outputs_assistant_for_configured_vendor(): void {
+		$this->set_up_seller_policy( array( 'sd-ai-agent/report-inability' ) );
+		add_filter( 'sd_ai_agent_is_dokan_vendor', '__return_true' );
+
+		ob_start();
+		( new DokanVendorDashboardHandler() )->render_dashboard( array( 'ai-assistant' => 'ai-assistant' ) );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'sd-ai-agent-dokan-dashboard', $output );
+		$this->assertStringContainsString( 'id="sdaa-floating-root"', $output );
+		$this->assertStringContainsString( 'data-display-mode="embedded"', $output );
+	}
+
+	/** A seller without an explicit allowlist receives no assistant mount. */
+	public function test_render_dashboard_denies_vendor_without_allowlist(): void {
+		$this->set_up_seller_policy( array() );
+		add_filter( 'sd_ai_agent_is_dokan_vendor', '__return_true' );
+
+		ob_start();
+		( new DokanVendorDashboardHandler() )->render_dashboard( array( 'ai-assistant' => 'ai-assistant' ) );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'do not have permission', $output );
+		$this->assertStringNotContainsString( 'id="sdaa-floating-root"', $output );
+	}
+
+	/**
+	 * Configure the current test user as a seller.
+	 *
+	 * @param string[] $abilities Explicit role allowlist.
+	 */
+	private function set_up_seller_policy( array $abilities ): void {
+		add_role( 'seller', 'Seller', array( 'read' => true ) );
+		RolePermissions::update(
+			array(
+				'seller' => array(
+					'chat_access'       => true,
+					'allowed_abilities' => $abilities,
+				),
+			)
+		);
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'seller' ) ) );
+	}
+}

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -40,6 +40,7 @@ use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SuperdavJourneyBudgetContext;
 use SdAiAgent\Core\SystemInstructionBuilder;
@@ -196,6 +197,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 		delete_option( 'openai_compat_api_key' );
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 		delete_option( Settings::OPTION_NAME );
+		delete_option( RolePermissions::OPTION_NAME );
+		remove_role( 'seller' );
 		SuperdavJourneyBudgetContext::deactivate();
 		ProviderTraceLogger::clear_runtime_context();
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
@@ -3581,12 +3584,13 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test one-time confirmed abilities are merged into the resolver tool set.
+	 * System runs without a logged-in user retain explicitly approved abilities.
 	 */
 	public function test_resolve_abilities_includes_approved_once_abilities(): void {
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			$this->markTestSkipped( 'Abilities API not available.' );
 		}
+		wp_set_current_user( 0 );
 
 		$loop = new AgentLoop(
 			'Test prompt',
@@ -3612,6 +3616,45 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 		$this->assertContains( 'sd-ai-agent/memory-list', $names );
 		$this->assertContains( 'sd-ai-agent/memory-save', $names );
+	}
+
+	/** Explicit run abilities remain constrained by a seller's role allowlist. */
+	public function test_resolve_abilities_filters_explicit_tools_for_seller(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_role( 'seller', 'Seller', array( 'read' => true ) );
+		$seller_id = self::factory()->user->create( array( 'role' => 'seller' ) );
+		RolePermissions::update(
+			array(
+				'seller' => array(
+					'chat_access'       => true,
+					'allowed_abilities' => array( 'sd-ai-agent/memory-list' ),
+				),
+			)
+		);
+		wp_set_current_user( $seller_id );
+		$catalog = JsAbilityCatalog::get_descriptors_by_name();
+
+		$loop = new AgentLoop(
+			'Test prompt',
+			array( 'sd-ai-agent/memory-list', 'sd-ai-agent/memory-save' ),
+			array(),
+			array( 'client_abilities' => array( $catalog['sd-ai-agent-js/navigate-to'] ) )
+		);
+		$method = new \ReflectionMethod( AgentLoop::class, 'resolve_abilities' );
+		$method->setAccessible( true );
+
+		$resolved = $method->invoke( $loop );
+		$names    = array_map(
+			static fn( $ability ): string => $ability instanceof \WP_Ability ? $ability->get_name() : '',
+			is_array( $resolved ) ? $resolved : array()
+		);
+
+		$this->assertContains( 'sd-ai-agent/memory-list', $names );
+		$this->assertNotContains( 'sd-ai-agent/memory-save', $names );
+		$this->assertNotContains( 'sd-ai-agent-js/navigate-to', $names );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/SdAiAgent/Core/RolePermissionsTest.php
+++ b/tests/SdAiAgent/Core/RolePermissionsTest.php
@@ -23,6 +23,8 @@ class RolePermissionsTest extends WP_UnitTestCase {
 	public function tear_down(): void {
 		parent::tear_down();
 		delete_option( RolePermissions::OPTION_NAME );
+		remove_role( 'seller' );
+		remove_all_filters( 'sd_ai_agent_explicit_ability_allowlist_roles' );
 	}
 
 	// ── constants ─────────────────────────────────────────────────────────
@@ -313,6 +315,53 @@ class RolePermissionsTest extends WP_UnitTestCase {
 		wp_set_current_user( $editor_id );
 
 		$this->assertFalse( RolePermissions::current_user_has_chat_access() );
+	}
+
+	/** Seller access fails closed until a non-empty ability allowlist is saved. */
+	public function test_seller_requires_explicit_non_empty_allowlist(): void {
+		add_role( 'seller', 'Seller', array( 'read' => true ) );
+		$seller_id = $this->factory->user->create( [ 'role' => 'seller' ] );
+		wp_set_current_user( $seller_id );
+
+		$this->assertFalse( RolePermissions::current_user_has_chat_access() );
+		$this->assertSame( [], RolePermissions::get_allowed_abilities_for_current_user() );
+
+		RolePermissions::update(
+			[
+				'seller' => [
+					'chat_access'       => true,
+					'allowed_abilities' => [ 'sd-ai-agent/report-inability' ],
+				],
+			]
+		);
+
+		$this->assertTrue( RolePermissions::current_user_has_chat_access() );
+		$this->assertSame(
+			[ 'sd-ai-agent/report-inability' ],
+			RolePermissions::get_allowed_abilities_for_current_user()
+		);
+	}
+
+	/** A permissive secondary role cannot bypass the seller restriction. */
+	public function test_seller_restriction_overrides_permissive_secondary_role(): void {
+		add_role( 'seller', 'Seller', array( 'read' => true ) );
+		$seller_id = $this->factory->user->create( [ 'role' => 'seller' ] );
+		$user      = get_user_by( 'id', $seller_id );
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$user->add_role( 'editor' );
+		wp_set_current_user( $seller_id );
+
+		RolePermissions::update(
+			[
+				'seller' => [
+					'chat_access'       => true,
+					'allowed_abilities' => [],
+				],
+			]
+		);
+
+		$this->assertFalse( RolePermissions::current_user_has_chat_access() );
+		$this->assertSame( [], RolePermissions::get_allowed_abilities_for_current_user() );
 	}
 
 	// ── get_allowed_abilities_for_current_user ────────────────────────────

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -25,6 +25,7 @@ use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\Database;
+use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Automations\AutomationRunner;
 use SdAiAgent\Automations\HumanApprovalGate;
@@ -92,6 +93,8 @@ class RestControllerTest extends WP_UnitTestCase {
 		$wp_rest_server = null;
 		remove_all_filters( 'sd_ai_agent_provider_request_max_bytes' );
 		remove_all_filters( 'sd_ai_agent_provider_request_safety_margin_bytes' );
+		delete_option( RolePermissions::OPTION_NAME );
+		remove_role( 'seller' );
 
 		parent::tear_down();
 	}
@@ -123,6 +126,21 @@ class RestControllerTest extends WP_UnitTestCase {
 		}
 
 		return $this->server->dispatch( $request );
+	}
+
+	/** Create a seller with the minimum explicit chat allowlist. */
+	private function create_chat_seller(): int {
+		add_role( 'seller', 'Seller', array( 'read' => true ) );
+		RolePermissions::update(
+			array(
+				'seller' => array(
+					'chat_access'       => true,
+					'allowed_abilities' => array( 'sd-ai-agent/report-inability' ),
+				),
+			)
+		);
+
+		return self::factory()->user->create( array( 'role' => 'seller' ) );
 	}
 
 	/**
@@ -281,6 +299,15 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertIsArray( $response->get_data() );
 	}
 
+	/** A configured seller may discover models without receiving admin access. */
+	public function test_providers_allows_configured_seller(): void {
+		wp_set_current_user( $this->create_chat_seller() );
+		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/providers' );
+
+		$this->assertStatus( 200, $response );
+		$this->assertIsArray( $response->get_data() );
+	}
+
 	// ─── /settings ───────────────────────────────────────────────────────────
 
 	/**
@@ -314,6 +341,31 @@ class RestControllerTest extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/settings' );
 		$this->assertStatus( 401, $response );
+	}
+
+	/** Seller settings responses expose presentation values only. */
+	public function test_get_settings_returns_sanitized_chat_settings_for_seller(): void {
+		Settings::instance()->update(
+			array(
+				'keyboard_shortcut'      => 'alt+v',
+				'greeting_message'       => 'Welcome vendor',
+				'system_prompt'          => 'Private administrator instruction',
+				'brave_search_api_key'   => 'private-search-key',
+				'show_tool_call_details' => true,
+			)
+		);
+		wp_set_current_user( $this->create_chat_seller() );
+
+		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/settings' );
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 'alt+v', $data['keyboard_shortcut'] ?? '' );
+		$this->assertSame( 'Welcome vendor', $data['greeting_message'] ?? '' );
+		$this->assertArrayNotHasKey( 'system_prompt', $data );
+		$this->assertArrayNotHasKey( 'brave_search_api_key', $data );
+		$this->assertArrayNotHasKey( '_features', $data );
+		$this->assertArrayNotHasKey( '_gsc_credentials', $data );
 	}
 
 	// ─── /memory ─────────────────────────────────────────────────────────────
@@ -1040,6 +1092,76 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'status', $data );
 		$this->assertSame( 'processing', $data['status'] );
 		$this->assertNotEmpty( $data['job_id'] );
+	}
+
+	/** Seller sessions and jobs remain isolated from other sellers. */
+	public function test_seller_chat_routes_require_session_and_job_ownership(): void {
+		$owner_id   = $this->create_chat_seller();
+		$other_id   = self::factory()->user->create( array( 'role' => 'seller' ) );
+		$session_id = Database::create_session(
+			array(
+				'user_id' => $owner_id,
+				'title'   => 'Vendor private session',
+			)
+		);
+		$this->assertIsInt( $session_id );
+
+		wp_set_current_user( $owner_id );
+		$this->assertStatus( 200, $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}" ) );
+
+		wp_set_current_user( $other_id );
+		$this->assertStatus( 403, $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}" ) );
+		$this->assertStatus(
+			403,
+			$this->dispatch(
+				'POST',
+				'/sd-ai-agent/v1/run',
+				array(
+					'message'    => 'Continue another vendor session',
+					'session_id' => $session_id,
+				)
+			)
+		);
+
+		$job_id = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			array( 'status' => 'processing', 'user_id' => $owner_id ),
+			RestController::JOB_TTL
+		);
+		$this->assertStatus( 403, $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" ) );
+
+		wp_set_current_user( $owner_id );
+		$this->assertStatus( 200, $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" ) );
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertStatus( 200, $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" ) );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+	}
+
+	/** Non-admin chat users cannot persist site-wide tool approval settings. */
+	public function test_seller_cannot_persist_always_allow_from_tool_confirmation(): void {
+		$seller_id = $this->create_chat_seller();
+		$job_id    = 'ffffffff-eeee-4ddd-8ccc-bbbbbbbbbbbb';
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			array(
+				'status'        => 'awaiting_confirmation',
+				'user_id'       => $seller_id,
+				'pending_tools' => array( array( 'ability' => 'sd-ai-agent/report-inability' ) ),
+			),
+			RestController::JOB_TTL
+		);
+		wp_set_current_user( $seller_id );
+
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/job/{$job_id}/confirm",
+			array( 'always_allow' => true )
+		);
+
+		$this->assertStatus( 403, $response );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
 	}
 
 	/** Public chat is disabled for anonymous visitors by default. */
@@ -1951,6 +2073,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
 
 		$session  = Database::get_session( $session_id );
+		$this->assertNotNull( $session );
 		$messages = json_decode( (string) $session->messages, true );
 		$paused   = json_decode( (string) $session->paused_state, true );
 
@@ -2042,6 +2165,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
 
 		$session       = Database::get_session( $session_id );
+		$this->assertNotNull( $session );
 		$messages      = json_decode( (string) $session->messages, true );
 		$stored_calls  = json_decode( (string) $session->tool_calls, true );
 		$this->assertIsArray( $messages );
@@ -2116,6 +2240,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
 
 		$session  = Database::get_session( $session_id );
+		$this->assertNotNull( $session );
 		$messages = json_decode( (string) $session->messages, true );
 
 		$this->assertCount( 3, $messages );

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -119,6 +119,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
 		}
 
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
 		$base_url         = 'https://service.example/v1';
 		$registration_url = $base_url . '/site/installations';
 		$models_url       = $base_url . '/models';
@@ -224,6 +226,47 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$second_response = $controller->handle_providers();
 		$this->assertSame( 200, $second_response->get_status() );
 		$this->assertSame( 1, $registration_hits );
+	}
+
+	/** Non-admin provider discovery never provisions or rotates site credentials. */
+	public function test_handle_providers_does_not_auto_provision_for_non_admin(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$base_url          = 'https://service.example/v1';
+		$registration_url  = $base_url . '/site/installations';
+		$registration_hits = 0;
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $registration_url, &$registration_hits ): mixed {
+				unset( $parsed_args );
+				if ( $registration_url !== $url ) {
+					return $preempt;
+				}
+
+				++$registration_hits;
+				return array(
+					'response' => array( 'code' => 201, 'message' => 'Created' ),
+					'body'     => wp_json_encode(
+						array(
+							'installation_id' => 'unexpected-installation',
+							'site_token'      => 'unexpected-token',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_providers();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $registration_hits );
+		$this->assertSame( '', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 	}
 
 	/**
@@ -1130,11 +1173,15 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 
 		$this->assertSame( 200, $whatsapp_response->get_status() );
 		$this->assertSame( 200, $telegram_response->get_status() );
-		$encoded = wp_json_encode( [ $whatsapp_response->get_data(), $telegram_response->get_data() ] ) ?: '';
+		$whatsapp_data = $whatsapp_response->get_data();
+		$telegram_data = $telegram_response->get_data();
+		$this->assertIsArray( $whatsapp_data );
+		$this->assertIsArray( $telegram_data );
+		$encoded = wp_json_encode( [ $whatsapp_data, $telegram_data ] ) ?: '';
 		$this->assertStringNotContainsString( 'meta-secret-token', $encoded );
 		$this->assertStringNotContainsString( 'telegram-secret', $encoded );
-		$this->assertSame( '********7890', $whatsapp_response->get_data()['phone_number_id_redacted'] ?? '' );
-		$this->assertTrue( $telegram_response->get_data()['has_bot_token'] ?? false );
+		$this->assertSame( '********7890', $whatsapp_data['phone_number_id_redacted'] ?? '' );
+		$this->assertTrue( $telegram_data['has_bot_token'] ?? false );
 
 		$whatsapp_update = $controller->handle_set_whatsapp_provider(
 			$this->json_request(


### PR DESCRIPTION
## Summary

- restore the least-privilege Dokan vendor assistant that was merged in #2678 and removed during the v1.23.0 release preparation in #2687
- require sellers to have chat enabled with an explicit non-empty ability allowlist
- isolate seller sessions and background jobs by owner, including shared-session and continuation paths
- add the embedded, simplified AI Assistant screen to the Dokan vendor dashboard
- preserve the current v1.23.0 core/Advanced packaging and updater architecture

## Security boundaries

- sellers fail closed when their allowlist is absent or empty
- restrictive marketplace roles cannot inherit unrestricted access from a secondary role
- non-admin users cannot persist site-wide tool approvals
- vendor-simple mode omits admin-oriented controls
- this PR does not add product, order, store, file, database, or administrative mutations

## Verification

- `pnpm run verify`: 4,391 PHP tests, 20,437 assertions; lint, PHPStan, production build, and bundle budgets passed
- post-sync focused PHP suite: 388 tests, 1,443 assertions, 68 skipped
- focused JavaScript suites: 2 passed, 5 tests passed
- production multisite smoke test: vendor navigation present; owner session/job access allowed; second vendor denied; admin settings and commerce ability denied

Resolves #2677

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 9m and 447,174 tokens on this with the user in an interactive session.