### PR TITLE
feat: preserve native tool search state with OAuth

### DIFF
--- a/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
+++ b/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
@@ -1,0 +1,138 @@
+# Native tool-search continuity
+
+## Scope
+
+The SD AI provider's experimental Responses model can continue an authenticated,
+persisted agent session using server-managed `previous_response_id`. This is a
+plugin-only implementation: it requires no PHP AI Client, WordPress core, or
+OpenAI connector changes. Other providers are unchanged.
+
+The service must support **both `/responses` with hosted `tool_search` and stored
+response continuation**. A managed model alias is not evidence of support. Keep
+the existing `sd_ai_agent_openai_tool_search_enabled` opt-in disabled for managed
+aliases until their service deployment supports this contract.
+
+## State and request behavior
+
+`AgentLoop::configure_model()` binds the server-owned session ID to the native
+model. `ResponsesContinuation` stores a one-day WordPress transient scoped to the
+site, session and current user. Its contents are only the response ID,
+acknowledged input count, history fingerprint and configuration fingerprint.
+It does not store prompts, function results, credentials or raw native output.
+
+The configuration fingerprint includes provider, model, endpoint, function
+descriptions/schemas and a site-salted HMAC of the bound API credential. Unknown
+authentication implementations do not get automatic persisted continuation.
+
+After a successful completed response, the cursor acknowledges the normalized
+local input plus the returned model message. On the next call, an identical
+prefix allows the model to send:
+
+- `previous_response_id` referencing that response;
+- only new function results or the new user turn in `input`;
+- current instructions and tool definitions, as required by Responses.
+
+The ordinary SDK history remains authoritative and continues to be serialized by
+the existing session/confirmation/browser-tool paths. No response ID is accepted
+from browser history. Fresh model objects can load the transient after a request
+boundary. Existing session concurrency controls remain responsible for serializing
+agent jobs; the transient is not a new lock or atomic job checkpoint.
+
+## Invalidation and fallback
+
+- Changed/compacted history, changed tools/model/endpoint/credential, missing or
+  expired cursors, and user/session mismatches cannot reuse the old cursor.
+- If tool history requires native state but no matching cursor is available,
+  send ordinary full history through the existing Chat Completions adapter.
+  Do not invent missing native discovery, namespace or reasoning items.
+- `store: false` clears the cursor and uses Chat Completions. This implementation
+  does not provide stateless native replay for zero-retention deployments.
+- Recognized Responses/tool-search/response-ID rejection clears the cursor and
+  falls back. Server failures propagate without advancing the acknowledgment.
+- An explicit SDK custom `previous_response_id` remains caller-managed; it does
+  not update the automatic session cursor.
+
+Falling back cannot reproduce hidden native state, but retains the ordinary
+messages and tool results. Native continuity remains an optimization, not a
+replacement for permission checks or durable local conversation storage.
+
+## Deterministic verification
+
+```sh
+php bin/run-wp-phpunit.php --filter=ResponsesContinuationTest --no-coverage
+php bin/run-wp-phpunit.php --filter='ResponsesContinuationTest|SuperdavAiProviderTest|AgentLoopTest|AgentLoopClientToolsTest' --no-coverage
+vendor/bin/phpcs includes/Core/AgentLoop.php includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+```
+
+The regression suite exercises cursor reconstruction, private-content exclusion,
+identity/history/configuration invalidation, serialized tool-result boundaries,
+new user turns, missing/rejected cursors, storage opt-out, credential rotation,
+and retry behavior. A real `AgentLoop` with a recording mocked HTTP boundary
+proves session binding, tool execution, suffix-only requests and response-ID
+rotation across a second loop instance. Inference is mocked in these tests.
+
+## Live experiment: 2026-09-09
+
+Real inference was sent through `AgentLoop` to the configured SD development
+service, using its advertised `superdav-chat-pro` alias. The experiment used the
+existing disposable WordPress test database and a fixture post, not production
+content. Only the actual `list-posts` and `get-post` abilities were allowed.
+Credentials stayed in process memory; shared site activation/settings/schema
+were not changed. Provider traces were inspected in the disposable environment;
+only aggregate measurements and synthetic answers are reported here.
+
+Prompts:
+
+1. Find the published post titled “Continuity Observatory,” read its content,
+   and report its calibration code and measurement window without guessing.
+2. Using that window, calculate the duration of two windows without another
+   tool call.
+
+Both runs correctly returned **7341**, **19 minutes**, then **38 minutes**, using
+three agent iterations on the first turn and one on the second.
+
+| Measurement | Native flag off | Native flag on, actual fallback |
+| --- | ---: | ---: |
+| Successful Chat Completions requests | 4 | 4 |
+| Responses requests | 0 | 1, HTTP 404 |
+| First-turn wall time | 7.694 s | 8.200 s |
+| Second-turn wall time | 3.190 s | 1.607 s |
+| Successful inference request-body bytes | 205,083 | 190,106 |
+| Extra failed Responses request-body bytes | 0 | 46,432 |
+| Provider-reported input tokens | 42,886 | 40,054 |
+| Provider-reported output tokens | 182 | 196 |
+| Provider-reported cached input tokens | 19,456 | 18,432 |
+| Requests containing `previous_response_id` | 0 | 0 |
+
+Token measurements come from HTTP response usage, not the agent's aggregate
+usage result (which was zero in this environment). SDK trace rows were excluded
+to avoid double-counting the same inference.
+
+**This is fallback evidence, not a native performance benchmark.** The available
+service returned HTTP 404 for `/v1/responses`. No live hosted discovery or stored
+response continuation occurred. The native flag also changes prompt construction,
+so even the differing token counts cannot be attributed to native tool search.
+One sample per mode and non-deterministic inference do not establish a latency
+improvement. The two-tool workload is only a functional smoke test, not a
+representative large-catalog benchmark.
+
+An initial raw `gpt-5.5` probe failed model selection after a tool call because
+the service advertises managed aliases rather than that raw model ID. Switching
+to the advertised alias resolved that test setup issue.
+
+## Before enabling or declaring live verification complete
+
+1. Use an SD service deployment and credential that support hosted tool search,
+   stored response IDs and the chosen advertised model.
+2. Repeat the two-turn fixture through a real agent session with tracing enabled
+   in a development environment. Verify each ID matches the immediately preceding
+   response, tool follow-ups contain only new `function_call_output`, and later
+   user turns contain only new user input. Check the native discovery output too.
+3. Repeat across an actual confirmation/browser pause and a new PHP request,
+   including cursor eviction and expired server state.
+4. Run repeated matched tasks over a representative permission-filtered catalog
+   with native search on/off. Compare correctness, tool selection, iterations,
+   HTTP bytes, usage/cache tokens and wall time. Do not assume less upload data
+   means fewer billed cumulative input tokens.
+
+Until those gates pass, keep the change experimental and the PR in draft.

--- a/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
+++ b/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
@@ -1,179 +1,127 @@
-# Native tool-search continuity
+# Native tool-search continuity with OAuth
 
-## Scope
+## Contract
 
-The SD AI provider's experimental Responses model can continue an authenticated,
-persisted agent session using server-managed `previous_response_id`. This is a
-plugin-only implementation: it requires no PHP AI Client, WordPress core, or
-OpenAI connector changes. Other providers are unchanged.
+The SD provider keeps its existing OAuth-backed upstream. Native requests use
+`/v1/responses`, `store: false`, and `include: ["reasoning.encrypted_content"]`.
+They do **not** use `previous_response_id` or require an OpenAI API key.
 
-The service must support **both `/responses` with hosted `tool_search` and stored
-response continuation**. A managed model alias is not evidence of support. Keep
-the existing `sd_ai_agent_openai_tool_search_enabled` opt-in disabled for managed
-aliases until their service deployment supports this contract.
+No PHP AI Client, WordPress core, or OpenAI connector changes are needed. The SD
+service wrapper must expose the stateless Responses forwarding route; the
+previously deployed wrapper lacked it. Managed aliases retain their existing
+`sd_ai_agent_openai_tool_search_enabled` opt-in until the matching service is
+deployed and reviewed. Other providers are unchanged.
 
-## State and request behavior
+## Complete native replay
 
-`AgentLoop::configure_model()` binds the server-owned session ID to the native
-model. `ResponsesContinuation` stores a one-day WordPress transient scoped to the
-site, session and current user. Its contents are only the response ID,
-acknowledged input count, history fingerprint and configuration fingerprint.
-It does not store prompts, function results, credentials or raw native output.
+`AgentLoop::configure_model()` binds the authenticated session to the SD model.
+After each completed response, `ResponsesContinuation` records:
 
-The configuration fingerprint includes provider, model, endpoint, function
-descriptions/schemas and a site-salted HMAC of the bound API credential. Unknown
-authentication implementations do not get automatic persisted continuation.
+- the normalized SDK history's acknowledged prefix count and fingerprint;
+- a provider/model/endpoint/function-schema/credential scope fingerprint;
+- an **encrypted snapshot of the complete native input plus raw output items**.
 
-After a successful completed response, the cursor acknowledges the normalized
-local input plus the returned model message. On the next call, an identical
-prefix allows the model to send:
+On the next call, the SDK prefix must match. The model then replays the saved
+native sequence and appends only the new local user input or function results.
+It never duplicates the reconstructed SDK assistant messages on top of native
+output. Reasoning items (including `encrypted_content`), discovery calls/results,
+function calls, namespaces, IDs, and provider-specific fields remain intact.
+Current instructions and tool declarations are sent on every request.
 
-- `previous_response_id` referencing that response;
-- only new function results or the new user turn in `input`;
-- current instructions and tool definitions, as required by Responses.
+The ordinary SDK history remains authoritative for UI, persistence, compaction,
+and confirmation/browser-tool boundaries. A snapshot is not a concurrency lock;
+existing job/session serialization remains responsible for parallel requests.
 
-The ordinary SDK history remains authoritative and continues to be serialized by
-the existing session/confirmation/browser-tool paths. No response ID is accepted
-from browser history. Fresh model objects can load the transient after a request
-boundary. Existing session concurrency controls remain responsible for serializing
-agent jobs; the transient is not a new lock or atomic job checkpoint.
+## Retention and fallback
 
-## Invalidation and fallback
+- Snapshots use one-day WordPress transients scoped to site/session/user.
+- Raw native history is encrypted with AES-256-GCM using a domain-separated key
+  derived from WordPress's auth salt. Authenticated metadata binds ciphertext to
+  the session key, scope, prefix hash and count. Public metadata contains no
+  plaintext prompt/tool result or credential value.
+- The snapshot's JSON is capped at 1 MiB. Missing OpenSSL, oversized snapshots,
+  corrupted ciphertext, salt/credential changes, expired state, or changed local
+  history/catalog cannot produce a partial native replay.
+- If tool history exists but no valid native snapshot remains, use full ordinary
+  SDK history through Chat Completions. Recognized native request rejection also
+  clears the snapshot and falls back. Server failures do not advance it.
+- `store: false` controls upstream retention, **not zero local retention**: this
+  feature deliberately retains an encrypted local copy for up to one day, in
+  addition to the agent's ordinary session history. Deleting/compacting a session
+  makes old state unusable; transient expiry handles the auxiliary retention.
+- Explicit custom `previous_response_id` is incompatible with this OAuth path and
+  uses the compatible fallback. The implementation does not silently switch to
+  API-key billing or fabricate missing native state.
+- `tool_search` is emitted only when at least one function is deferred. Upstream
+  rejects eager-only catalogs containing a tool-search declaration.
 
-- Changed/compacted history, changed tools/model/endpoint/credential, missing or
-  expired cursors, and user/session mismatches cannot reuse the old cursor.
-- If tool history requires native state but no matching cursor is available,
-  send ordinary full history through the existing Chat Completions adapter.
-  Do not invent missing native discovery, namespace or reasoning items.
-- `store: false` clears the cursor and uses Chat Completions. This implementation
-  does not provide stateless native replay for zero-retention deployments.
-- Recognized Responses/tool-search/response-ID rejection clears the cursor and
-  falls back. Server failures propagate without advancing the acknowledgment.
-- An explicit SDK custom `previous_response_id` remains caller-managed; it does
-  not update the automatic session cursor.
+## Live verification: 2026-09-09
 
-Falling back cannot reproduce hidden native state, but retains the ordinary
-messages and tool results. Native continuity remains an optimization, not a
-replacement for permission checks or durable local conversation storage.
+A temporary dev service used the existing SD OAuth backend and the advertised
+`superdav-chat-pro` alias. Actual `AgentLoop` calls used a disposable WordPress
+fixture and only `list-terms`, `list-posts`, and `get-post`. No production
+deployment, account change, or shared-site activation/schema change was made.
 
-## Deterministic verification
+The tasks retrieved a category description (**CERULEAN-842**), then a published
+post's calibration values (**7341**, **19 minutes**), then calculated **38 minutes**.
+
+Verified from HTTP traces and assertions:
+
+1. Actual `tool_search_call`, `tool_search_output`, and function-call output.
+2. All six calls returned HTTP 200 through `/v1/responses`; **no fallback**.
+3. Every follow-up replayed the exact preceding native input plus output as its
+   prefix, including encrypted reasoning. Every call used `store: false` and no
+   `previous_response_id`.
+4. The second and third user turns ran in **fresh PHP processes**, reading the
+   encrypted snapshot from the database rather than relying on object memory.
+5. A separate run explicitly paused `list-terms` for confirmation and approved
+   that read-only fixture in a fresh PHP process. Native replay continued across
+   the pause and subsequent turns; all six requests stayed native and successful.
+
+The fresh-process run passed 49 assertions; the confirmation run passed 54.
+The latter is confirmation-path evidence, not a claim that browser UI E2E ran.
+
+## Small-workload comparison
+
+One matched three-tool run per mode, with the same prompts/model and fresh PHP
+processes on turns two and three:
+
+| Measurement | OAuth native replay | Eager Chat Completions |
+| --- | ---: | ---: |
+| Correct tasks | 3/3 | 3/3 |
+| Provider calls | 6 | 6 |
+| Total wall time | 20.735 s | 18.087 s |
+| Provider input tokens | 63,838 | 66,667 |
+| Provider output tokens | 332 | 428 |
+| Cached input tokens | 19,968 | 31,232 |
+| Total HTTP request-body bytes | 321,946 | 320,396 |
+
+**No speedup is established.** Native replay was slower in this small sample,
+with fewer input tokens and slightly more upload bytes. Cache state, stochastic
+output, and mode-specific prompt construction differ. This is a functional
+three-tool smoke comparison, not a statistically meaningful large-catalog
+benchmark. Use repeated representative workloads before making performance claims.
+
+Usage comes from HTTP responses; SDK trace rows are excluded to avoid double
+counting. The agent's aggregate token result was zero in this environment.
+Trace collection uses a per-run high-water mark to exclude older fixture rows.
+
+## Regression checks
 
 ```sh
-php bin/run-wp-phpunit.php --filter=ResponsesContinuationTest --no-coverage
+php bin/run-wp-phpunit.php --filter='ResponsesContinuationTest|SuperdavAiProviderTest' --no-coverage
 php bin/run-wp-phpunit.php --filter='ResponsesContinuationTest|SuperdavAiProviderTest|AgentLoopTest|AgentLoopClientToolsTest' --no-coverage
-vendor/bin/phpcs includes/Core/AgentLoop.php includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+vendor/bin/phpcs includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
 ```
 
-The regression suite exercises cursor reconstruction, private-content exclusion,
-identity/history/configuration invalidation, serialized tool-result boundaries,
-new user turns, missing/rejected cursors, storage opt-out, credential rotation,
-and retry behavior. A real `AgentLoop` with a recording mocked HTTP boundary
-proves session binding, tool execution, suffix-only requests and response-ID
-rotation across a second loop instance. Inference is mocked in these tests.
+Tests cover complete native replay, exact prefix matching, real agent-loop binding
+with mocked HTTP, encryption/tampering/session isolation, bounded retention,
+credential/catalog changes, eviction, storage opt-out, retries and eager-only tools.
 
-## Live experiment: 2026-09-09
+## Delivery boundary
 
-Real inference was sent through `AgentLoop` to the configured SD development
-service, using its advertised `superdav-chat-pro` alias. The experiment used the
-existing disposable WordPress test database and a fixture post, not production
-content. Only the actual `list-posts` and `get-post` abilities were allowed.
-Credentials stayed in process memory; shared site activation/settings/schema
-were not changed. Provider traces were inspected in the disposable environment;
-only aggregate measurements and synthetic answers are reported here.
-
-Prompts:
-
-1. Find the published post titled “Continuity Observatory,” read its content,
-   and report its calibration code and measurement window without guessing.
-2. Using that window, calculate the duration of two windows without another
-   tool call.
-
-Both runs correctly returned **7341**, **19 minutes**, then **38 minutes**, using
-three agent iterations on the first turn and one on the second.
-
-| Measurement | Native flag off | Native flag on, actual fallback |
-| --- | ---: | ---: |
-| Successful Chat Completions requests | 4 | 4 |
-| Responses requests | 0 | 1, HTTP 404 |
-| First-turn wall time | 7.694 s | 8.200 s |
-| Second-turn wall time | 3.190 s | 1.607 s |
-| Successful inference request-body bytes | 205,083 | 190,106 |
-| Extra failed Responses request-body bytes | 0 | 46,432 |
-| Provider-reported input tokens | 42,886 | 40,054 |
-| Provider-reported output tokens | 182 | 196 |
-| Provider-reported cached input tokens | 19,456 | 18,432 |
-| Requests containing `previous_response_id` | 0 | 0 |
-
-Token measurements come from HTTP response usage, not the agent's aggregate
-usage result (which was zero in this environment). SDK trace rows were excluded
-to avoid double-counting the same inference.
-
-**This initial run is fallback evidence, not a native performance benchmark.**
-The service returned HTTP 404 for `/v1/responses`. No live hosted discovery or
-stored response continuation occurred in that run. The native flag also changes prompt construction,
-so even the differing token counts cannot be attributed to native tool search.
-One sample per mode and non-deterministic inference do not establish a latency
-improvement. The two-tool workload is only a functional smoke test, not a
-representative large-catalog benchmark.
-
-An initial raw `gpt-5.5` probe failed model selection after a tool call because
-the service advertises managed aliases rather than that raw model ID. Switching
-to the advertised alias resolved that test setup issue.
-
-## Follow-up: native discovery verified through an isolated dev wrapper
-
-A later investigation located the deployment wrapper and confirmed that its
-public edge had no Responses route, although the Sub2API backend supports
-Responses. An isolated dev implementation was tested without replacing the
-running service. Its route preserves edge authentication/accounting and returns
-encrypted, site-bound response cursors rather than exposing a cross-installation
-continuation primitive through a shared upstream pool.
-
-The plugin now accepts bounded opaque response IDs up to 2,048 bytes for that
-wrapper. The live test also exposed and fixed an existing adapter defect:
-`tool_search` must be omitted when every configured function is eager. Upstream
-explicitly rejects tool search without at least one deferred tool.
-
-The expanded fixture supplied `list-posts`, `get-post`, and deferred `list-terms`.
-It asked first for the description of a synthetic category, then for the fixture
-post's calibration values, then for twice its measurement window. Traces showed:
-
-1. HTTP **200** from `/v1/responses`, with actual **`tool_search_call`**,
-   **`tool_search_output`** and **`function_call`** output items.
-2. The next request contained the matching `previous_response_id` and exactly
-   one new **`function_call_output`**, with no acknowledged history replay.
-3. Sub2API rejected that continuation: **“previous_response_id requires an
-   OpenAI API-key account for HTTP requests.”** The dev backend's aggregate
-   account-type check found one active OpenAI OAuth account and no API-key account.
-4. A sanitized HTTP 400 from the wrapper activated the plugin's Chat Completions
-   fallback. All three answers were correct: **CERULEAN-842**, **7341 / 19 minutes**,
-   and **38 minutes**. The live fixture passed 12 assertions.
-
-The first native response reported 10,736 input tokens and 252 output tokens.
-These observations prove **hosted native discovery and correct continuation
-request construction**, but not successful server-stored continuation or a
-performance gain. The existing OAuth account can perform tool search; the
-restriction concerns HTTP stored-response continuation in this Sub2API routing
-configuration, not tool search itself.
-
-Completing native continuity therefore requires either an explicitly approved
-API-key-backed upstream or a separate implementation preserving/replaying the
-complete native state for OAuth. Do not silently switch billing routes, drop
-native discovery/reasoning state, or present fallback timings as native results.
-
-## Before enabling or declaring live verification complete
-
-1. Use an SD service deployment and credential that support hosted tool search,
-   stored response IDs and the chosen advertised model.
-2. Repeat the two-turn fixture through a real agent session with tracing enabled
-   in a development environment. Verify each ID matches the immediately preceding
-   response, tool follow-ups contain only new `function_call_output`, and later
-   user turns contain only new user input. Check the native discovery output too.
-3. Repeat across an actual confirmation/browser pause and a new PHP request,
-   including cursor eviction and expired server state.
-4. Run repeated matched tasks over a representative permission-filtered catalog
-   with native search on/off. Compare correctness, tool selection, iterations,
-   HTTP bytes, usage/cache tokens and wall time. Do not assume less upload data
-   means fewer billed cumulative input tokens.
-
-Until those gates pass, keep the change experimental and the PR in draft.
+Keep the PR experimental until the matching service route is deployed and its
+accounting/security review is complete. Browser-tool UI E2E and representative
+large-catalog performance evaluation remain follow-ups. The OAuth continuation
+blocker itself is resolved by replay; no new billing route is needed.

--- a/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
+++ b/docs/NATIVE_TOOL_SEARCH_CONTINUITY.md
@@ -108,9 +108,9 @@ Token measurements come from HTTP response usage, not the agent's aggregate
 usage result (which was zero in this environment). SDK trace rows were excluded
 to avoid double-counting the same inference.
 
-**This is fallback evidence, not a native performance benchmark.** The available
-service returned HTTP 404 for `/v1/responses`. No live hosted discovery or stored
-response continuation occurred. The native flag also changes prompt construction,
+**This initial run is fallback evidence, not a native performance benchmark.**
+The service returned HTTP 404 for `/v1/responses`. No live hosted discovery or
+stored response continuation occurred in that run. The native flag also changes prompt construction,
 so even the differing token counts cannot be attributed to native tool search.
 One sample per mode and non-deterministic inference do not establish a latency
 improvement. The two-tool workload is only a functional smoke test, not a
@@ -119,6 +119,47 @@ representative large-catalog benchmark.
 An initial raw `gpt-5.5` probe failed model selection after a tool call because
 the service advertises managed aliases rather than that raw model ID. Switching
 to the advertised alias resolved that test setup issue.
+
+## Follow-up: native discovery verified through an isolated dev wrapper
+
+A later investigation located the deployment wrapper and confirmed that its
+public edge had no Responses route, although the Sub2API backend supports
+Responses. An isolated dev implementation was tested without replacing the
+running service. Its route preserves edge authentication/accounting and returns
+encrypted, site-bound response cursors rather than exposing a cross-installation
+continuation primitive through a shared upstream pool.
+
+The plugin now accepts bounded opaque response IDs up to 2,048 bytes for that
+wrapper. The live test also exposed and fixed an existing adapter defect:
+`tool_search` must be omitted when every configured function is eager. Upstream
+explicitly rejects tool search without at least one deferred tool.
+
+The expanded fixture supplied `list-posts`, `get-post`, and deferred `list-terms`.
+It asked first for the description of a synthetic category, then for the fixture
+post's calibration values, then for twice its measurement window. Traces showed:
+
+1. HTTP **200** from `/v1/responses`, with actual **`tool_search_call`**,
+   **`tool_search_output`** and **`function_call`** output items.
+2. The next request contained the matching `previous_response_id` and exactly
+   one new **`function_call_output`**, with no acknowledged history replay.
+3. Sub2API rejected that continuation: **“previous_response_id requires an
+   OpenAI API-key account for HTTP requests.”** The dev backend's aggregate
+   account-type check found one active OpenAI OAuth account and no API-key account.
+4. A sanitized HTTP 400 from the wrapper activated the plugin's Chat Completions
+   fallback. All three answers were correct: **CERULEAN-842**, **7341 / 19 minutes**,
+   and **38 minutes**. The live fixture passed 12 assertions.
+
+The first native response reported 10,736 input tokens and 252 output tokens.
+These observations prove **hosted native discovery and correct continuation
+request construction**, but not successful server-stored continuation or a
+performance gain. The existing OAuth account can perform tool search; the
+restriction concerns HTTP stored-response continuation in this Sub2API routing
+configuration, not tool search itself.
+
+Completing native continuity therefore requires either an explicitly approved
+API-key-backed upstream or a separate implementation preserving/replaying the
+complete native state for OAuth. Do not silently switch billing routes, drop
+native discovery/reasoning state, or present fallback timings as native results.
 
 ## Before enabling or declaring live verification complete
 

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3654,6 +3654,9 @@ PROMPT;
 				// This bypasses the SDK's model-listing HTTP call which
 				// can fail for OpenAI-compatible endpoints.
 				$model = $registry->getProviderModel( $provider_id, $model_id );
+				if ( $model instanceof \SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiResponsesToolSearchTextGenerationModel ) {
+					$model->set_continuation_session_id( $this->session_id );
+				}
 				$builder->using_model( $model );
 			} else {
 				$builder->using_provider( $provider_id );

--- a/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
+++ b/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
 /**
- * Stores a short-lived server conversation cursor, never the prompt or credentials.
+ * Stores encrypted, short-lived native conversation state for OAuth replay.
  *
- * A matching prefix proves which local input the server has already acknowledged.
+ * A matching prefix links ordinary SDK history to its complete native snapshot.
  * WordPress transients survive PHP requests but may be evicted; a miss must use the
  * caller's full-history fallback rather than submitting orphaned tool results.
  */
@@ -24,11 +24,11 @@ final class ResponsesContinuation {
 	}
 
 	/**
-	 * Return only input not already held by the server, if the cursor still matches.
+	 * Return complete native history followed by new local input when the prefix matches.
 	 *
 	 * @param list<array<string, mixed>> $input Full locally reconstructed input.
 	 * @param string                     $scope Model, endpoint and tool-catalog fingerprint.
-	 * @return array{previous_response_id:string,input:list<array<string,mixed>>}|null
+	 * @return array{input:list<array<string,mixed>>}|null
 	 */
 	public function resume( array $input, string $scope ): ?array {
 		$state = '' !== $this->key ? get_transient( $this->key ) : false;
@@ -47,21 +47,30 @@ final class ResponsesContinuation {
 			return null;
 		}
 
-		return array(
-			'previous_response_id' => $state['response_id'],
-			'input'                => array_values( array_slice( $input, $count ) ),
-		);
+		$native = $this->decrypt_history( $state['native'] ?? null, $scope . ':' . $state['hash'] . ':' . $count );
+		if ( null === $native ) {
+			$this->clear();
+			return null;
+		}
+		return array( 'input' => array_merge( $native, array_values( array_slice( $input, $count ) ) ) );
 	}
 
 	/**
 	 * Persist the response ID and the local history prefix represented by that response.
 	 *
-	 * @param string                     $response_id Accepted Responses API ID.
-	 * @param list<array<string, mixed>> $input       Expected acknowledged history, including model output.
-	 * @param string                     $scope       Model, endpoint and tool-catalog fingerprint.
+	 * @param string                          $response_id Accepted Responses API ID.
+	 * @param list<array<string, mixed>>      $input       Expected acknowledged history, including model output.
+	 * @param string                          $scope       Model, endpoint and tool-catalog fingerprint.
+	 * @param list<array<string, mixed>>|null $native_input Complete native input and output; null uses local input.
 	 */
-	public function acknowledge( string $response_id, array $input, string $scope ): void {
+	public function acknowledge( string $response_id, array $input, string $scope, ?array $native_input = null ): void {
 		if ( '' === $this->key || ! self::valid_response_id( $response_id ) || empty( $input ) ) {
+			$this->clear();
+			return;
+		}
+		$native = $this->encrypt_history( $native_input ?? $input, $scope . ':' . self::fingerprint( $input ) . ':' . count( $input ) );
+		if ( null === $native ) {
+			$this->clear();
 			return;
 		}
 		set_transient(
@@ -71,9 +80,63 @@ final class ResponsesContinuation {
 				'count'       => count( $input ),
 				'hash'        => self::fingerprint( $input ),
 				'scope'       => $scope,
+				'native'      => $native,
 			),
 			DAY_IN_SECONDS
 		);
+	}
+
+	/**
+	 * Encrypt at rest and bound retention; unavailable crypto disables persisted replay.
+	 *
+	 * @param list<array<string, mixed>> $input Complete native history.
+	 */
+	private function encrypt_history( array $input, string $context ): ?string {
+		if ( ! function_exists( 'openssl_encrypt' ) ) {
+			return null;
+		}
+		$json = wp_json_encode( $input );
+		if ( false === $json || strlen( $json ) > 1048576 ) {
+			return null;
+		}
+		$iv     = random_bytes( 12 );
+		$tag    = '';
+		$cipher = openssl_encrypt( $json, 'aes-256-gcm', hash( 'sha256', 'sd-ai-native-replay:' . wp_salt( 'auth' ), true ), 0, $iv, $tag, $this->key . ':' . $context );
+		return false !== $cipher ? bin2hex( $iv . $tag ) . $cipher : null;
+	}
+
+	/** @return list<array<string, mixed>>|null */
+	private function decrypt_history( mixed $encrypted, string $context ): ?array {
+		if ( ! is_string( $encrypted ) || strlen( $encrypted ) > 1400000 || ! function_exists( 'openssl_decrypt' ) ) {
+			return null;
+		}
+		if ( strlen( $encrypted ) <= 56 || ! ctype_xdigit( substr( $encrypted, 0, 56 ) ) ) {
+			return null;
+		}
+		$bytes = hex2bin( substr( $encrypted, 0, 56 ) );
+		if ( false === $bytes ) {
+			return null;
+		}
+		$json = openssl_decrypt( substr( $encrypted, 56 ), 'aes-256-gcm', hash( 'sha256', 'sd-ai-native-replay:' . wp_salt( 'auth' ), true ), 0, substr( $bytes, 0, 12 ), substr( $bytes, 12, 16 ), $this->key . ':' . $context );
+		$data = false !== $json ? json_decode( $json, true ) : null;
+		if ( ! is_array( $data ) || ! array_is_list( $data ) ) {
+			return null;
+		}
+		$validated = array();
+		foreach ( $data as $item ) {
+			if ( ! is_array( $item ) ) {
+				return null;
+			}
+			$row = array();
+			foreach ( $item as $key => $value ) {
+				if ( ! is_string( $key ) ) {
+					return null;
+				}
+				$row[ $key ] = $value;
+			}
+			$validated[] = $row;
+		}
+		return $validated;
 	}
 
 	/** Remove a cursor after fallback or incompatible history changes. */
@@ -94,7 +157,7 @@ final class ResponsesContinuation {
 
 	/** Reject malformed or unbounded opaque response IDs. */
 	private static function valid_response_id( string $response_id ): bool {
-		// The SD edge may wrap an upstream ID in an authenticated site-bound cursor.
+		// IDs are bounded diagnostic identifiers, never dereferenced during OAuth replay.
 		return strlen( $response_id ) <= 2048 && 1 === preg_match( '/^resp_[a-zA-Z0-9_-]+$/D', $response_id );
 	}
 }

--- a/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
+++ b/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Infrastructure\AiClient\Superdav;
+
+/**
+ * Stores a short-lived server conversation cursor, never the prompt or credentials.
+ *
+ * A matching prefix proves which local input the server has already acknowledged.
+ * WordPress transients survive PHP requests but may be evicted; a miss must use the
+ * caller's full-history fallback rather than submitting orphaned tool results.
+ */
+final class ResponsesContinuation {
+
+	/** @var string Site/session/user-scoped transient key. */
+	private string $key;
+
+	/** Construct a cursor for an authenticated agent session. */
+	public function __construct( int $session_id, int $user_id ) {
+		$this->key = $session_id > 0 && $user_id > 0
+			? 'sd_ai_agent_responses_' . get_current_blog_id() . '_' . $session_id . '_' . $user_id
+			: '';
+	}
+
+	/**
+	 * Return only input not already held by the server, if the cursor still matches.
+	 *
+	 * @param list<array<string, mixed>> $input Full locally reconstructed input.
+	 * @param string                     $scope Model, endpoint and tool-catalog fingerprint.
+	 * @return array{previous_response_id:string,input:list<array<string,mixed>>}|null
+	 */
+	public function resume( array $input, string $scope ): ?array {
+		$state = '' !== $this->key ? get_transient( $this->key ) : false;
+		if ( ! is_array( $state ) ) {
+			return null;
+		}
+		$count = $state['count'] ?? null;
+		if ( ! is_int( $count ) || $count < 1 || $count >= count( $input )
+			|| ! is_string( $state['response_id'] ?? null )
+			|| ! self::valid_response_id( $state['response_id'] )
+			|| ( $state['scope'] ?? null ) !== $scope
+			|| ! is_string( $state['hash'] ?? null )
+			|| ! hash_equals( $state['hash'], self::fingerprint( array_slice( $input, 0, $count ) ) )
+		) {
+			$this->clear();
+			return null;
+		}
+
+		return array(
+			'previous_response_id' => $state['response_id'],
+			'input'                => array_values( array_slice( $input, $count ) ),
+		);
+	}
+
+	/**
+	 * Persist the response ID and the local history prefix represented by that response.
+	 *
+	 * @param string                     $response_id Accepted Responses API ID.
+	 * @param list<array<string, mixed>> $input       Expected acknowledged history, including model output.
+	 * @param string                     $scope       Model, endpoint and tool-catalog fingerprint.
+	 */
+	public function acknowledge( string $response_id, array $input, string $scope ): void {
+		if ( '' === $this->key || ! self::valid_response_id( $response_id ) || empty( $input ) ) {
+			return;
+		}
+		set_transient(
+			$this->key,
+			array(
+				'response_id' => $response_id,
+				'count'       => count( $input ),
+				'hash'        => self::fingerprint( $input ),
+				'scope'       => $scope,
+			),
+			DAY_IN_SECONDS
+		);
+	}
+
+	/** Remove a cursor after fallback or incompatible history changes. */
+	public function clear(): void {
+		if ( '' !== $this->key ) {
+			delete_transient( $this->key );
+		}
+	}
+
+	/**
+	 * Hash local structures without persisting their potentially sensitive content.
+	 *
+	 * @param array<mixed> $data Local structures to fingerprint.
+	 */
+	public static function fingerprint( array $data ): string {
+		return hash( 'sha256', (string) wp_json_encode( $data ) );
+	}
+
+	/** Reject malformed or unbounded opaque response IDs. */
+	private static function valid_response_id( string $response_id ): bool {
+		return 1 === preg_match( '/^resp_[a-zA-Z0-9_-]{1,200}$/D', $response_id );
+	}
+}

--- a/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
+++ b/includes/Infrastructure/AiClient/Superdav/ResponsesContinuation.php
@@ -94,6 +94,7 @@ final class ResponsesContinuation {
 
 	/** Reject malformed or unbounded opaque response IDs. */
 	private static function valid_response_id( string $response_id ): bool {
-		return 1 === preg_match( '/^resp_[a-zA-Z0-9_-]{1,200}$/D', $response_id );
+		// The SD edge may wrap an upstream ID in an authenticated site-bound cursor.
+		return strlen( $response_id ) <= 2048 && 1 === preg_match( '/^resp_[a-zA-Z0-9_-]+$/D', $response_id );
 	}
 }

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -325,6 +325,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 
 		$immediate_function_names = $this->immediate_tool_function_names();
 		$groups                   = array();
+		$has_deferred_tools       = false;
 		foreach ( $declarations as $declaration ) {
 			if ( ! $declaration instanceof FunctionDeclaration ) {
 				continue;
@@ -332,7 +333,10 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 
 			$function_name    = $declaration->getName();
 			$key              = $this->namespace_key_for_function( $function_name );
-			$groups[ $key ][] = $this->function_declaration_to_tool( $declaration, ! isset( $immediate_function_names[ $function_name ] ) );
+			$deferred         = ! isset( $immediate_function_names[ $function_name ] );
+			$groups[ $key ][] = $this->function_declaration_to_tool( $declaration, $deferred );
+
+			$has_deferred_tools = $has_deferred_tools || $deferred;
 		}
 
 		$tools = array();
@@ -349,7 +353,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			}
 		}
 
-		if ( ! empty( $tools ) ) {
+		if ( $has_deferred_tools ) {
 			$tools[] = array( 'type' => 'tool_search' );
 		}
 

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -43,7 +43,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	/** Keep namespaces small as recommended by the OpenAI tool-search guide. */
 	private const NAMESPACE_TOOL_LIMIT = 10;
 
-	/** @var int Session owning the server-managed Responses cursor (zero disables persistence). */
+	/** @var int Session owning the encrypted native replay snapshot (zero disables persistence). */
 	private int $continuation_session_id = 0;
 
 	/** Bind continuation to the agent's server-owned session, not a user-supplied response ID. */
@@ -62,30 +62,25 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	public function generateTextResult( array $prompt ): GenerativeAiResult {
 		$cursor = new ResponsesContinuation( $this->continuation_session_id, get_current_user_id() );
 		try {
-			$params = $this->prepare_responses_params( $prompt );
-			/** @var list<array<string, mixed>> $full_input */
+			$params     = $this->prepare_responses_params( $prompt );
 			$full_input = $params['input'];
 			$scope      = $this->continuation_scope();
-			if ( ( $params['store'] ?? true ) === false ) {
+			if ( array_key_exists( 'previous_response_id', $params ) ) {
 				$cursor->clear();
 				return $this->generate_chat_completions_fallback( $prompt );
 			}
-			$managed = ! array_key_exists( 'previous_response_id', $params );
-			if ( $managed ) {
-				if ( null === $scope ) {
-					$cursor->clear();
-				}
-				$continuation = null !== $scope ? $cursor->resume( $full_input, $scope ) : null;
-				if ( null !== $continuation ) {
-					$params['previous_response_id'] = $continuation['previous_response_id'];
-					$params['input']                = $continuation['input'];
-				} elseif ( $this->has_tool_history( $full_input ) ) {
-					// An expired/edited cursor cannot faithfully replay native namespaces or reasoning.
-					$cursor->clear();
-					return $this->generate_chat_completions_fallback( $prompt );
-				}
-			} else {
+			$params['store']   = false;
+			$params['include'] = array( 'reasoning.encrypted_content' );
+			if ( null === $scope ) {
 				$cursor->clear();
+			}
+			$continuation = null !== $scope ? $cursor->resume( $full_input, $scope ) : null;
+			if ( null !== $continuation ) {
+				$params['input'] = $continuation['input'];
+			} elseif ( $this->has_tool_history( $full_input ) ) {
+				// An expired/edited snapshot cannot faithfully replay native namespaces or reasoning.
+				$cursor->clear();
+				return $this->generate_chat_completions_fallback( $prompt );
 			}
 			$request = $this->createRequest(
 				HttpMethodEnum::POST(),
@@ -100,10 +95,18 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 
 			$result = $this->parse_response_to_generative_ai_result( $response );
 			$data   = $response->getData();
-			if ( $managed && null !== $scope && is_array( $data ) && ( $data['status'] ?? 'completed' ) === 'completed' ) {
+			if ( null !== $scope && is_array( $data ) && ( $data['status'] ?? 'completed' ) === 'completed' ) {
 				// The agent may split this message for transport; input normalization is identical.
 				$acknowledged = array_merge( $full_input, $this->prepare_input_param( array( $result->toMessage() ) ) );
-				$cursor->acknowledge( $result->getId(), $acknowledged, $scope );
+				$output       = $this->native_output_items( $data['output'] ?? null );
+				if ( null !== $output ) {
+					$native_input = array_merge( $continuation['input'] ?? $full_input, $output );
+					$cursor->acknowledge( $result->getId(), $acknowledged, $scope, $native_input );
+				} else {
+					$cursor->clear();
+				}
+			} else {
+				$cursor->clear();
 			}
 			return $result;
 		} catch ( ClientException $e ) {
@@ -114,6 +117,32 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 
 			throw $e;
 		}
+	}
+
+	/**
+	 * Validate native rows without discarding provider-specific fields.
+	 *
+	 * @return list<array<string, mixed>>|null
+	 */
+	private function native_output_items( mixed $output ): ?array {
+		if ( ! is_array( $output ) || ! array_is_list( $output ) ) {
+			return null;
+		}
+		$rows = array();
+		foreach ( $output as $item ) {
+			if ( ! is_array( $item ) ) {
+				return null;
+			}
+			$row = array();
+			foreach ( $item as $key => $value ) {
+				if ( ! is_string( $key ) ) {
+					return null;
+				}
+				$row[ $key ] = $value;
+			}
+			$rows[] = $row;
+		}
+		return $rows;
 	}
 
 	/** Scope by model, endpoint, credential and tools, independent of usage-driven deferral. */
@@ -179,6 +208,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	 * @param Message[] $prompt Prompt messages.
 	 * @phpstan-param list<Message> $prompt
 	 * @return array<string, mixed>
+	 * @phpstan-return array{model: string, input: list<array<string, mixed>>, ...}
 	 */
 	protected function prepare_responses_params( array $prompt ): array {
 		$config = $this->getConfig();
@@ -218,14 +248,13 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			$params['parallel_tool_calls'] = false;
 		}
 
-		foreach ( $config->getCustomOptions() as $key => $value ) {
+		foreach ( array_keys( $config->getCustomOptions() ) as $key ) {
 			if ( isset( $params[ $key ] ) ) {
 				throw new InvalidArgumentException( sprintf( 'The custom option "%s" conflicts with an existing Responses parameter.', esc_html( (string) $key ) ) );
 			}
-			$params[ $key ] = $value;
 		}
 
-		return $params;
+		return array_merge( $config->getCustomOptions(), $params );
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -10,6 +10,7 @@ use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
@@ -42,6 +43,14 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	/** Keep namespaces small as recommended by the OpenAI tool-search guide. */
 	private const NAMESPACE_TOOL_LIMIT = 10;
 
+	/** @var int Session owning the server-managed Responses cursor (zero disables persistence). */
+	private int $continuation_session_id = 0;
+
+	/** Bind continuation to the agent's server-owned session, not a user-supplied response ID. */
+	public function set_continuation_session_id( int $session_id ): void {
+		$this->continuation_session_id = max( 0, $session_id );
+	}
+
 	/**
 	 * Generate text through `/responses`, falling back to Chat Completions if the
 	 * experimental endpoint/tool is unavailable.
@@ -51,8 +60,33 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	 * @return GenerativeAiResult
 	 */
 	public function generateTextResult( array $prompt ): GenerativeAiResult {
+		$cursor = new ResponsesContinuation( $this->continuation_session_id, get_current_user_id() );
 		try {
-			$params  = $this->prepare_responses_params( $prompt );
+			$params = $this->prepare_responses_params( $prompt );
+			/** @var list<array<string, mixed>> $full_input */
+			$full_input = $params['input'];
+			$scope      = $this->continuation_scope();
+			if ( ( $params['store'] ?? true ) === false ) {
+				$cursor->clear();
+				return $this->generate_chat_completions_fallback( $prompt );
+			}
+			$managed = ! array_key_exists( 'previous_response_id', $params );
+			if ( $managed ) {
+				if ( null === $scope ) {
+					$cursor->clear();
+				}
+				$continuation = null !== $scope ? $cursor->resume( $full_input, $scope ) : null;
+				if ( null !== $continuation ) {
+					$params['previous_response_id'] = $continuation['previous_response_id'];
+					$params['input']                = $continuation['input'];
+				} elseif ( $this->has_tool_history( $full_input ) ) {
+					// An expired/edited cursor cannot faithfully replay native namespaces or reasoning.
+					$cursor->clear();
+					return $this->generate_chat_completions_fallback( $prompt );
+				}
+			} else {
+				$cursor->clear();
+			}
 			$request = $this->createRequest(
 				HttpMethodEnum::POST(),
 				'responses',
@@ -64,14 +98,62 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			$response = $this->getHttpTransporter()->send( $request );
 			ResponseUtil::throwIfNotSuccessful( $response );
 
-			return $this->parse_response_to_generative_ai_result( $response );
+			$result = $this->parse_response_to_generative_ai_result( $response );
+			$data   = $response->getData();
+			if ( $managed && null !== $scope && is_array( $data ) && ( $data['status'] ?? 'completed' ) === 'completed' ) {
+				// The agent may split this message for transport; input normalization is identical.
+				$acknowledged = array_merge( $full_input, $this->prepare_input_param( array( $result->toMessage() ) ) );
+				$cursor->acknowledge( $result->getId(), $acknowledged, $scope );
+			}
+			return $result;
 		} catch ( ClientException $e ) {
 			if ( $this->should_fallback_to_chat_completions( $e ) ) {
+				$cursor->clear();
 				return $this->generate_chat_completions_fallback( $prompt );
 			}
 
 			throw $e;
 		}
+	}
+
+	/** Scope by model, endpoint, credential and tools, independent of usage-driven deferral. */
+	private function continuation_scope(): ?string {
+		$authentication = $this->getRequestAuthentication();
+		if ( ! $authentication instanceof ApiKeyRequestAuthentication ) {
+			// Unknown authentication cannot establish a stable cross-request account identity.
+			return null;
+		}
+		$functions = array();
+		foreach ( $this->getConfig()->getFunctionDeclarations() ?? array() as $declaration ) {
+			$functions[ $declaration->getName() ] = array(
+				'description' => $declaration->getDescription(),
+				'parameters'  => $declaration->getParameters(),
+			);
+		}
+		ksort( $functions );
+		return ResponsesContinuation::fingerprint(
+			array(
+				$this->providerMetadata()->getId(),
+				$this->metadata()->getId(),
+				SuperdavAiProvider::configured_base_url(),
+				hash_hmac( 'sha256', $authentication->getApiKey(), wp_salt( 'auth' ) ),
+				$functions,
+			)
+		);
+	}
+
+	/**
+	 * Determine whether local input requires native context that ordinary SDK messages cannot retain.
+	 *
+	 * @param list<array<string, mixed>> $input Locally reconstructed input.
+	 */
+	private function has_tool_history( array $input ): bool {
+		foreach ( $input as $item ) {
+			if ( in_array( $item['type'] ?? '', array( 'function_call', 'function_call_output', 'reasoning' ), true ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -495,7 +577,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			return false;
 		}
 
-		return (bool) preg_match( '/\b(tool_search|defer_loading|responses|unsupported|unknown parameter)\b/i', $e->getMessage() );
+		return (bool) preg_match( '/\b(tool_search|defer_loading|previous_response_id|responses|unsupported|unknown parameter)\b/i', $e->getMessage() );
 	}
 
 	/**
@@ -506,7 +588,11 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	 */
 	private function generate_chat_completions_fallback( array $prompt ): GenerativeAiResult {
 		$fallback = new SuperdavAiTextGenerationModel( $this->metadata(), $this->providerMetadata() );
-		$fallback->setConfig( $this->getConfig() );
+		$config   = clone $this->getConfig();
+		$options  = $config->getCustomOptions();
+		unset( $options['previous_response_id'] );
+		$config->setCustomOptions( $options );
+		$fallback->setConfig( $config );
 		$fallback->setHttpTransporter( $this->getHttpTransporter() );
 		$fallback->setRequestAuthentication( $this->getRequestAuthentication() );
 

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -771,6 +771,9 @@ namespace WordPress\AiClient\Providers\Http\DTO {
 	class ApiKeyRequestAuthentication implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
 		/** @param string $api_key API key. */
 		public function __construct( string $api_key ) {}
+
+		/** Return the bound API credential. */
+		public function getApiKey(): string { return ''; }
 	}
 }
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Infrastructure\AiClient\Superdav;
+
+use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ConversationSerializer;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Infrastructure\AiClient\Superdav\ResponsesContinuation;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiResponsesToolSearchTextGenerationModel;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Exception\ServerException;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WP_UnitTestCase;
+
+/** Tests persisted server cursors and the actual provider transport boundary. */
+final class ResponsesContinuationTest extends WP_UnitTestCase {
+
+	/** @var int Owner of the isolated cursor fixtures. */
+	private int $owner;
+
+	/** Establish an authenticated request context. */
+	public function set_up(): void {
+		parent::set_up();
+		$this->owner = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->owner );
+	}
+
+	/** Remove only fixture cursors. */
+	public function tear_down(): void {
+		( new ResponsesContinuation( 123, $this->owner ) )->clear();
+		parent::tear_down();
+	}
+
+	/** A fresh PHP object loads the cursor without retaining any old prompt content. */
+	public function test_cursor_survives_reconstruction_and_returns_only_new_input(): void {
+		$before = array( array( 'role' => 'user', 'content' => 'private fixture' ) );
+		( new ResponsesContinuation( 123, $this->owner ) )->acknowledge( 'resp_first', $before, 'scope' );
+		$after = array_merge( $before, array( array( 'type' => 'function_call_output', 'call_id' => 'call_1', 'output' => 'ok' ) ) );
+		$next  = ( new ResponsesContinuation( 123, $this->owner ) )->resume( $after, 'scope' );
+		$this->assertSame( 'resp_first', $next['previous_response_id'] );
+		$this->assertSame( array( $after[1] ), $next['input'] );
+		$stored = get_transient( 'sd_ai_agent_responses_' . get_current_blog_id() . '_123_' . $this->owner );
+		$this->assertSame( array( 'response_id', 'count', 'hash', 'scope' ), array_keys( $stored ) );
+		$this->assertStringNotContainsString( 'private fixture', wp_json_encode( $stored ) );
+	}
+
+	/** Changed history, tools, identity, or expired state must not reuse a response ID. */
+	public function test_mismatched_cursors_are_not_reused(): void {
+		$before = array( array( 'role' => 'user', 'content' => 'first' ) );
+		$after  = array_merge( $before, array( array( 'role' => 'user', 'content' => 'next' ) ) );
+		$cursor = new ResponsesContinuation( 123, $this->owner );
+		$cursor->acknowledge( 'resp_first', $before, 'scope' );
+		$this->assertNull( ( new ResponsesContinuation( 123, $this->owner + 1 ) )->resume( $after, 'scope' ) );
+		$this->assertNull( ( new ResponsesContinuation( 124, $this->owner ) )->resume( $after, 'scope' ) );
+		$this->assertNull( $cursor->resume( $after, 'different_model_or_catalog' ) );
+		$cursor->acknowledge( 'resp_first', $before, 'scope' );
+		$after[0]['content'] = 'edited or compacted history';
+		$this->assertNull( $cursor->resume( $after, 'scope' ) );
+		$this->assertFalse( get_transient( 'sd_ai_agent_responses_' . get_current_blog_id() . '_123_' . $this->owner ) );
+		$cursor->acknowledge( 'resp_first', $before, 'scope' );
+		$cursor->clear();
+		$this->assertNull( $cursor->resume( $after, 'scope' ) );
+	}
+
+	/** Invalid IDs, anonymous calls and unpersisted sessions never create reusable cursors. */
+	public function test_invalid_or_unscoped_cursors_are_ignored(): void {
+		$before = array( array( 'role' => 'user', 'content' => 'first' ) );
+		$after  = array_merge( $before, $before );
+		foreach ( array( new ResponsesContinuation( 0, $this->owner ), new ResponsesContinuation( 123, 0 ) ) as $cursor ) {
+			$cursor->acknowledge( 'resp_first', $before, 'scope' );
+			$this->assertNull( $cursor->resume( $after, 'scope' ) );
+		}
+		$cursor = new ResponsesContinuation( 123, $this->owner );
+		$cursor->acknowledge( 'invalid/id', $before, 'scope' );
+		$this->assertNull( $cursor->resume( $after, 'scope' ) );
+	}
+
+	/** Model reconstruction and serialized browser/confirmation history preserve server continuity. */
+	public function test_three_turns_send_only_tool_results_then_new_user_input(): void {
+		$requests = array();
+		$history  = array( new UserMessage( array( new MessagePart( 'Find the fixture.' ) ) ) );
+		$first    = $this->model( array( $this->tool_response() ), $requests )->generateTextResult( $history );
+		ConversationSerializer::append_assistant_message( $history, $first->toMessage() );
+		// This is the same serialization boundary used by paused tool/confirmation jobs.
+		$history = ConversationSerializer::deserialize( ConversationSerializer::serialize( $history ) );
+		ConversationSerializer::append_tool_response(
+			$history,
+			new UserMessage( array( new MessagePart( new FunctionResponse( 'call_1', 'lookup', array( 'found' => true ) ) ) ) )
+		);
+		$second = $this->model( array( $this->text_response( 'resp_second' ) ), $requests )->generateTextResult( $history );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[0]->getData() );
+		$this->assertSame( 'resp_first', $requests[1]->getData()['previous_response_id'] );
+		$this->assertSame( 'Inspect only.', $requests[1]->getData()['instructions'] );
+		$this->assertCount( 1, $requests[1]->getData()['input'] );
+		$this->assertSame( 'function_call_output', $requests[1]->getData()['input'][0]['type'] );
+		$this->assertSame( 'call_1', $requests[1]->getData()['input'][0]['call_id'] );
+		ConversationSerializer::append_assistant_message( $history, $second->toMessage() );
+		$history   = ConversationSerializer::deserialize( ConversationSerializer::serialize( $history ) );
+		$history[] = new UserMessage( array( new MessagePart( 'Explain the finding.' ) ) );
+		$this->model( array( $this->text_response( 'resp_third' ) ), $requests )->generateTextResult( $history );
+		$this->assertSame( 'resp_second', $requests[2]->getData()['previous_response_id'] );
+		$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), $requests[2]->getData()['input'] );
+	}
+
+	/** An unavailable server cursor falls back once with full history, without native parameters. */
+	public function test_rejected_response_id_falls_back_with_full_history(): void {
+		$requests = array();
+		$history  = array( new UserMessage( array( new MessagePart( 'Find the fixture.' ) ) ) );
+		$first    = $this->model( array( $this->tool_response() ), $requests )->generateTextResult( $history );
+		ConversationSerializer::append_assistant_message( $history, $first->toMessage() );
+		$history[] = new UserMessage( array( new MessagePart( new FunctionResponse( 'call_1', 'lookup', array( 'ok' => true ) ) ) ) );
+		$expired   = new Response( 400, array(), wp_json_encode( array( 'error' => array( 'message' => 'Invalid previous_response_id', 'type' => 'invalid_request_error' ) ) ) );
+		$this->model( array( $expired, $this->chat_response() ), $requests )->generateTextResult( $history );
+		$this->assertCount( 3, $requests );
+		$this->assertStringEndsWith( '/responses', $requests[1]->getUri() );
+		$this->assertStringEndsWith( '/chat/completions', $requests[2]->getUri() );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[2]->getData() );
+		$this->assertGreaterThanOrEqual( 3, count( $requests[2]->getData()['messages'] ) );
+	}
+
+	/** Storage opt-out cannot accidentally resume an older stored conversation. */
+	public function test_storage_opt_out_uses_eager_fallback(): void {
+		$requests = array();
+		$model    = $this->model( array( $this->chat_response() ), $requests );
+		$model->getConfig()->setCustomOption( 'store', false );
+		$model->generateTextResult( array( new UserMessage( array( new MessagePart( 'Inspect only.' ) ) ) ) );
+		$this->assertStringEndsWith( '/chat/completions', $requests[0]->getUri() );
+		$this->assertFalse( $requests[0]->getData()['store'] );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[0]->getData() );
+	}
+
+	/** Cache eviction must never send a standalone native function result. */
+	public function test_missing_cursor_falls_back_without_trying_responses(): void {
+		$requests = array();
+		$history  = $this->pending_history( $requests );
+		( new ResponsesContinuation( 123, $this->owner ) )->clear();
+		$this->model( array( $this->chat_response() ), $requests )->generateTextResult( $history );
+		$this->assertCount( 2, $requests );
+		$this->assertStringEndsWith( '/chat/completions', $requests[1]->getUri() );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[1]->getData() );
+	}
+
+	/** Changing the account must not reference a response owned by the old account. */
+	public function test_rotating_credentials_invalidates_the_cursor(): void {
+		$requests = array();
+		$history  = $this->pending_history( $requests );
+		$model    = $this->model( array( $this->chat_response() ), $requests );
+		$model->setRequestAuthentication( new ApiKeyRequestAuthentication( 'different-test-credential' ) );
+		$model->generateTextResult( $history );
+		$this->assertStringEndsWith( '/chat/completions', $requests[1]->getUri() );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[1]->getData() );
+	}
+
+	/** Removed tools cannot remain available through an old stored response. */
+	public function test_changed_catalog_invalidates_the_cursor(): void {
+		$requests = array();
+		$history  = $this->pending_history( $requests );
+		$model    = $this->model( array( $this->chat_response() ), $requests );
+		$model->getConfig()->setFunctionDeclarations( array() );
+		$model->generateTextResult( $history );
+		$this->assertStringEndsWith( '/chat/completions', $requests[1]->getUri() );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[1]->getData() );
+	}
+
+	/** Failed HTTP calls must neither advance the cursor nor silently switch protocols. */
+	public function test_transient_server_failure_preserves_the_previous_acknowledgment(): void {
+		$requests = array();
+		$history  = $this->pending_history( $requests );
+		$failure  = new Response( 500, array(), wp_json_encode( array( 'error' => array( 'message' => 'Temporary failure' ) ) ) );
+		try {
+			$this->model( array( $failure ), $requests )->generateTextResult( $history );
+			$this->fail( 'Expected the server error to propagate.' );
+		} catch ( ServerException $error ) {
+			$this->assertCount( 2, $requests );
+		}
+		$this->model( array( $this->text_response( 'resp_retry' ) ), $requests )->generateTextResult( $history );
+		$this->assertSame( 'resp_first', $requests[2]->getData()['previous_response_id'] );
+		$this->assertSame( $requests[1]->getData()['input'], $requests[2]->getData()['input'] );
+	}
+
+	/** Real agent loops must bind the session, execute the tool, and resume on a new user turn. */
+	public function test_agent_loop_binds_continuation_across_tool_and_user_turns(): void {
+		$requests = array();
+		$tool     = $this->tool_response()->getData();
+		$tool['output'][2]['name'] = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'sd-ai-agent/list-posts' );
+		$replies = array( $tool, $this->text_response( 'resp_second' )->getData(), $this->text_response( 'resp_third' )->getData() );
+		$transport = static function ( $preempt, $args, $url ) use ( &$requests, &$replies ) {
+			if ( str_ends_with( $url, '/models' ) ) {
+				$data = array( 'data' => array( array( 'id' => 'gpt-5.5', 'capabilities' => array( 'text_generation' ) ) ) );
+			} elseif ( str_ends_with( $url, '/responses' ) ) {
+				$requests[] = json_decode( $args['body'], true );
+				$data = array_shift( $replies );
+			} else {
+				return new \WP_Error( 'unexpected_test_http', 'Unexpected HTTP request in the continuity regression.' );
+			}
+			return array( 'response' => array( 'code' => 200, 'message' => 'OK' ), 'headers' => array(), 'body' => wp_json_encode( $data ) );
+		};
+		$credential = static fn() => 'fixture-only-credential';
+		add_filter( 'pre_http_request', $transport, 1, 3 );
+		add_filter( 'pre_option_' . SuperdavAiProvider::CREDENTIAL_OPTION, $credential );
+		add_filter( 'sd_ai_agent_openai_tool_search_enabled', '__return_true' );
+		$session = Database::create_session( array( 'user_id' => $this->owner, 'title' => 'Continuity regression' ) );
+		try {
+			$options = array(
+				'session_id' => $session, 'provider_id' => SuperdavAiProvider::PROVIDER_ID, 'model_id' => 'gpt-5.5',
+				'max_iterations' => 3, 'max_output_tokens' => 1024, 'provider_retry_max_attempts' => 1,
+			);
+			$first = ( new AgentLoop( 'Find posts.', array( 'sd-ai-agent/list-posts' ), array(), $options ) )->run();
+			$this->assertIsArray( $first );
+			$this->assertSame( 'resp_first', $requests[1]['previous_response_id'] );
+			$this->assertSame( array( 'function_call_output' ), array_column( $requests[1]['input'], 'type' ) );
+			$history = ConversationSerializer::deserialize( $first['history'] );
+			$second = ( new AgentLoop( 'Explain the finding.', array( 'sd-ai-agent/list-posts' ), $history, $options ) )->run();
+			$this->assertIsArray( $second );
+			$this->assertSame( 'resp_second', $requests[2]['previous_response_id'] );
+			$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), $requests[2]['input'] );
+			$this->assertCount( 3, $requests );
+		} finally {
+			remove_filter( 'pre_http_request', $transport, 1 );
+			remove_filter( 'pre_option_' . SuperdavAiProvider::CREDENTIAL_OPTION, $credential );
+			remove_filter( 'sd_ai_agent_openai_tool_search_enabled', '__return_true' );
+			( new ResponsesContinuation( $session, $this->owner ) )->clear();
+		}
+	}
+
+	/** Build a tool-result boundary shared by invalidation and retry cases. */
+	private function pending_history( array &$requests ): array {
+		$history = array( new UserMessage( array( new MessagePart( 'Find the fixture.' ) ) ) );
+		$first   = $this->model( array( $this->tool_response() ), $requests )->generateTextResult( $history );
+		ConversationSerializer::append_assistant_message( $history, $first->toMessage() );
+		ConversationSerializer::append_tool_response(
+			$history,
+			new UserMessage( array( new MessagePart( new FunctionResponse( 'call_1', 'lookup', array( 'found' => true ) ) ) ) )
+		);
+		return $history;
+	}
+
+	/** Construct the real model with a recording SDK transporter and fixture responses. */
+	private function model( array $responses, array &$requests ): SuperdavAiResponsesToolSearchTextGenerationModel {
+		$model = new SuperdavAiResponsesToolSearchTextGenerationModel(
+			new ModelMetadata( 'gpt-5.5', 'GPT', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$model->set_continuation_session_id( 123 );
+		$config = new ModelConfig();
+		$config->setSystemInstruction( 'Inspect only.' );
+		$config->setFunctionDeclarations( array( new FunctionDeclaration( 'lookup', 'Read a fixture.', array( 'type' => 'object' ) ) ) );
+		$model->setConfig( $config );
+		$model->setRequestAuthentication( new ApiKeyRequestAuthentication( 'fixture-only-credential' ) );
+		$transport = $this->createMock( HttpTransporterInterface::class );
+		$transport->method( 'send' )->willReturnCallback(
+			static function ( Request $request ) use ( &$responses, &$requests ): Response {
+				$requests[] = $request;
+				return array_shift( $responses );
+			}
+		);
+		$model->setHttpTransporter( $transport );
+		return $model;
+	}
+
+	/** Native discovery followed by a function call (namespace state remains on the server). */
+	private function tool_response(): Response {
+		return new Response( 200, array(), wp_json_encode( array(
+			'id' => 'resp_first', 'status' => 'completed', 'output' => array(
+				array( 'type' => 'tool_search_call', 'execution' => 'server', 'call_id' => null, 'arguments' => array( 'paths' => array( 'general' ) ) ),
+				array( 'type' => 'tool_search_output', 'execution' => 'server', 'tools' => array() ),
+				array( 'type' => 'function_call', 'call_id' => 'call_1', 'name' => 'lookup', 'namespace' => 'general', 'arguments' => '{}' ),
+			),
+		) ) );
+	}
+
+	/** Native text-only final response. */
+	private function text_response( string $id ): Response {
+		return new Response( 200, array(), wp_json_encode( array(
+			'id' => $id, 'status' => 'completed', 'output' => array(
+				array( 'type' => 'message', 'content' => array( array( 'type' => 'output_text', 'text' => 'Found it.' ) ) ),
+			),
+		) ) );
+	}
+
+	/** Compatible eager fallback response. */
+	private function chat_response(): Response {
+		return new Response( 200, array(), wp_json_encode( array(
+			'id' => 'chatcmpl_fixture', 'choices' => array(
+				array( 'index' => 0, 'message' => array( 'role' => 'assistant', 'content' => 'Found it.' ), 'finish_reason' => 'stop' ),
+			),
+		) ) );
+	}
+}

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
@@ -43,17 +43,40 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	/** A fresh PHP object loads the cursor without retaining any old prompt content. */
-	public function test_cursor_survives_reconstruction_and_returns_only_new_input(): void {
+	/** A fresh PHP object loads encrypted native history without storing plaintext. */
+	public function test_cursor_survives_reconstruction_and_replays_native_input(): void {
 		$before = array( array( 'role' => 'user', 'content' => 'private fixture' ) );
 		( new ResponsesContinuation( 123, $this->owner ) )->acknowledge( 'resp_first', $before, 'scope' );
 		$after = array_merge( $before, array( array( 'type' => 'function_call_output', 'call_id' => 'call_1', 'output' => 'ok' ) ) );
 		$next  = ( new ResponsesContinuation( 123, $this->owner ) )->resume( $after, 'scope' );
-		$this->assertSame( 'resp_first', $next['previous_response_id'] );
-		$this->assertSame( array( $after[1] ), $next['input'] );
+		$this->assertArrayNotHasKey( 'previous_response_id', $next );
+		$this->assertSame( $after, $next['input'] );
 		$stored = get_transient( 'sd_ai_agent_responses_' . get_current_blog_id() . '_123_' . $this->owner );
-		$this->assertSame( array( 'response_id', 'count', 'hash', 'scope' ), array_keys( $stored ) );
+		$this->assertSame( array( 'response_id', 'count', 'hash', 'scope', 'native' ), array_keys( $stored ) );
 		$this->assertStringNotContainsString( 'private fixture', wp_json_encode( $stored ) );
+	}
+
+	/** Ciphertext and public metadata cannot be tampered with or moved to another session. */
+	public function test_encrypted_snapshot_integrity_and_retention_bound(): void {
+		$before = array( array( 'role' => 'user', 'content' => 'private fixture' ) );
+		$after = array_merge( $before, array( array( 'role' => 'user', 'content' => 'continue' ) ) );
+		$key = 'sd_ai_agent_responses_' . get_current_blog_id() . '_123_' . $this->owner;
+		$cursor = new ResponsesContinuation( 123, $this->owner );
+		$cursor->acknowledge( 'resp_first', $before, 'scope' );
+		$state = get_transient( $key );
+		$corrupt = $state;
+		$corrupt['native'][0] = '0' === $corrupt['native'][0] ? '1' : '0';
+		set_transient( $key, $corrupt, DAY_IN_SECONDS );
+		$this->assertNull( $cursor->resume( $after, 'scope' ) );
+		$forged = $state;
+		$forged['scope'] = 'changed-scope';
+		set_transient( $key, $forged, DAY_IN_SECONDS );
+		$this->assertNull( $cursor->resume( $after, 'changed-scope' ) );
+		$other_key = 'sd_ai_agent_responses_' . get_current_blog_id() . '_124_' . $this->owner;
+		set_transient( $other_key, $state, DAY_IN_SECONDS );
+		$this->assertNull( ( new ResponsesContinuation( 124, $this->owner ) )->resume( $after, 'scope' ) );
+		$cursor->acknowledge( 'resp_large', $before, 'scope', array( array( 'content' => str_repeat( 'x', 1048577 ) ) ) );
+		$this->assertFalse( get_transient( $key ) );
 	}
 
 	/** Changed history, tools, identity, or expired state must not reuse a response ID. */
@@ -87,14 +110,14 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 		$this->assertNull( $cursor->resume( $after, 'scope' ) );
 		$opaque = 'resp_' . str_repeat( 'a', 2043 );
 		$cursor->acknowledge( $opaque, $before, 'scope' );
-		$this->assertSame( $opaque, $cursor->resume( $after, 'scope' )['previous_response_id'] );
+		$this->assertSame( $after, $cursor->resume( $after, 'scope' )['input'] );
 		$cursor->clear();
 		$cursor->acknowledge( $opaque . 'a', $before, 'scope' );
 		$this->assertNull( $cursor->resume( $after, 'scope' ) );
 	}
 
 	/** Model reconstruction and serialized browser/confirmation history preserve server continuity. */
-	public function test_three_turns_send_only_tool_results_then_new_user_input(): void {
+	public function test_three_turns_replay_complete_native_state_without_duplicate_history(): void {
 		$requests = array();
 		$history  = array( new UserMessage( array( new MessagePart( 'Find the fixture.' ) ) ) );
 		$first    = $this->model( array( $this->tool_response() ), $requests )->generateTextResult( $history );
@@ -107,17 +130,22 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 		);
 		$second = $this->model( array( $this->text_response( 'resp_second' ) ), $requests )->generateTextResult( $history );
 		$this->assertArrayNotHasKey( 'previous_response_id', $requests[0]->getData() );
-		$this->assertSame( 'resp_first', $requests[1]->getData()['previous_response_id'] );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[1]->getData() );
+		$this->assertFalse( $requests[1]->getData()['store'] );
+		$this->assertSame( array( 'reasoning.encrypted_content' ), $requests[1]->getData()['include'] );
 		$this->assertSame( 'Inspect only.', $requests[1]->getData()['instructions'] );
-		$this->assertCount( 1, $requests[1]->getData()['input'] );
-		$this->assertSame( 'function_call_output', $requests[1]->getData()['input'][0]['type'] );
-		$this->assertSame( 'call_1', $requests[1]->getData()['input'][0]['call_id'] );
+		$this->assertCount( 6, $requests[1]->getData()['input'] );
+		$this->assertSame( $this->tool_response()->getData()['output'], array_slice( $requests[1]->getData()['input'], 1, 4 ) );
+		$this->assertSame( 'function_call_output', $requests[1]->getData()['input'][5]['type'] );
+		$this->assertSame( 'call_1', $requests[1]->getData()['input'][5]['call_id'] );
 		ConversationSerializer::append_assistant_message( $history, $second->toMessage() );
 		$history   = ConversationSerializer::deserialize( ConversationSerializer::serialize( $history ) );
 		$history[] = new UserMessage( array( new MessagePart( 'Explain the finding.' ) ) );
 		$this->model( array( $this->text_response( 'resp_third' ) ), $requests )->generateTextResult( $history );
-		$this->assertSame( 'resp_second', $requests[2]->getData()['previous_response_id'] );
-		$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), $requests[2]->getData()['input'] );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[2]->getData() );
+		$this->assertCount( 8, $requests[2]->getData()['input'] );
+		$this->assertSame( $requests[1]->getData()['input'], array_slice( $requests[2]->getData()['input'], 0, 6 ) );
+		$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), array_slice( $requests[2]->getData()['input'], -1 ) );
 	}
 
 	/** An unavailable server cursor falls back once with full history, without native parameters. */
@@ -137,12 +165,12 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 	}
 
 	/** Storage opt-out cannot accidentally resume an older stored conversation. */
-	public function test_storage_opt_out_uses_eager_fallback(): void {
+	public function test_storage_opt_out_uses_stateless_native_replay(): void {
 		$requests = array();
-		$model    = $this->model( array( $this->chat_response() ), $requests );
+		$model    = $this->model( array( $this->text_response( 'resp_stateless' ) ), $requests );
 		$model->getConfig()->setCustomOption( 'store', false );
 		$model->generateTextResult( array( new UserMessage( array( new MessagePart( 'Inspect only.' ) ) ) ) );
-		$this->assertStringEndsWith( '/chat/completions', $requests[0]->getUri() );
+		$this->assertStringEndsWith( '/responses', $requests[0]->getUri() );
 		$this->assertFalse( $requests[0]->getData()['store'] );
 		$this->assertArrayNotHasKey( 'previous_response_id', $requests[0]->getData() );
 	}
@@ -192,7 +220,7 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 			$this->assertCount( 2, $requests );
 		}
 		$this->model( array( $this->text_response( 'resp_retry' ) ), $requests )->generateTextResult( $history );
-		$this->assertSame( 'resp_first', $requests[2]->getData()['previous_response_id'] );
+		$this->assertArrayNotHasKey( 'previous_response_id', $requests[2]->getData() );
 		$this->assertSame( $requests[1]->getData()['input'], $requests[2]->getData()['input'] );
 	}
 
@@ -200,7 +228,7 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 	public function test_agent_loop_binds_continuation_across_tool_and_user_turns(): void {
 		$requests = array();
 		$tool     = $this->tool_response()->getData();
-		$tool['output'][2]['name'] = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'sd-ai-agent/list-posts' );
+		$tool['output'][3]['name'] = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'sd-ai-agent/list-posts' );
 		$replies = array( $tool, $this->text_response( 'resp_second' )->getData(), $this->text_response( 'resp_third' )->getData() );
 		$transport = static function ( $preempt, $args, $url ) use ( &$requests, &$replies ) {
 			if ( str_ends_with( $url, '/models' ) ) {
@@ -226,13 +254,15 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 			$first = ( new AgentLoop( 'Find posts.', array( 'sd-ai-agent/list-posts' ), array(), $options ) )->run();
 			$this->assertIsArray( $first );
 			$this->assertNotContains( 'tool_search', array_column( $requests[0]['tools'], 'type' ) );
-			$this->assertSame( 'resp_first', $requests[1]['previous_response_id'] );
-			$this->assertSame( array( 'function_call_output' ), array_column( $requests[1]['input'], 'type' ) );
+			$this->assertArrayNotHasKey( 'previous_response_id', $requests[1] );
+			$this->assertSame( $tool['output'], array_slice( $requests[1]['input'], 1, 4 ) );
+			$this->assertSame( array( 'function_call_output' ), array_column( array_slice( $requests[1]['input'], -1 ), 'type' ) );
 			$history = ConversationSerializer::deserialize( $first['history'] );
 			$second = ( new AgentLoop( 'Explain the finding.', array( 'sd-ai-agent/list-posts' ), $history, $options ) )->run();
 			$this->assertIsArray( $second );
-			$this->assertSame( 'resp_second', $requests[2]['previous_response_id'] );
-			$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), $requests[2]['input'] );
+			$this->assertArrayNotHasKey( 'previous_response_id', $requests[2] );
+			$this->assertSame( $requests[1]['input'], array_slice( $requests[2]['input'], 0, count( $requests[1]['input'] ) ) );
+			$this->assertSame( array( array( 'role' => 'user', 'content' => 'Explain the finding.' ) ), array_slice( $requests[2]['input'], -1 ) );
 			$this->assertCount( 3, $requests );
 		} finally {
 			remove_filter( 'pre_http_request', $transport, 1 );
@@ -283,6 +313,7 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 			'id' => 'resp_first', 'status' => 'completed', 'output' => array(
 				array( 'type' => 'tool_search_call', 'execution' => 'server', 'call_id' => null, 'arguments' => array( 'paths' => array( 'general' ) ) ),
 				array( 'type' => 'tool_search_output', 'execution' => 'server', 'tools' => array() ),
+				array( 'type' => 'reasoning', 'id' => 'rs_fixture', 'summary' => array(), 'encrypted_content' => 'opaque-reasoning-fixture' ),
 				array( 'type' => 'function_call', 'call_id' => 'call_1', 'name' => 'lookup', 'namespace' => 'general', 'arguments' => '{}' ),
 			),
 		) ) );

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php
@@ -85,6 +85,12 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 		$cursor = new ResponsesContinuation( 123, $this->owner );
 		$cursor->acknowledge( 'invalid/id', $before, 'scope' );
 		$this->assertNull( $cursor->resume( $after, 'scope' ) );
+		$opaque = 'resp_' . str_repeat( 'a', 2043 );
+		$cursor->acknowledge( $opaque, $before, 'scope' );
+		$this->assertSame( $opaque, $cursor->resume( $after, 'scope' )['previous_response_id'] );
+		$cursor->clear();
+		$cursor->acknowledge( $opaque . 'a', $before, 'scope' );
+		$this->assertNull( $cursor->resume( $after, 'scope' ) );
 	}
 
 	/** Model reconstruction and serialized browser/confirmation history preserve server continuity. */
@@ -219,6 +225,7 @@ final class ResponsesContinuationTest extends WP_UnitTestCase {
 			);
 			$first = ( new AgentLoop( 'Find posts.', array( 'sd-ai-agent/list-posts' ), array(), $options ) )->run();
 			$this->assertIsArray( $first );
+			$this->assertNotContains( 'tool_search', array_column( $requests[0]['tools'], 'type' ) );
 			$this->assertSame( 'resp_first', $requests[1]['previous_response_id'] );
 			$this->assertSame( array( 'function_call_output' ), array_column( $requests[1]['input'], 'type' ) );
 			$history = ConversationSerializer::deserialize( $first['history'] );


### PR DESCRIPTION
## Summary

Keep the existing OAuth-backed SD service and preserve/replay complete native Responses state. No OpenAI API key, new billing route, PHP AI Client change, WordPress core change, or OpenAI connector change is required.

- Bind the server-owned agent session in `includes/Core/AgentLoop.php`.
- In `SuperdavAiResponsesToolSearchTextGenerationModel`, request `store: false` and `include: ["reasoning.encrypted_content"]`. Never send `previous_response_id` on this OAuth path.
- Preserve all raw native output fields, including reasoning ciphertext, tool-search calls/results, namespaces and function calls. Replay the saved sequence plus new local input without duplicating normalized SDK assistant messages.
- In `ResponsesContinuation`, store a one-day, 1-MiB-bounded encrypted snapshot. AES-GCM authenticates the site/session/user key, model/endpoint/tool/credential scope and local-prefix metadata. Corrupt, expired, mismatched or oversized state cannot produce partial replay.
- Keep ordinary SDK history and compatible fallback. Keep eager-only catalogs free of invalid `tool_search` declarations.

Reference patterns: the existing SDK transporter/authentication path, `ConversationSerializer`, existing agent confirmation/session handling, and SD Chat Completions fallback. Tests are in `tests/SdAiAgent/Infrastructure/AiClient/Superdav/ResponsesContinuationTest.php`; retention and measured evidence are documented in `docs/NATIVE_TOOL_SEARCH_CONTINUITY.md`.

## Verification

- Focused provider/agent suites: **265 tests, 868 assertions, 69 skips, no failures**.
  - `php bin/run-wp-phpunit.php --filter='ResponsesContinuationTest|SuperdavAiProviderTest|AgentLoopTest|AgentLoopClientToolsTest' --no-coverage`
- Changed runtime PHP PHPCS and scoped PHPStan: **passed**.
- Commit-hook PHP checks and `git diff --check`: **passed**.
- Full PHPUnit and browser UI E2E were not run locally.

## Actual OAuth inference

A separate temporary dev wrapper exposed stateless `/v1/responses` using the existing OAuth backend. Actual `AgentLoop` prompts used a disposable WordPress fixture with `list-terms`, `list-posts` and `get-post`.

- Native discovery returned `tool_search_call`, `tool_search_output`, reasoning and function-call items.
- **All six requests stayed on Responses and returned HTTP 200, with no fallback.**
- Every follow-up's prefix exactly equaled the preceding native input plus output. Encrypted reasoning was present; all requests used `store: false` and no previous-response ID.
- Later user turns ran in **fresh PHP processes** reading the persisted encrypted snapshot. This live run passed **49 assertions**.
- A separate run paused a read-only tool for confirmation and resumed it in a fresh PHP process, then continued later turns. All six calls remained native; **54 assertions passed**.
- Answers correctly returned CERULEAN-842, calibration 7341 / 19 minutes, and the doubled window of 38 minutes.

Credentials stayed in memory and were not printed. No production deployment, upstream account change, or shared-site activation/schema change was made.

## Performance: limited smoke comparison, no speedup claim

The matched three-tool sample completed all tasks in both modes. Native replay took **20.735 s**, with **63,838 input tokens** and **321,946 request bytes**. Eager mode took **18.087 s**, with **66,667 input tokens** and **320,396 request bytes**. Cache/output variation and the tiny catalog prevent general conclusions; native was not faster in this sample.

## Draft delivery boundary

- [x] Keep OAuth and preserve/replay complete native state.
- [x] Verify native discovery and continuation across fresh PHP requests.
- [x] Verify real confirmation pause/resume without fallback.
- [ ] Land/review/deploy the matching stateless Responses route in the SD service. That companion change is currently isolated development work, not a deployed dependency.
- [ ] Broader catalog performance evaluation and browser-tool UI E2E before general enablement.

`store: false` means no upstream storage, not zero local retention: an encrypted local replay copy lives for up to one day. Keep managed-alias opt-in disabled until the matching service route is available. No merge or release is requested.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 5h 54m and 2,252,397 tokens on this with the user in an interactive session.