### PR TITLE
Update official plugin homepage and demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 SD AI Agent is your AI teammate for the WordPress site you already run. Ask one assistant to improve content, prepare products, review SEO and site information, and automate repeatable work — while keeping your existing theme, plugins, and AI provider. The technical foundation below lets compatible plugins add tools the assistant can use as your site grows.
 
+Try it at [sdaiagent.com](https://sdaiagent.com), an AI site builder demo site.
+
 ## How it works
 
 WordPress 7.0 introduced two core APIs that make this possible:

--- a/advanced-plugin/superdav-ai-agent-advanced.php
+++ b/advanced-plugin/superdav-ai-agent-advanced.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: SD AI Agent Advanced
- * Plugin URI:  https://github.com/Ultimate-Multisite/superdav-ai-agent
+ * Plugin URI:  https://sdaiagent.com
  * Description: Advanced companion plugin for SD AI Agent with self-hosted code, filesystem, database, WP-CLI, REST dispatcher, and plugin-builder tools.
  * Version:     1.23.0
  * Author:      superdav42

--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
 			"@phpstan"
 		]
 	},
-	"homepage": "https://github.com/Ultimate-Multisite/superdav-ai-agent",
+	"homepage": "https://sdaiagent.com",
 	"support": {
 		"issues": "https://github.com/Ultimate-Multisite/superdav-ai-agent/issues",
 		"source": "https://github.com/Ultimate-Multisite/superdav-ai-agent"

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ A native AI agent for WordPress. Fix, publish, optimise, and run your site from 
 
 SD AI Agent is a native AI agent for the WordPress site you already run. Ask it to improve a page, draft content, review SEO opportunities, prepare media, answer questions with site context, or run routine admin work from inside WordPress using natural language.
 
+Try it at [sdaiagent.com](https://sdaiagent.com), an AI site builder demo site.
+
 You stay in control: choose the included SD AI-managed service or your own compatible WordPress AI provider, decide which tools the agent can use, and require confirmation before consequential actions run.
 
 = What it helps you do =

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: SD AI Agent
- * Plugin URI:  https://github.com/Ultimate-Multisite/superdav-ai-agent
+ * Plugin URI:  https://sdaiagent.com
  * Description: Agentic AI loop for WordPress — chat with an AI that can call WordPress abilities (tools) autonomously.
  * Version:     1.23.0
  * Author:      superdav42


### PR DESCRIPTION
## Summary

- point the core and Advanced plugin metadata to `https://sdaiagent.com`
- update the Composer homepage metadata
- invite README readers to try the AI site builder demo site

## Worker self-verification
- PHPUnit: Tests: 4409, Assertions: 20508, Errors: 0, Failures: 0, Skipped: 139, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a link inviting readers to try the plugin at sdaiagent.com, an AI site builder demo.
  - Updated project and plugin homepage references to the product website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->