### PR TITLE
GH#2700: scope provider failures to matching URLs

### DIFF
--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -95,6 +95,7 @@ class ProviderTraceLogger {
 	private static array $provider_patterns = [
 		'api.anthropic.com'                 => 'anthropic',
 		'api.openai.com'                    => 'openai',
+		'api.sdaiagent.com'                 => 'sd-ai-agent-cloud',
 		'generativelanguage.googleapis.com' => 'google',
 		'localhost:11434'                   => 'ollama',
 		'127.0.0.1:11434'                   => 'ollama',
@@ -477,7 +478,8 @@ class ProviderTraceLogger {
 			? ProviderErrorClassifier::FAILURE_CLASS_GATEWAY_REJECTION
 			: '';
 
-		if ( $has_context && $status_code >= 400 ) {
+		$matches_runtime_provider = $has_context && $canonical_provider_id === self::$runtimeContext['provider_id'];
+		if ( $matches_runtime_provider && $status_code >= 400 ) {
 			self::$runtimeContext['failure_status_code'] = $status_code;
 			self::$runtimeContext['failure_class']       = $failure_class;
 			self::$runtimeContext['failure_source']      = 'http';
@@ -487,7 +489,7 @@ class ProviderTraceLogger {
 		// responses from canonical AI providers regardless of debug mode.
 		// Uses the strict allowlist so unrelated 4xx responses (update
 		// checks, WP.org, etc.) never produce noise here.
-		$request_provider_id = $has_context ? self::$runtimeContext['provider_id'] : $canonical_provider_id;
+		$request_provider_id = $has_context && ! $matches_runtime_provider ? '' : $canonical_provider_id;
 		if ( '' !== $request_provider_id && $status_code >= 400 ) {
 			$model_id_for_log = self::$runtimeContext['model_id'];
 			if ( '' === $model_id_for_log ) {

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -203,6 +203,10 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 			'anthropic',
 			ProviderTraceLogger::match_provider( 'https://api.anthropic.com/v1/messages' )
 		);
+		$this->assertSame(
+			'sd-ai-agent-cloud',
+			ProviderTraceLogger::match_provider( 'https://api.sdaiagent.com/v1/chat/completions' )
+		);
 	}
 
 	/**
@@ -384,10 +388,46 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 			ProviderTraceLogger::on_http_response(
 				$response,
 				array( 'body' => $request_body ),
-				'https://private-provider.example/v1/infer'
+				'https://api.anthropic.com/v1/messages'
 			)
 		);
 		$this->assertNull( $body_seen, 'Disabled tracing must not pass 413 prompt bodies to trace resolution filters.' );
+	}
+
+	/** An unrelated HTTP failure cannot inherit the active provider attribution. */
+	public function test_runtime_context_ignores_failure_from_unrelated_url(): void {
+		add_filter( 'sd_ai_agent_provider_trace_enabled', '__return_false' );
+		$captured_events = array();
+		add_action(
+			'sd_ai_agent_event_logged',
+			static function ( string $event ) use ( &$captured_events ): void {
+				$captured_events[] = $event;
+			}
+		);
+
+		ProviderTraceLogger::set_runtime_context( 'openai', 'gpt-test' );
+		$response = array(
+			'headers'  => array(),
+			'body'     => 'Service unavailable',
+			'response' => array( 'code' => 503, 'message' => 'Service Unavailable' ),
+			'cookies'  => array(),
+			'filename' => '',
+		);
+
+		ProviderTraceLogger::on_http_response(
+			$response,
+			array( 'body' => '' ),
+			'https://api.wordpress.org/plugins/info/1.2/'
+		);
+		ProviderTraceLogger::on_http_response(
+			$response,
+			array( 'body' => '' ),
+			'https://api.anthropic.com/v1/messages'
+		);
+
+		$this->assertSame( array(), ProviderTraceLogger::get_runtime_failure_metadata() );
+		$this->assertNotContains( 'provider_http_error', $captured_events );
+		$this->assertNotContains( 'provider_payload_limit', $captured_events );
 	}
 
 	public function test_gateway_response_writes_only_bounded_terminal_trace_metadata(): void {


### PR DESCRIPTION
## Summary

Require HTTP failures to match the active provider before updating runtime metadata or emitting provider error events. Include the first-party managed provider host in the strict matcher.

## Files Changed

- `includes/Core/ProviderTraceLogger.php`
- `tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed with direct WordPress PHPUnit coverage of matching and unrelated HTTP response paths.

## Worker self-verification

- PHPUnit: Tests: 4410, Assertions: 20515, Errors: 0, Failures: 0, Skipped: 139, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Targeted regression: `ProviderTraceLoggerResolveTest` — 23 tests, 86 assertions.

Resolves #2700

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 25m and 194,434 tokens on this with the user in an interactive session. Overall, 1d 4h since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected provider identification for requests to the SDAI Agent Cloud endpoint.
  - Improved error attribution so failed requests are associated only with the matching provider when runtime provider information is available.
  - Prevented unrelated endpoints from inheriting provider-specific failure metadata or error events.
  - Updated handling for HTTP failures and payload-limit errors to ensure more accurate tracing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->